### PR TITLE
Override NormalizedTitle to compensate for components without a title or date

### DIFF
--- a/lib/traject/sul/normalized_title.rb
+++ b/lib/traject/sul/normalized_title.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Sul
+  ##
+  # A utility class to normalize titles, typically by joining
+  # the title and date, e.g., "My Title, 1990-2000"
+  class NormalizedTitle
+    # @param [String] `title` from the `unittitle`
+    # @param [String] `date` from the `unitdate`
+    def initialize(title, date = nil)
+      @title = title.gsub(/\s*,\s*$/, '').strip if title.present?
+      @date = date.strip if date.present?
+    end
+
+    # @return [String] the normalized title/date
+    def to_s
+      normalize
+    end
+
+    private
+
+    attr_reader :title, :date, :default
+
+    # Some EAD components in SUL finding aids lack both a title and date.
+    def normalize
+      result = [title, date].compact.join(', ')
+      result = '[NO TITLE PROVIDED]' if result.blank?
+
+      result
+    end
+  end
+end

--- a/lib/traject/sul_component_config.rb
+++ b/lib/traject/sul_component_config.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'arclight'
+require_relative 'sul/normalized_title'
+
+settings do
+  provide 'component_traject_config', __FILE__
+  provide 'title_normalizer', 'Sul::NormalizedTitle'
+end
+
+load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_component_config.rb"))

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'arclight'
+
+settings do
+  provide 'component_traject_config', File.join(__dir__, 'sul_component_config.rb')
+  provide 'solr_writer.http_timeout', 1200
+end
+
+load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb"))


### PR DESCRIPTION
Sets title to "[NO TITLE PROVIDED]" for components without a title or date. We will request guidance from archivists about whether we should form a title differently or if these components need remediation.

Relates to #381 and closes #376