### PR TITLE
ASpace v3.3.1 requires precision param for date queries

### DIFF
--- a/app/services/aspace_client.rb
+++ b/app/services/aspace_client.rb
@@ -175,6 +175,7 @@ class AspaceClient
       { 'field' => 'system_mtime',
         'value' => updated_after,
         'comparator' => 'greater_than',
+        'precision' => 'DAY',
         'jsonmodel_type' => 'date_field_query',
         'negated' => false,
         'literal' => false }


### PR DESCRIPTION
This query broke after we upgraded ASpace versions. A little digging around the ASpace code revealed: https://github.com/archivesspace/archivesspace/blob/master/backend/app/model/advanced_query_string.rb#L48