### PR TITLE
Unpin Capistrano version

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# config valid for current version and patch releases of Capistrano
-lock '~> 3.11.0'
-
 set :application, 'stanford-arclight'
 set :repo_url, 'https://github.com/sul-dlss/stanford-arclight.git'
 


### PR DESCRIPTION
The Capfile is locked to an earlier version of Capistrano, while the Gemfile
version has been updated. Locking version in the Capfile seems to be inconsistent with our deployment practices elsewhere in the
portfolio. This is currently preventing us from deploying the app. 
