### PR TITLE
pin arclight to v1.0.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,9 @@ group :test do
   gem 'webmock'
 end
 
-gem 'arclight', '~> 1.0'
+# pin arclight to v1.0.* until we address some changes in v1.1.0
+# documented here: https://github.com/sul-dlss/stanford-arclight/issues/404
+gem 'arclight', '~> 1.0.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  arclight (~> 1.0)
+  arclight (~> 1.0.0)
   blacklight-locale_picker
   bootsnap
   capistrano (~> 3.0)


### PR DESCRIPTION
This will unblock dependency updates and let us upgrade after winter close, see: https://github.com/sul-dlss/stanford-arclight/issues/404