### PR TITLE
Move access facet to top and expand by default

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -138,6 +138,9 @@ class CatalogController < ApplicationController
     # :index_range can be an array or range of prefixes that will be used to create the navigation
     #  (note: It is case sensitive when searching values)
 
+    config.add_facet_field 'access', collapse: false, query: {
+      online: { label: 'Online access', fq: 'has_online_content_ssim:true' }
+    }
     config.add_facet_field 'collection', field: 'collection_ssim', limit: 10
     config.add_facet_field 'creators', field: 'creator_ssim', limit: 10
     config.add_facet_field 'date_range', field: 'date_range_isim', range: true
@@ -162,10 +165,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'creator', accessor: true, component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'abstract_or_scope', accessor: true, truncate: true, repository_context: true, helper_method: :render_html_tags, component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'breadcrumbs', accessor: :itself, component: Arclight::SearchResultBreadcrumbsComponent, compact: { count: 2 }
-
-    config.add_facet_field 'access', query: {
-      online: { label: 'Online access', fq: 'has_online_content_ssim:true' }
-    }
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Facets', type: :feature do
+  context 'when viewing the Catalog page' do
+    before do
+      visit search_catalog_path
+    end
+
+    it 'the Access facet is first in the list and expanded' do
+      expect(page).to have_css('.facets .blacklight-access:first-child', text: 'Access')
+      expect(page).not_to have_css('.facets .blacklight-access .collapsed')
+    end
+  end
+end

--- a/spec/fixtures/ead/uarc/sc0097.xml
+++ b/spec/fixtures/ead/uarc/sc0097.xml
@@ -1,0 +1,8975 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" findaidstatus="edited-full-draft" langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid countrycode="US" mainagencycode="US-CSt" url="http://www.oac.cdlib.org/findaid/ark:/13030/kt2k4035s1">sc0097.xml</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper type="filing">Knuth (Donald E.) papers</titleproper>
+        <titleproper>Guide to the Donald E. Knuth papers <num>SC0097</num></titleproper>
+        <author>University Archives staff</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>Department of Special Collections and University Archives</publisher>
+        <p>
+          <date>August 2018; January 2024</date>
+        </p>
+        <address>
+          <addressline>Green Library</addressline>
+          <addressline>557 Escondido Mall</addressline>
+          <addressline>Stanford 94305-6064</addressline>
+          <addressline>Fax Number: (650) 723-8690</addressline>
+          <addressline>specialcollections@stanford.edu</addressline>
+          <addressline>URL: <extptr xlink:href="https://library.stanford.edu/libraries/special-collections" xlink:show="new" xlink:title="https://library.stanford.edu/libraries/special-collections" xlink:type="simple"/></addressline>
+        </address>
+      </publicationstmt>
+      <notestmt>
+        <note>
+          <p>This encoded finding aid is compliant with Stanford EAD Best Practice Guidelines, Version 1.0.</p>
+        </note>
+      </notestmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace on <date>2024-03-18 16:02:40 -0700</date>.</creation>
+      <langusage>English</langusage>
+      <descrules>Describing Archives: A Content Standard</descrules>
+    </profiledesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>Department of Special Collections and University Archives</corpname>
+      </repository>
+      <unittitle>Donald E. Knuth papers</unittitle>
+      <unitid>SC0097</unitid>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">39.75 Linear Feet</extent>
+      </physdesc>
+      <physdesc altrender="part">
+        <extent altrender="materialtype spaceoccupied">4.3 gigabyte(s)</extent>
+        <physfacet>email files</physfacet>
+      </physdesc>
+      <unitdate calendar="gregorian" datechar="creation" era="ce" normal="1962/2018" type="inclusive">1962-2018</unitdate>
+      <abstract id="aspace_513e7a6b25dad9bf7cde476ad5c1c214" label="Summary:">Papers reflect his work in the study and teaching of computer programming, computer systems for publishing, and mathematics. Included are correspondence, notes, manuscripts, computer printouts, logbooks, proofs, and galleys pertaining to the computer systems TeX, METAFONT, and Computer Modern; and to his books THE ART OF COMPUTER PROGRAMMING, COMPUTERS &amp; TYPESETTING, CONCRETE MATHEMATICS, THE STANFORD GRAPHBASE, DIGITAL TYPOGRAPHY, SELECTED PAPERS ON ANALYSIS OF ALGORITHMS, MMIXWARE : A RISC COMPUTER FOR THE THIRD MILLENNIUM, and THINGS A COMPUTER SCIENTIST RARELY TALKS ABOUT.</abstract>
+      <physloc id="aspace_47b06dc9e99aded149ad182de2a94fb7">Special Collections and University Archives materials are stored offsite and must be paged 36-48 hours in advance. For more information on paging collections, see the department's website: http://library.stanford.edu/depts/spc/spc.html.</physloc>
+      <langmaterial><language langcode="eng" scriptcode="Latn">English</language>
+.    </langmaterial>
+    </did>
+    <acqinfo id="aspace_a677c29df41a1ae6668c3820ab63acb2">
+      <head>Immediate Source of Acquisition note</head>
+      <p>Gift of Donald Knuth, 1972, 1980, 1983, 1989, 1996, 1998, 2001, 2014, 2015, 2019.</p>
+    </acqinfo>
+    <accessrestrict id="aspace_022c458b9d7c61e78800d742efd35391">
+      <head>Information about Access</head>
+      <p>This collection is open for research.</p>
+      <p>The full text version of the email contained in this collection is available in the Field Reading Room; a redacted version, displaying correspondents and extracted entities (personal and corporate names and locations) from Knuth's email have been published in Stanford's online discovery module: http://epadd.stanford.edu/epadd/collections. 515 messages have been entirely restricted from both the discovery module and the full text version available in the reading room according to federal and state guidelines, and Stanford Libraries policy, for up to 80 years. These messages may contain financial, medical, legal, and other sensitive information. They will be made available in 2099.</p>
+    </accessrestrict>
+    <userestrict id="aspace_39a90fadb5ab504bb07cb2de0b04d401">
+      <head>Ownership &amp; Copyright</head>
+      <p>Literary rights reside with Donald Knuth.</p>
+    </userestrict>
+    <prefercite id="aspace_6664c8537c305698161106a4b7cafa37">
+      <head>Cite As</head>
+      <p>Donald E. Knuth Papers (SC0097). Dept. of Special Collections and University Archives, Stanford University Libraries, Stanford, Calif.</p>
+    </prefercite>
+    <arrangement id="aspace_67ed93faf5c37ad4edc620145db144f9">
+      <head>Arrangement</head>
+      <p>The materials are arranged in three series and subsequent accessions: Series 1. The Art of Computer Programming; Series 2. Computers and Typesetting; Series 3. Concrete Mathematics.</p>
+    </arrangement>
+    <bioghist id="aspace_29540b30522c2fe7b31bba23cb01e409">
+      <head>Biographical/Historical Sketch</head>
+      <p>Donald Ervin Knuth's work established the analysis of algorithms as an academic field. He contributed to the development of the rigorous analysis of the computational complexity of algorithms and systematized formal mathematical techniques for it. In the process he also popularized the asymptotic notation.</p>
+      <p>In addition to fundamental contributions in several branches of theoretical computer science, Knuth is the creator of the TeX computer typesetting system, the related METAFONT font definition language and rendering system, and the Computer Modern family of typefaces.</p>
+      <p>As a writer and scholar, Knuth created the WEB/CWEB computer programming systems designed to encourage and facilitate literate programming, and designed the MIX/MMIX instruction set architectures.</p>
+      <p>Professor of computer science at Stanford University from 1968-1992, Knuth was born in January 10, 1938 in Milwaukee, Wisconsin. He received a B.S. from Case Institute of Technology in 1960 and a Ph.D. from the California Institute of Technology in 1963. That same year he began to work on <title render="italic">The Art of Computer Programming</title>. He had initially accepted a commission to write a book on compilers which would later become the multi-volume <title render="italic">The Art of Computer Programming</title>. Originally planned to be a single book, and then planned as a six- and then seven-volume series. In 1968, he published the first volume.</p>
+      <p>After producing the third volume of his series in 1976, he expressed such frustration with the nascent state of the then newly developed electronic publishing tools (especially those that provided input to phototypesetters) that he took time out to work on typesetting and created the TeX and METAFONT tools. At the TUG 2010 Conference, Knuth announced an XML-based successor to TeX, titled "iTeX",  which would support features such as arbitrarily scaled irrational units, 3D printing, animation, and stereographic sound.</p>
+      <p>Knuth has won numerous awards for his work, including:</p>
+      <p>First ACM Grace Murray Hopper Award, 1971
+Turing Award, 1974
+National Medal of Science, 1979
+Franklin Medal, 1988
+John von Neumann Medal, 1995
+Harvey Prize from the Technion, 1995
+Kyoto Prize, 1996
+Katayanagi Prize, 2010
+BBVA Foundation Frontiers of Knowledge Award, 2010
+Stanford University School of Engineering Hero Award, 2011 </p>
+      <p>He was elected to the National Academy of Sciences in 1975. In 1992, he became an associate of the French Academy of Sciences. Also that year, he retired from regular research and teaching at Stanford University in order to finish <title render="italic">The Art of Computer Programming</title>. In 2003, he was elected as a foreign member of the Royal Society. Knuth was elected as a Fellow (first class of Fellows) of the Society for Industrial and Applied Mathematics in 2009 for his outstanding contributions to mathematics. He is also a member of the Norwegian Academy of Science and Letters.</p>
+      <p>On June 24, 1961 he married Nancy June Carter (b. July 15, 1939). They have two children: John Martin (b. July 21, 1965) and Jennifer Sierra (b. December 12, 1966).</p>
+    </bioghist>
+    <scopecontent id="aspace_fff7f7fece6cddaa8c1e987d71578f3f">
+      <head>Description of the Collection</head>
+      <p>Papers reflect his work in the study and teaching of computer programming, computer systems for publishing, and mathematics. Included are correspondence, notes, manuscripts, computer printouts, logbooks, proofs, and galleys pertaining to the computer systems TeX, METAFONT, and Computer Modern; and to his books <title render="italic">THE ART OF COMPUTER PROGRAMMING</title>, <title render="italic">COMPUTERS &amp; TYPESETTING</title>, <title render="italic">CONCRETE MATHEMATICS</title>, <title render="italic">THE STANFORD GRAPHBASE</title>, <title render="italic">DIGITAL TYPOGRAPHY</title>, <title render="italic">SELECTED PAPERS ON ANALYSIS OF ALGORITHMS</title>, <title render="italic">MMIXWARE : A RISC COMPUTER FOR THE THIRD MILLENNIUM</title>, and <title render="italic">THINGS A COMPUTER SCIENTIST RARELY TALKS ABOUT</title>.</p>
+    </scopecontent>
+    <controlaccess>
+      <subject source="lcsh">Computer programs.</subject>
+      <subject source="lcsh">Computer science.</subject>
+      <occupation source="lcsh">Computer scientists.</occupation>
+      <subject source="local">TeX (Computer system).</subject>
+      <occupation source="lcsh">College teachers.</occupation>
+      <subject source="local">METAFONT (Computer system).</subject>
+      <subject source="local">Computerized typesetting.</subject>
+    </controlaccess>
+    <dsc>
+      <c id="aspace_ref128_jpj" level="series">
+        <did>
+          <unittitle>
+            <title render="italic">The Art of Computer Programming</title>
+          </unittitle>
+          <unitid>Series 1</unitid>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+        </did>
+        <scopecontent id="aspace_6a7411210c7c09de9035728e411ee09f">
+          <head>Scope and Contents note</head>
+          <p>Hand-written notes on <title render="italic">The  Art of Computer Programming</title>, computer print-outs that were prepared for this book, various stages of the second edition of volume 2 of the book, 1980 revisions of the book, and the TeX form of the book. Also included is the correspondence received on the book, and correspondence between Knuth and his editor, Marion Howe.</p>
+          <p><title render="italic">The  Art of Computer Programming</title> describes the body of scientific knowledge on the programming of digital computers. The second edition led to Dr. Knuth's development of METAFONT, his computer design typeface system allowing subtle changes in alphabet design, and his page-formatting system, TeX; both systems are intended for the creation of beautiful books by the hand of the original author/printer.</p>
+          <p>Notes on the second edition of Volume 2, by Donald Knuth, July 30, 1980:</p>
+          <p>I began to revise the first edition in November 1974, just after finishing revisions for the second printing of Volume 3. Worked steadily until October 1975, preparing hundreds of hand-written inserts. The intent was to preserve the existing page numbering. Marion Howe at Addison-Wesley unscrambled my manuscript using scissors, tape, etc. During 1976, Addison-Wesley found that the number of changes necessitated a complete resetting of the book. Cost of Monotype had skyrocketed; tried to match fonts on Linotron 505, no luck. I discussed the problem with Addison-Wesley chairman (Cummings) during a visit to Boston; decision was made to prepare new fonts for Linotron 505 by photographing the old ones. First results of this were awful; they tried to tune things up. Finally in the spring of 1977, I decided to work on typography myself, and I told them to stop trying as their method was not going to work. During the rest of 1977, I developed TeX and proto-METAFONT; was ready to compose Volume 2 in spring of 1978. I mostly worked on METAFONT and refinements to TeX during 1979, then returned to Volume 2 in 1980, when I made further technical revisions during April-June to incorporate the research results accumulated since 1975.</p>
+          <p>I saved the following things for Archives: A. Original manuscript, as unscrambled by Marion Howe. B. Galley proofs from Universities Press, Belfast, showing why I got into typesetting. C. Galley proofs I made while recomposing the book in 1978. D. TeX form of Chapter 3 at the time I sent Addison-Wesley the first results of my work (June 1978). E. Marion Howe's comments on my initial try at Chapter 3. F. The state of the entire book as of the end of 1978: Chapter 3 revised, and Chapter 4 in its initial form. This copy also shows markings made by Marion Howe, and changes I made during 1980 (this was my source document for the final revision in 1980). G. The state of the entire book after 1980 revision but before proofreading by Aspvall and Liang, and before the final revision of the Computer Modern fonts. H. The state of the book just before final camera-ready copy made, showing last-minute refinements and the index. I. TeX form of the book as printed.</p>
+          <p>Boxes 31-36: Subsequent editions of Volumes 1, 2 and 3</p>
+          <p>Notes, by Donald Knuth, August 25, 1988</p>
+          <p>From February 1995 to February 1998, my major project was to produce new editions of the existing volumes of The Art of Computer Programming: Volume 1 (3rd edition), Volume 2 (3rd edition), and Volume 3 (2nd edition). These were the first new editions of Volumes 1 and 3 since 1975, and the first new edition of Volume 2 since 1981. My work on typesetting, and other projects such as Concrete Mathematics, 3:16 Bible Texts Illuminated, and The Stanford GraphBase, had occupied nearly all of my time since 1977; now I could best return to The Art of Computer Programming by applying the typesetting software I had constructed to the main task that had motivated it from the beginning.</p>
+          <p>The first major use of TeX had been to produce the second edition of Volume 2 in 1981. My secretary, Phyllis Winkler, then put the texts of Volumes 1 and 3 into the same form; but I never had had time to use the results of her work, because the international use of TeX had become so great that I knew I would have to completely revise that system. Thus in 1995 all I had "online" was a set of approximations to Volumes 1, 2, and 3, expressed in an old version of the TeX language that had become obsolete in 1982.</p>
+          <p>I also had received many hundreds of letters from readers, and had made significant amendments to the text; I began to put those changes into electronic form, as a 350-page list of errata to the old editions. Silvio Levy volunteered to convert the old TeX files to modern TeX form, and to incorporate all of the new errata, while carefully proofreading everything; he began this work in 1996, while I was still gather the errata together.</p>
+          <p>Finally in January of 1997, my errata lists were complete, and Silvio had also finished preparing the new electronic version of Volume 1. I began on January 11 to prepare the final version of that volume, and I had the first ten pages done on January 31.</p>
+          <p>Meanwhile another volunteer, Jeffrey Oldham, had begun to convert all of the illustrations to electronic form in the METAPOST language – a major undertaking involving more than 600 illustrations, many of which were quite complex. While I was working on Volume 1, Levy and Oldham continued to prepare the text and illustrations for Volumes 2 and 3.</p>
+          <p>I soon found that the existence of these documents in electronic form changed everything: The temptation to make small improvements (once prohibitively expensive but now easy) became irresistible. Therefore I soon found that I wanted to make dozens of improvements to every page. Fortunately the typographical tools now available made it possible for me to do this with reasonable speed, and I completed Volume 1 at 4am on April 21.</p>
+          <p>Volume 2 was more of the same; I began it on April 29 and finished on September 3 (this time at 5:30 am). Work on Volume 3 began on September 16 – coincidentally the day my first grandchild was born! -- and consumed most of my energy until 4:30 am on February 27, 1998. The completed volumes totaled 670 +776 + 794 = 2240 pages.</p>
+          <p>In these boxes I have placed the main things that seem to be worth archiving:</p>
+          <p>0a. Xerox of the notebook entries I made while doing the work. 0b. Copies of email correspondence with Silvio Levy, 1995-1998. 1a. Volume 1 illustration proofs, showing the figures as received from Jeffrey Oldham. Handwritten corrections show most of the changes that I incorporated into the master files as I polished the book. 1b. Volume 1 first proofs: Pages formatted as received from Levy, with markings to show changes that I made while proofreading. (Most of the corrections are in green ink; red ink shows later changes made after the "green" ones were already corrected. This saved paper!) When I made extensive amendments, my first pencil drafts are often interfiled; but the drafts of shorter amendments were not saved. 1c. Volume 1 after I had completed one pass over the entire book. I laserprinted just this one copy and had it velo-bound, for use in preparing the index; then I circled items that needed to be indexed. 1d. Volume 1 index proofs: An inverted index of the old edition (used to cross-check that my new indexing hadn't forgotten anything), followed by the first proof of the new index. 2a, 2b, 2c, 2d. Same as above, but for Volume 2. 3a, 3b, 3c, 3d. Same as above, but for Volume 3.</p>
+        </scopecontent>
+        <c id="aspace_ref130_q4m" level="file">
+          <did>
+            <unittitle>Dedication and Introduction to The Art of Computer Programming</unittitle>
+            <container id="aspace_d80872dc9c47bd13224e3bf9e1b46d5e" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_0547ee1306583c1152a6ed3a677e17a1" parent="aspace_d80872dc9c47bd13224e3bf9e1b46d5e" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref131_925" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, changes to the first edition</unittitle>
+            <container id="aspace_2b9a56497754f5312668e8317a7e7bb3" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_9abcb5208398277df26baa0da2edbd67" parent="aspace_2b9a56497754f5312668e8317a7e7bb3" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref132_nrv" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 1</unittitle>
+            <container id="aspace_1eb7de8c8df064664d5e0720c11ac40d" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_c07a6dfd9346befd382f8c6fcfa5df64" parent="aspace_1eb7de8c8df064664d5e0720c11ac40d" type="folder">3-5</container>
+          </did>
+        </c>
+        <c id="aspace_ref133_h2l" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 2</unittitle>
+            <container id="aspace_39087cf598d2fac26c55eaa7b324ecc4" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_edf8df1bf8d8020159ed733436a7d5a7" parent="aspace_39087cf598d2fac26c55eaa7b324ecc4" type="folder">6-12</container>
+          </did>
+        </c>
+        <c id="aspace_ref134_0px" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 3</unittitle>
+            <container id="aspace_9a2c3c244e8e20a6d801dace6fb54185" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_803d0770e4fd1c6c8d7c58fa3bd128c6" parent="aspace_9a2c3c244e8e20a6d801dace6fb54185" type="folder">13 - 15</container>
+          </did>
+        </c>
+        <c id="aspace_ref135_zs5" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 4 outline, notes</unittitle>
+            <container id="aspace_fd1ba7c5d0ff9307c998cd4850c5cd27" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_cc7fd1352f4a38120bd0ccef9a1edcb7" parent="aspace_fd1ba7c5d0ff9307c998cd4850c5cd27" type="folder">16</container>
+          </did>
+        </c>
+        <c id="aspace_ref136_1c7" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 4</unittitle>
+            <container id="aspace_1f745df24db6b8a8765ab424eb01463c" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_fa47abe1272f5deb1b0b4e1314fd89b8" parent="aspace_1f745df24db6b8a8765ab424eb01463c" type="folder">17 - 31</container>
+          </did>
+        </c>
+        <c id="aspace_ref137_kip" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 4 and 5 brief drafts</unittitle>
+            <container id="aspace_8f1cd8874cbc30cef9cda42ee27cda1a" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_bbdc8ce8162ed7eb96c2f91947075de8" parent="aspace_8f1cd8874cbc30cef9cda42ee27cda1a" type="folder">32</container>
+          </did>
+        </c>
+        <c id="aspace_ref138_fqk" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 5</unittitle>
+            <container id="aspace_633b456a5ff5e70dd65d4790675f4584" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_607398988febae9a6451ef62d369b834" parent="aspace_633b456a5ff5e70dd65d4790675f4584" type="folder">33 - 45</container>
+          </did>
+        </c>
+        <c id="aspace_ref139_ij2" level="file">
+          <did>
+            <unittitle>Sorting techniques</unittitle>
+            <container id="aspace_44978f316d056ff975308f5ef61aa695" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_43b8a4a8991bca29b415b90042fac5bb" parent="aspace_44978f316d056ff975308f5ef61aa695" type="folder">46</container>
+          </did>
+        </c>
+        <c id="aspace_ref140_g61" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 5, p. 1-40</unittitle>
+            <container id="aspace_fdd3dd733d9b17e244125b2aa141db64" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_303483a94a0e12dce0fbbb07cdc33968" parent="aspace_fdd3dd733d9b17e244125b2aa141db64" type="folder">47</container>
+          </did>
+        </c>
+        <c id="aspace_ref141_qt7" level="file">
+          <did>
+            <unittitle><title render="italic">The  Art of Computer Programming</title>, Chapter 6</unittitle>
+            <container id="aspace_0757e472a5e38f536484ff3918895f11" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_b05de55c493b7305e0995618adaaba7e" parent="aspace_0757e472a5e38f536484ff3918895f11" type="folder">48 - 55</container>
+          </did>
+        </c>
+        <c id="aspace_ref142_qxn" level="file">
+          <did>
+            <unittitle>Correspondence and notes on chapter 7</unittitle>
+            <container id="aspace_a1d9938b45ec6b857f8abdc9892bb086" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_eafefd55ef837828df3f4199c9e2ef48" parent="aspace_a1d9938b45ec6b857f8abdc9892bb086" type="folder">56</container>
+          </did>
+        </c>
+        <c id="aspace_ref143_53r" level="file">
+          <did>
+            <unittitle>Chapter 9 and information on scanner</unittitle>
+            <container id="aspace_21260e332b2c64914b1f79e8fb17bd1f" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_e4a78d6172dac224b4bc0c5611bfbadd" parent="aspace_21260e332b2c64914b1f79e8fb17bd1f" type="folder">57</container>
+          </did>
+        </c>
+        <c id="aspace_ref144_6lx" level="file">
+          <did>
+            <unittitle>p. 11-138</unittitle>
+            <container id="aspace_1d70e725f05dbfba73107b2486c4b4f3" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_3ff2517ac11d79701bee9483cf324d9e" parent="aspace_1d70e725f05dbfba73107b2486c4b4f3" type="folder">58</container>
+          </did>
+        </c>
+        <c id="aspace_ref145_d2w" level="file">
+          <did>
+            <unittitle>p. 139-221</unittitle>
+            <container id="aspace_10a57c11b64ef77b8c791175c117f1e7" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_fa9a8d5407b2f32c4a773fb7dec7c900" parent="aspace_10a57c11b64ef77b8c791175c117f1e7" type="folder">59</container>
+          </did>
+        </c>
+        <c id="aspace_ref146_kda" level="file">
+          <did>
+            <unittitle>p. 222-272</unittitle>
+            <container id="aspace_8c4629432407ac36c8e6b903b8a57672" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_4dd1c6e8d8166221e3b83628bdb7ba67" parent="aspace_8c4629432407ac36c8e6b903b8a57672" type="folder">60</container>
+          </did>
+        </c>
+        <c id="aspace_ref147_29n" level="file">
+          <did>
+            <unittitle>p. 410-445</unittitle>
+            <container id="aspace_bc0945be01bb0b6f1ae5ecb33b55c452" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_f907e2254a4792a14de0da1f37b51e0a" parent="aspace_bc0945be01bb0b6f1ae5ecb33b55c452" type="folder">61</container>
+          </did>
+        </c>
+        <c id="aspace_ref148_a9v" level="file">
+          <did>
+            <unittitle>p. 610-634</unittitle>
+            <container id="aspace_d7f42a9e4ab7d73e813092f9036476d0" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_c76ebbb053e3ef2929ecd6e1331437b9" parent="aspace_d7f42a9e4ab7d73e813092f9036476d0" type="folder">62</container>
+          </did>
+        </c>
+        <c id="aspace_ref149_awp" level="file">
+          <did>
+            <unittitle>Miscellaneous notes</unittitle>
+            <container id="aspace_5df6e7f7cd2f720bf3f1b0192935bea0" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+            <container id="aspace_afdd1b1a0a988d65ac5e6abc2f3299b8" parent="aspace_5df6e7f7cd2f720bf3f1b0192935bea0" type="folder">63</container>
+          </did>
+        </c>
+        <c id="aspace_ref150_1wk" level="file">
+          <did>
+            <unittitle>A3 - A23 Algorithm</unittitle>
+            <container id="aspace_38ba63ed9237bb0f74c85ed681cd5cb1" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_f9e66695b14fadc4a949d655e5c46b27" parent="aspace_38ba63ed9237bb0f74c85ed681cd5cb1" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref151_x3c" level="file">
+          <did>
+            <unittitle>Algorithm, p. 507, 508, 540</unittitle>
+            <container id="aspace_c46e5870c0546c18326baafe87caf3a7" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_c81456d6683aeaedf6e10e60346ff4ce" parent="aspace_c46e5870c0546c18326baafe87caf3a7" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref152_wxb" level="file">
+          <did>
+            <unittitle>Algorithm for inverse pennutation</unittitle>
+            <container id="aspace_e7bfdf1f836e9ff0a26934f1a6639fda" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_534ce33f1e65affccf38428ea589fad2" parent="aspace_e7bfdf1f836e9ff0a26934f1a6639fda" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref153_603" level="file">
+          <did>
+            <unittitle>The analysis of radix exchange</unittitle>
+            <container id="aspace_37f2a7a9c9e954690542e3c839a6cdfb" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_15b470e9b053af063ff12497e0c0c76c" parent="aspace_37f2a7a9c9e954690542e3c839a6cdfb" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref154_ni1" level="file">
+          <did>
+            <unittitle>Componological problem in group theory</unittitle>
+            <container id="aspace_dbf5a3782f9a24d45452510941aa3a4b" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_3f0546a8f2c13a0ec2f06e4a4eee1287" parent="aspace_dbf5a3782f9a24d45452510941aa3a4b" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref155_xgn" level="file">
+          <did>
+            <unittitle>Chapter organization</unittitle>
+            <container id="aspace_dac668b3962e155882244a6193f84c22" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_1ebc24109f3d887dafbb70c45c2aec82" parent="aspace_dac668b3962e155882244a6193f84c22" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref156_xx1" level="file">
+          <did>
+            <unittitle>Combinational searching</unittitle>
+            <container id="aspace_266a69ce3588f2726a9a18a745be114e" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_ed93236f9fdb10b6a4a796b5b046c161" parent="aspace_266a69ce3588f2726a9a18a745be114e" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref157_v0l" level="file">
+          <did>
+            <unittitle>Correspondence</unittitle>
+            <container id="aspace_6edb12866eec2653b1c981c4a9783236" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_feb211e506c214a4cb6c25f7deb14c06" parent="aspace_6edb12866eec2653b1c981c4a9783236" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref158_ive" level="file">
+          <did>
+            <unittitle>Distribution for cascade</unittitle>
+            <container id="aspace_3dc67d698b92ae5f48b86c22e1360f4b" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_fe6dc3e15f5be0c189f02695fc9aa470" parent="aspace_3dc67d698b92ae5f48b86c22e1360f4b" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref159_6c5" level="file">
+          <did>
+            <unittitle>Evaluation of polynomials</unittitle>
+            <container id="aspace_b404268308caf3e9af71f98ca1cecd8e" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_d11d658c9e0e0f7cd87ecb4088589557" parent="aspace_b404268308caf3e9af71f98ca1cecd8e" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref160_lzo" level="file">
+          <did>
+            <unittitle>Example, the boy and the apple tree</unittitle>
+            <container id="aspace_bbd010c6bc94c88c1281ff28d610edbf" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_bbc905dd9e68e012a3f42f896dd2277e" parent="aspace_bbd010c6bc94c88c1281ff28d610edbf" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref161_6d6" level="file">
+          <did>
+            <unittitle>Factor method tree</unittitle>
+            <container id="aspace_43e55bd181fe6020b4532ea349c5c8a4" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_625fedde99a96e4f4ae3e43f710fa6d5" parent="aspace_43e55bd181fe6020b4532ea349c5c8a4" type="folder">12</container>
+          </did>
+        </c>
+        <c id="aspace_ref162_476" level="file">
+          <did>
+            <unittitle>Finite state language</unittitle>
+            <container id="aspace_c99b87e39aa7b972adcf963f71010221" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_ec44635f4e77e64a6827ccfb674d38b5" parent="aspace_c99b87e39aa7b972adcf963f71010221" type="folder">13</container>
+          </did>
+        </c>
+        <c id="aspace_ref163_maf" level="file">
+          <did>
+            <unittitle>Formulas and readings</unittitle>
+            <container id="aspace_eb8bc558daa71cb3dfdd53420c44ae1e" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_51b6f7825713699f9d4df9171e716e83" parent="aspace_eb8bc558daa71cb3dfdd53420c44ae1e" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref164_7lj" level="file">
+          <did>
+            <unittitle>Generalized zero-one principle</unittitle>
+            <container id="aspace_d19362ddceb7d3b5270afa551c0ce1bc" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_05bb2c72f668e6ebaeb7d7ef1f9abce3" parent="aspace_d19362ddceb7d3b5270afa551c0ce1bc" type="folder">15</container>
+          </did>
+        </c>
+        <c id="aspace_ref165_u62" level="file">
+          <did>
+            <unittitle>A good scrambling function for hardware</unittitle>
+            <container id="aspace_0bc88339816cef7382e201eb9d486933" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_bf3e1bc5063c44a98de10ca4b9f5f323" parent="aspace_0bc88339816cef7382e201eb9d486933" type="folder">16</container>
+          </did>
+        </c>
+        <c id="aspace_ref166_ry8" level="file">
+          <did>
+            <unittitle>Historical names and places</unittitle>
+            <container id="aspace_f703a3a849624e55276dfc5ca9f6bf3e" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_0c4eec0eb203335b25f560044d8da87e" parent="aspace_f703a3a849624e55276dfc5ca9f6bf3e" type="folder">17</container>
+          </did>
+        </c>
+        <c id="aspace_ref167_swz" level="file">
+          <did>
+            <unittitle>Historical roles</unittitle>
+            <container id="aspace_fc528c8b158c5a00a67108be024d0828" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_1b8a4f464c08dab82abbe5c8aea34eb8" parent="aspace_fc528c8b158c5a00a67108be024d0828" type="folder">18</container>
+          </did>
+        </c>
+        <c id="aspace_ref168_bxk" level="file">
+          <did>
+            <unittitle>Index and glossary</unittitle>
+            <container id="aspace_f4043b1ad242606958494aef78307ead" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_833d8031a70e0e1b930811e9ba9d46f3" parent="aspace_f4043b1ad242606958494aef78307ead" type="folder">19</container>
+          </did>
+        </c>
+        <c id="aspace_ref169_299" level="file">
+          <did>
+            <unittitle>Index entries</unittitle>
+            <container id="aspace_821c8f30fe77390e638698cae97e9b49" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_d888b64b047aa84e6a9290aa7c8ebdde" parent="aspace_821c8f30fe77390e638698cae97e9b49" type="folder">20</container>
+          </did>
+        </c>
+        <c id="aspace_ref170_g3t" level="file">
+          <did>
+            <unittitle>Index material</unittitle>
+            <container id="aspace_26341d7d6c313bcd735af484edf8670a" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_d2d6f1a2ab00d966b94129968fc4d57f" parent="aspace_26341d7d6c313bcd735af484edf8670a" type="folder">21</container>
+          </did>
+        </c>
+        <c id="aspace_ref171_7n7" level="file">
+          <did>
+            <unittitle>Information on integers</unittitle>
+            <container id="aspace_ed103b37dc868175f5a77aa007b0130c" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_e2d4985d08d98a2cd73a1d6a5fdda4f5" parent="aspace_ed103b37dc868175f5a77aa007b0130c" type="folder">22</container>
+          </did>
+        </c>
+        <c id="aspace_ref172_uu9" level="file">
+          <did>
+            <unittitle>Information on quick sort</unittitle>
+            <container id="aspace_9763ba5768a69d69a928241ff97b4a81" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_af709df96833a28094c3203cff81c81e" parent="aspace_9763ba5768a69d69a928241ff97b4a81" type="folder">23</container>
+          </did>
+        </c>
+        <c id="aspace_ref173_hg2" level="file">
+          <did>
+            <unittitle>Introduction to the book</unittitle>
+            <container id="aspace_c8b01186f741aef35cf6f6a1a76caedd" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_382738126b1ed7e855e0fa0205337b62" parent="aspace_c8b01186f741aef35cf6f6a1a76caedd" type="folder">24</container>
+          </did>
+        </c>
+        <c id="aspace_ref174_65s" level="file">
+          <did>
+            <unittitle>latin square</unittitle>
+            <container id="aspace_9950d3d602005b2996e2140758ea6dbb" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_b9fa265e8fca6166c204e0a51ecb8d13" parent="aspace_9950d3d602005b2996e2140758ea6dbb" type="folder">25</container>
+          </did>
+        </c>
+        <c id="aspace_ref175_iv3" level="file">
+          <did>
+            <unittitle>Maclaren's method/algorithm</unittitle>
+            <container id="aspace_e0d54b5e6522218a428fae2ff8ec9f6c" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_50a8690bafce9400b617f048366f6f13" parent="aspace_e0d54b5e6522218a428fae2ff8ec9f6c" type="folder">26</container>
+          </did>
+        </c>
+        <c id="aspace_ref176_6as" level="file">
+          <did>
+            <unittitle>MIX: Math Department subroutine 10/8/62</unittitle>
+            <container id="aspace_1b765c682ae43918ca16ce875168c9d4" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_14d430f830edde3940068d2e2eee6507" parent="aspace_1b765c682ae43918ca16ce875168c9d4" type="folder">27</container>
+          </did>
+        </c>
+        <c id="aspace_ref177_na6" level="file">
+          <did>
+            <unittitle>Names list</unittitle>
+            <container id="aspace_b775f723187450178cdf59d80e2bac89" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_00d3506c244886b5e0d84fec5a5998ff" parent="aspace_b775f723187450178cdf59d80e2bac89" type="folder">28</container>
+          </did>
+        </c>
+        <c id="aspace_ref178_npo" level="file">
+          <did>
+            <unittitle>Non-isomorphic solutions to "queens" problem</unittitle>
+            <container id="aspace_e445761996107c14fe27a2da838281dc" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_ba873c2801c7cd36c0fdb39e07d5b74a" parent="aspace_e445761996107c14fe27a2da838281dc" type="folder">29</container>
+          </did>
+        </c>
+        <c id="aspace_ref179_29w" level="file">
+          <did>
+            <unittitle>Notes for class</unittitle>
+            <container id="aspace_e72be4d69f24ac74a21ffb9caff82d89" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_beb98d07a75f0c4e1f0a98878096186f" parent="aspace_e72be4d69f24ac74a21ffb9caff82d89" type="folder">30</container>
+          </did>
+        </c>
+        <c id="aspace_ref180_duq" level="file">
+          <did>
+            <unittitle>Optimal search tree</unittitle>
+            <container id="aspace_882b5c1fab02edce3ec4bfa13a5ca71e" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_6bf5cf13c21e2806d4b30b752de308af" parent="aspace_882b5c1fab02edce3ec4bfa13a5ca71e" type="folder">31</container>
+          </did>
+        </c>
+        <c id="aspace_ref181_gw1" level="file">
+          <did>
+            <unittitle>Optinn.nn sorting</unittitle>
+            <container id="aspace_23be1aecdd9dc4778c3ac3bfa2046b53" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_c966d603dcf5780c8d63c8c601948a30" parent="aspace_23be1aecdd9dc4778c3ac3bfa2046b53" type="folder">32</container>
+          </did>
+        </c>
+        <c id="aspace_ref182_fgh" level="file">
+          <did>
+            <unittitle>Organizational outline for the book</unittitle>
+            <container id="aspace_94ec2bd0bd45c5cd5c8cd851e7697baa" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_db4ef30bc6a0057e971e1ca04e7e7d30" parent="aspace_94ec2bd0bd45c5cd5c8cd851e7697baa" type="folder">33</container>
+          </did>
+        </c>
+        <c id="aspace_ref183_5tk" level="file">
+          <did>
+            <unittitle>Organization of book</unittitle>
+            <container id="aspace_a0d40905396a96d70af516d5ca5f53d2" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_0d40d1c5b2aff451fb6b31b799ec48b4" parent="aspace_a0d40905396a96d70af516d5ca5f53d2" type="folder">34</container>
+          </did>
+        </c>
+        <c id="aspace_ref184_d19" level="file">
+          <did>
+            <unittitle>Page conunentaries</unittitle>
+            <container id="aspace_4b9c83258367dcef1f92fcf9136263a7" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_9345dd78512be718572f5e976debbd81" parent="aspace_4b9c83258367dcef1f92fcf9136263a7" type="folder">35</container>
+          </did>
+        </c>
+        <c id="aspace_ref185_cno" level="file">
+          <did>
+            <unittitle>Pagination changes</unittitle>
+            <container id="aspace_5a606ca417505f5bff04fd8dabdd808e" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_6db2bccc80ac627594ebd6a7686a4526" parent="aspace_5a606ca417505f5bff04fd8dabdd808e" type="folder">36</container>
+          </did>
+        </c>
+        <c id="aspace_ref186_0x4" level="file">
+          <did>
+            <unittitle>Permutations of a finite multi-set</unittitle>
+            <container id="aspace_7505a43d09ff0e764069369c1bd2311a" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_39ce89a2e352d7a14c0e45d6165ba7cc" parent="aspace_7505a43d09ff0e764069369c1bd2311a" type="folder">37</container>
+          </did>
+        </c>
+        <c id="aspace_ref187_z8t" level="file">
+          <did>
+            <unittitle>Polynomials</unittitle>
+            <container id="aspace_2ae1d36ae2665abae6d12d33f91adf47" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_ab12bd31597c066cbeeed89064aeddda" parent="aspace_2ae1d36ae2665abae6d12d33f91adf47" type="folder">38</container>
+          </did>
+        </c>
+        <c id="aspace_ref188_m20" level="file">
+          <did>
+            <unittitle>Polynomial division</unittitle>
+            <container id="aspace_a4b14e15c7b86bce5db2174b8161a56b" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_cc4f2887fc5e65ab094342b83407461c" parent="aspace_a4b14e15c7b86bce5db2174b8161a56b" type="folder">39</container>
+          </did>
+        </c>
+        <c id="aspace_ref189_92p" level="file">
+          <did>
+            <unittitle>The power tree</unittitle>
+            <container id="aspace_e53a28a5469e3e9f4764a904bd7b182d" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_1cb6268a2659061010adfdc6180480da" parent="aspace_e53a28a5469e3e9f4764a904bd7b182d" type="folder">40</container>
+          </did>
+        </c>
+        <c id="aspace_ref190_l14" level="file">
+          <did>
+            <unittitle>Preface and index</unittitle>
+            <container id="aspace_36f34a0d4c41e5fae4900f65fa913478" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_693c6e1547ec17e5d5b8f4c0e1f322cb" parent="aspace_36f34a0d4c41e5fae4900f65fa913478" type="folder">41</container>
+          </did>
+        </c>
+        <c id="aspace_ref191_ce8" level="file">
+          <did>
+            <unittitle>Preparing for polyphase merge</unittitle>
+            <container id="aspace_6ff13174040c08214344074adaff00ac" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_63c9f7be9d0089ea9370c823828a55a4" parent="aspace_6ff13174040c08214344074adaff00ac" type="folder">42</container>
+          </did>
+        </c>
+        <c id="aspace_ref192_8mc" level="file">
+          <did>
+            <unittitle>Radix system</unittitle>
+            <container id="aspace_c54df0e38a5e2be431fdacec242199c0" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_8a8e4d26c3ff956a82e5fad14f595038" parent="aspace_c54df0e38a5e2be431fdacec242199c0" type="folder">43</container>
+          </did>
+        </c>
+        <c id="aspace_ref193_hcv" level="file">
+          <did>
+            <unittitle>Random mnnbers sorting</unittitle>
+            <container id="aspace_8b9a1278160d334c0f1d50b4b2a852ed" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_4156c43840764b5c2e15747c67df950e" parent="aspace_8b9a1278160d334c0f1d50b4b2a852ed" type="folder">44</container>
+          </did>
+        </c>
+        <c id="aspace_ref194_bme" level="file">
+          <did>
+            <unittitle>Recurring series mod m</unittitle>
+            <container id="aspace_1c60cd6d881652123ad13d993fec3b60" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_df3d955c89dc2787eed07edd1c6be532" parent="aspace_1c60cd6d881652123ad13d993fec3b60" type="folder">45</container>
+          </did>
+        </c>
+        <c id="aspace_ref195_wor" level="file">
+          <did>
+            <unittitle>References</unittitle>
+            <container id="aspace_34101f0809597caca83ce98cdb84f34b" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_88769ec0c8e95fa74146c2feadcf3005" parent="aspace_34101f0809597caca83ce98cdb84f34b" type="folder">46</container>
+          </did>
+        </c>
+        <c id="aspace_ref196_swh" level="file">
+          <did>
+            <unittitle>Run-distribution alternating directions</unittitle>
+            <container id="aspace_80c27f704f8a85d82b24bce8f322dac3" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_9ec29d8184ccd016e82d25e83672906d" parent="aspace_80c27f704f8a85d82b24bce8f322dac3" type="folder">47</container>
+          </did>
+        </c>
+        <c id="aspace_ref197_55x" level="file">
+          <did>
+            <unittitle>SIAM Review 9 / 1967</unittitle>
+            <container id="aspace_ed351b66be2ee99d7b7960ed0c4d74b7" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_e9984ba44a4e46d262ea4972775b06e0" parent="aspace_ed351b66be2ee99d7b7960ed0c4d74b7" type="folder">48</container>
+          </did>
+        </c>
+        <c id="aspace_ref198_m56" level="file">
+          <did>
+            <unittitle>Sorting</unittitle>
+            <container id="aspace_f28e2da91e19db30ce1d07ccaf51abf3" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_5c846156ad46fa1afd70475c7b6f714a" parent="aspace_f28e2da91e19db30ce1d07ccaf51abf3" type="folder">49</container>
+          </did>
+        </c>
+        <c id="aspace_ref199_zij" level="file">
+          <did>
+            <unittitle>Sorting information</unittitle>
+            <container id="aspace_b1edc87d2b3d368143ba83c88b3e0921" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_ac439cf58a06f8c31481cfd762c474b8" parent="aspace_b1edc87d2b3d368143ba83c88b3e0921" type="folder">50</container>
+          </did>
+        </c>
+        <c id="aspace_ref200_2tl" level="file">
+          <did>
+            <unittitle>statistical study of published algorithurns</unittitle>
+            <container id="aspace_e684e973809d93143f5b9391929d6a19" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_e21e64bc7229d9d9b28b7a8aaf5c6868" parent="aspace_e684e973809d93143f5b9391929d6a19" type="folder">51</container>
+          </did>
+        </c>
+        <c id="aspace_ref201_z81" level="file">
+          <did>
+            <unittitle>Subroutines p. 1-36, caltech, Fall 1963</unittitle>
+            <container id="aspace_58c3f48153245ff45e31b6b46433dc5a" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_5b7180da04c59c061ea7f6d0ae24f053" parent="aspace_58c3f48153245ff45e31b6b46433dc5a" type="folder">52</container>
+          </did>
+        </c>
+        <c id="aspace_ref202_tns" level="file">
+          <did>
+            <unittitle>Summary for 1/29-30/72</unittitle>
+            <container id="aspace_1da8e4e6b3e872c6203da49223ef30e2" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_a7417d6e2588e14b211c61948ad909c4" parent="aspace_1da8e4e6b3e872c6203da49223ef30e2" type="folder">53</container>
+          </did>
+        </c>
+        <c id="aspace_ref203_k59" level="file">
+          <did>
+            <unittitle>Tables I</unittitle>
+            <container id="aspace_bd3186d8a0f73a8489433726fa34ce33" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_0cec9e1bdea9b3e74a53fab4b9cabcd8" parent="aspace_bd3186d8a0f73a8489433726fa34ce33" type="folder">54</container>
+          </did>
+        </c>
+        <c id="aspace_ref204_9vp" level="file">
+          <did>
+            <unittitle>Tables II</unittitle>
+            <container id="aspace_da291c8a71934c93604d9a04325e3181" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_02e09f984eb529ca8d6a97c224d74c34" parent="aspace_da291c8a71934c93604d9a04325e3181" type="folder">55</container>
+          </did>
+        </c>
+        <c id="aspace_ref205_l6i" level="file">
+          <did>
+            <unittitle>Tablet with book organization</unittitle>
+            <container id="aspace_e2cfa1d3b70c4a7eddc064927f02b3e6" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_2b5fc21a9341445e42ab01f6d857f7ef" parent="aspace_e2cfa1d3b70c4a7eddc064927f02b3e6" type="folder">56</container>
+          </did>
+        </c>
+        <c id="aspace_ref206_ee3" level="file">
+          <did>
+            <unittitle>Theory and techniques for design of electronic digital computer</unittitle>
+            <container id="aspace_5d1b3cd77ee4938f7426eca97ec3e694" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_4399839527e36a0b4037788fccb41e66" parent="aspace_5d1b3cd77ee4938f7426eca97ec3e694" type="folder">57</container>
+          </did>
+        </c>
+        <c id="aspace_ref207_x59" level="file">
+          <did>
+            <unittitle>38 exercises</unittitle>
+            <container id="aspace_2924a5aea59d0668891ad44a4082cc0f" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_8cfa3e59cc3896446c5fe6a6791f945d" parent="aspace_2924a5aea59d0668891ad44a4082cc0f" type="folder">58</container>
+          </did>
+        </c>
+        <c id="aspace_ref208_zy7" level="file">
+          <did>
+            <unittitle>Three tran algorithm</unittitle>
+            <container id="aspace_1ade7c5448277395640f3ec5e1425617" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_11840d167994f50d958bd04fdaf297dc" parent="aspace_1ade7c5448277395640f3ec5e1425617" type="folder">59</container>
+          </did>
+        </c>
+        <c id="aspace_ref209_awk" level="file">
+          <did>
+            <unittitle>Traffic signal problem</unittitle>
+            <container id="aspace_33d506dcabf14fec5509770dfb9c1fc5" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_eeba285133228f31c767443bf8196a64" parent="aspace_33d506dcabf14fec5509770dfb9c1fc5" type="folder">60</container>
+          </did>
+        </c>
+        <c id="aspace_ref210_x3b" level="file">
+          <did>
+            <unittitle>Unification problem</unittitle>
+            <container id="aspace_a718dd4eb4bb562945af2f5dd2bf7412" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_e3feb3d601f050f7d73fdf4fb1757468" parent="aspace_a718dd4eb4bb562945af2f5dd2bf7412" type="folder">61</container>
+          </did>
+        </c>
+        <c id="aspace_ref211_idd" level="file">
+          <did>
+            <unittitle>Utility arithmetic subroutines</unittitle>
+            <container id="aspace_c07c3b142a1ff0be98fcac35028f30f0" label="Mixed Materials [aspace.536064.box.2]" type="Box">2</container>
+            <container id="aspace_8b1663cb8fb6002b4e97e60d4c76efe6" parent="aspace_c07c3b142a1ff0be98fcac35028f30f0" type="folder">62</container>
+          </did>
+        </c>
+        <c id="aspace_ref212_r35" level="file">
+          <did>
+            <unittitle>Computer print-outs on experiments with sort routines, algorithms, cascade merge programs, Morteson table, source listing</unittitle>
+            <container id="aspace_dace4cf321ba522a747217fde96cea46" label="Mixed Materials [aspace.536064.box.3]" type="Box">3</container>
+            <container id="aspace_013b0f43b948c68e645f804b0e6ee400" parent="aspace_dace4cf321ba522a747217fde96cea46" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref213_thi" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 1-49</unittitle>
+            <container id="aspace_77b27a4de992abc7e4ceff617daba5e8" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_0733fcaf2fa4e4153fc2d1d510775d8d" parent="aspace_77b27a4de992abc7e4ceff617daba5e8" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref214_zhe" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 69-135</unittitle>
+            <container id="aspace_a87c18e1562b51df54675d908772635b" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_59cb61c51327d1bd0f51679f733feb91" parent="aspace_a87c18e1562b51df54675d908772635b" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref215_eyf" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 136-191</unittitle>
+            <container id="aspace_bc12ac9a8342c1fb1b635a3448d2d212" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_295fddb33ef36b52dff2a5736cb0193d" parent="aspace_bc12ac9a8342c1fb1b635a3448d2d212" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref216_581" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 192-236</unittitle>
+            <container id="aspace_8ae62c32f5b2e0bce6a18ddb0efa9915" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_b0310e5b3b6de3b5bab2a13d9681fa7e" parent="aspace_8ae62c32f5b2e0bce6a18ddb0efa9915" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref217_b7e" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 237-316</unittitle>
+            <container id="aspace_8ad274bd0b1c49aad0a13ab597a8586d" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_b34815169319d1b6414e29b482a1d9f3" parent="aspace_8ad274bd0b1c49aad0a13ab597a8586d" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref218_u29" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 317-380</unittitle>
+            <container id="aspace_bdab53c16e372abdae4615fee3c63b5c" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_35ce79dbc54f0496cf3882e3660ffdd8" parent="aspace_bdab53c16e372abdae4615fee3c63b5c" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref219_svp" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 381-435</unittitle>
+            <container id="aspace_96d1e807e3c6cc3ceb9e26a46757fdb8" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_a513916077476d604c3d903951dae710" parent="aspace_96d1e807e3c6cc3ceb9e26a46757fdb8" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref220_5e5" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 436-501</unittitle>
+            <container id="aspace_50139d6c298e5ac9a9914277a1476e1f" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_716f54bcbb364ee92f9b13c30b1fc63b" parent="aspace_50139d6c298e5ac9a9914277a1476e1f" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref221_52c" level="file">
+          <did>
+            <unittitle>Manuscript of <title render="italic">The  Art of Computer Programming</title>, p. 502-545</unittitle>
+            <container id="aspace_e5d35827325eeef19bce6942026a52df" label="Mixed Materials [aspace.536064.box.4]" type="Box">4</container>
+            <container id="aspace_76c541e89ab922a9473e5c2c381217ff" parent="aspace_e5d35827325eeef19bce6942026a52df" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref222_ptq" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 546-595</unittitle>
+            <container id="aspace_112db89f7c0469bff0c376f0def78e68" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_b74d58fecc76533ee227468847561447" parent="aspace_112db89f7c0469bff0c376f0def78e68" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref223_rof" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 596-635</unittitle>
+            <container id="aspace_6ab639291f27b64793e173ab028e9b2c" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_d6647b7691aeb71ec06827a7f15bf697" parent="aspace_6ab639291f27b64793e173ab028e9b2c" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref224_lxp" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 636-683</unittitle>
+            <container id="aspace_6f31c02a8837b49ebdf548a6727b0ea2" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_92090167719f18cfc32caae9002a8264" parent="aspace_6f31c02a8837b49ebdf548a6727b0ea2" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref225_k4s" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 685-734</unittitle>
+            <container id="aspace_50c90973a4af949884a8bca68174a1fb" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_12f9679fd80c166c3a91626ce2f7b7ca" parent="aspace_50c90973a4af949884a8bca68174a1fb" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref226_7qc" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 735-776</unittitle>
+            <container id="aspace_9cec3e1aad816c4352bba2108109ebc4" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_c34adae78900485ec3da983755a438af" parent="aspace_9cec3e1aad816c4352bba2108109ebc4" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref227_4un" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 777-808</unittitle>
+            <container id="aspace_af5e5b0774d7dd71c94d83a0d6f5df76" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_b2db89fc7eb4c009e54e35d78f936d48" parent="aspace_af5e5b0774d7dd71c94d83a0d6f5df76" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref228_uq8" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 809-843</unittitle>
+            <container id="aspace_4c6c165bdffa95215d6592b2d643fff1" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_136e57ea801ac9b49843c29564ea276f" parent="aspace_4c6c165bdffa95215d6592b2d643fff1" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref229_04e" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 844-851</unittitle>
+            <container id="aspace_c9d8b6e9d51f3513bb520d4c9439dc67" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_36763f6b929c865462ce911a99f2f62e" parent="aspace_c9d8b6e9d51f3513bb520d4c9439dc67" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref230_p1u" level="file">
+          <did>
+            <unittitle><title render="italic">The Art of Computer Programming</title>, Volume II, p. 7-30 miscellaneous information</unittitle>
+            <container id="aspace_8928679719b60ac96bd77e8ef1fca48f" label="Mixed Materials [aspace.536064.box.5]" type="Box">5</container>
+            <container id="aspace_866d1c370d2d2e07a04f79591ba06d40" parent="aspace_8928679719b60ac96bd77e8ef1fca48f" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref231_ted" level="file">
+          <did>
+            <unittitle>The Art of Computer Programming, Volume II, Galley proofs from universities press</unittitle>
+            <container id="aspace_abd33c1f4fbe139fbd68799d146dbd3e" label="Mixed Materials [aspace.536064.box.6]" type="Box">6</container>
+            <container id="aspace_3a1fd97230e9c4f29bc468ef36c072d6" parent="aspace_abd33c1f4fbe139fbd68799d146dbd3e" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref232_ak0" level="file">
+          <did>
+            <unittitle>Chapter 3 and introduction</unittitle>
+            <container id="aspace_6f4c2dd7fc7a8b5587a1d6ca34485533" label="Mixed Materials [aspace.536064.box.6]" type="Box">6</container>
+            <container id="aspace_925183b18d97fedc1e74ee2365545104" parent="aspace_6f4c2dd7fc7a8b5587a1d6ca34485533" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref233_39s" level="file">
+          <did>
+            <unittitle>Chapter 3</unittitle>
+            <container id="aspace_c25d58cb2b56168059969692b9154c01" label="Mixed Materials [aspace.536064.box.6]" type="Box">6</container>
+            <container id="aspace_4ad77ededce2d77a2f907187427730a0" parent="aspace_c25d58cb2b56168059969692b9154c01" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref234_xv8" level="file">
+          <did>
+            <unittitle>Chapter 3 continued</unittitle>
+            <container id="aspace_accbe88ade43e44aed025282cbcbd73d" label="Mixed Materials [aspace.536064.box.6]" type="Box">6</container>
+            <container id="aspace_78e206d37332141868f4b618c56ed786" parent="aspace_accbe88ade43e44aed025282cbcbd73d" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref235_fde" level="file">
+          <did>
+            <unittitle>Chapter 4</unittitle>
+            <container id="aspace_7213fbd8bd950b51bdc468a3801feb01" label="Mixed Materials [aspace.536064.box.6]" type="Box">6</container>
+            <container id="aspace_3b7483de7687dc844522548b0dc0026a" parent="aspace_7213fbd8bd950b51bdc468a3801feb01" type="folder">5-10</container>
+          </did>
+        </c>
+        <c id="aspace_ref236_0hm" level="file">
+          <did>
+            <unittitle>Answers to exercises, section 3, section 4</unittitle>
+            <container id="aspace_028ac0bef8bbf664d376c31f1859e58a" label="Mixed Materials [aspace.536064.box.6]" type="Box">6</container>
+            <container id="aspace_6ab5670a0cbd5dbf8cf6fb919a72341b" parent="aspace_028ac0bef8bbf664d376c31f1859e58a" type="folder">11-13</container>
+          </did>
+        </c>
+        <c id="aspace_ref237_oe8" level="file">
+          <did>
+            <unittitle>TeX form of chapter 3</unittitle>
+            <container id="aspace_c579b8662f5d2116c68fac6f368510aa" label="Mixed Materials [aspace.536064.box.7]" type="Box">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref238_wke" level="file">
+          <did>
+            <unittitle>Marion Howe's comments on the state of the book,</unittitle>
+            <unitdate datechar="creation">1978</unitdate>
+            <container id="aspace_7ea3f5a6e56bc0cac072d98e763cda82" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_9bff2d9fc1fc6c17cef7e1f2e8e13483" parent="aspace_7ea3f5a6e56bc0cac072d98e763cda82" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref239_yd7" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 1-36</unittitle>
+            <container id="aspace_6cbe8f24a1526c9a63831ff57f083682" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_205e978bffd69dfb986ef347a38e4f4f" parent="aspace_6cbe8f24a1526c9a63831ff57f083682" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref240_roq" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 37-111</unittitle>
+            <container id="aspace_0d16d17389f0651228bec67e08fe4cac" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_e1d76f9737e4132d57cfc3fd87e079fe" parent="aspace_0d16d17389f0651228bec67e08fe4cac" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref241_3dt" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 112-175</unittitle>
+            <container id="aspace_180904c48554e2e7eeb4f5a8d3c32113" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_5436ebf30e5975f494e3bb0bd1652a17" parent="aspace_180904c48554e2e7eeb4f5a8d3c32113" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref242_tsb" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 176-246</unittitle>
+            <container id="aspace_13e8dad926cba516badd9f2998796421" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_9dfae278f0dc325b657ab92825c8e632" parent="aspace_13e8dad926cba516badd9f2998796421" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref243_1j4" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 247-298</unittitle>
+            <container id="aspace_12355198ec90b62926945580f3261782" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_6bf7150c1dcb96bd1678cbc166b3727c" parent="aspace_12355198ec90b62926945580f3261782" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref244_o4j" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 299-309</unittitle>
+            <container id="aspace_f612b5661bc7dad22fff10e7647cf73c" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_18eb9db2760819c13a475e124b66ecc8" parent="aspace_f612b5661bc7dad22fff10e7647cf73c" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref245_m9v" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 310-386</unittitle>
+            <container id="aspace_89864af8422634a52e72035e2c814e5c" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_bf33c64c091b1f825a0915e3f453d8a9" parent="aspace_89864af8422634a52e72035e2c814e5c" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref246_o9c" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 387-485</unittitle>
+            <container id="aspace_0efda14c9469657f5e36e006a0946dec" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_3a812585eecef4197db9943809dd1878" parent="aspace_0efda14c9469657f5e36e006a0946dec" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref247_lxn" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 486-494</unittitle>
+            <container id="aspace_90f2bf306283571c26d79f1bb505d8e2" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_35f842b710c649f60197d0b025e46a5c" parent="aspace_90f2bf306283571c26d79f1bb505d8e2" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref248_kv1" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 495-540</unittitle>
+            <container id="aspace_90da45b25b4e01a23b3722f41eef475d" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_6f67b171ac8267c5a3b1b2c2ef2ffb9b" parent="aspace_90da45b25b4e01a23b3722f41eef475d" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref249_ate" level="file">
+          <did>
+            <unittitle>State of the book, 1978, p. 541-632</unittitle>
+            <container id="aspace_e76fe01fe6147bcc8f27946f9774add0" label="Mixed Materials [aspace.536064.box.8]" type="Box">8</container>
+            <container id="aspace_c23bd922e176b37e4814692a1ad9c3d7" parent="aspace_e76fe01fe6147bcc8f27946f9774add0" type="folder">12</container>
+          </did>
+        </c>
+        <c id="aspace_ref250_6sj" level="file">
+          <did>
+            <unittitle>State of the book, 1980 revisions, p. 1-113</unittitle>
+            <container id="aspace_168021cffda4e7a6bf26f4743b4952f8" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_e90b3087f9b6263c3ef41c337fc78657" parent="aspace_168021cffda4e7a6bf26f4743b4952f8" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref251_jen" level="file">
+          <did>
+            <unittitle>State of the book, 1980 revisions, p. 114-177</unittitle>
+            <container id="aspace_beadaa21d7fa1091e952d0c2074bc493" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_abce99ee304218bdf5b9b1bf2c6f055f" parent="aspace_beadaa21d7fa1091e952d0c2074bc493" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref252_jxk" level="file">
+          <did>
+            <unittitle>State of the book, 1980 revisions, p. 178-249</unittitle>
+            <container id="aspace_22f56d9ce8a9ab67087130c1c67c4974" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_80fb900db72f81f9e36439fb0af4b3b3" parent="aspace_22f56d9ce8a9ab67087130c1c67c4974" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref253_si7" level="file">
+          <did>
+            <unittitle>State of the book, 1980 revisions, p. 250-312</unittitle>
+            <container id="aspace_cb87f1724941637fd1970717a7c806a2" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_dc4ea26dee2c094879a8696e0e0ad75c" parent="aspace_cb87f1724941637fd1970717a7c806a2" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref254_x7j" level="file">
+          <did>
+            <unittitle>State of the book, 1980 revisions, p. 313-398</unittitle>
+            <container id="aspace_32b40ac9beb9e2f49ad0566759342a81" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_cb707b412cf03bbf22bf292f17c1a5b3" parent="aspace_32b40ac9beb9e2f49ad0566759342a81" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref255_91l" level="file">
+          <did>
+            <unittitle>State of the book, 1980 revisions, p. 399-466</unittitle>
+            <container id="aspace_3665b8385569578ba4fed75592342663" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_507ff872961a0c3cc2e582cb28ee7672" parent="aspace_3665b8385569578ba4fed75592342663" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref268_gx9" level="file">
+          <did>
+            <unittitle>Proofs for the 3rd edition of Volumes 1 and 2 and for the 2nd edition of Volume 3</unittitle>
+          </did>
+          <c id="aspace_ref269_upr" level="file">
+            <did>
+              <unittitle>Notebook entries (photocopies)</unittitle>
+              <container id="aspace_9700609cb470eebcb1fdf1df35be9a4e" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_63e43a59456807340b73c4ffe624dfb1" parent="aspace_9700609cb470eebcb1fdf1df35be9a4e" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref270_32l" level="file">
+            <did>
+              <unittitle>E-mail with Silvio Levy 1995 Aug. - 1996 Feb.</unittitle>
+              <container id="aspace_2a701740ab0293ef73963268ffb78574" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_53dc4d2f118135ab1450c545255aede2" parent="aspace_2a701740ab0293ef73963268ffb78574" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref271_qm0" level="file">
+            <did>
+              <unittitle>E-mail with Silvio Levy 1996 Mar. - July</unittitle>
+              <container id="aspace_0d5a2940d6f24fea531b5c083d2c4a68" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_efbf65bcf4b74f94c1bcf0381c50d4a8" parent="aspace_0d5a2940d6f24fea531b5c083d2c4a68" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref272_hy0" level="file">
+            <did>
+              <unittitle>E-mail with Silvio Levy 1996 Aug. - 1997 Mar.</unittitle>
+              <container id="aspace_458d9456977d39b0cc4d5037427eb074" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_5c2affaba811d28f9e22fd773bec77d8" parent="aspace_458d9456977d39b0cc4d5037427eb074" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref273_xje" level="file">
+            <did>
+              <unittitle>E-mail with Silvio Levy 1997 May - 1998 Jan.</unittitle>
+              <container id="aspace_348e6733a54db7937ab38dfffea034d2" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_cbd776e94726c168ab9070854123bb9b" parent="aspace_348e6733a54db7937ab38dfffea034d2" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref274_c4c" level="file">
+            <did>
+              <unittitle>Volume 1 illustration proofs</unittitle>
+              <container id="aspace_6cdb65190ecfe7268b9180ad594cb0f7" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_d8c8a637e952f71c92bea5fb35c8def4" parent="aspace_6cdb65190ecfe7268b9180ad594cb0f7" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref275_e5e" level="file">
+            <did>
+              <unittitle>Volume 1 Proofs: Preface - p. 99</unittitle>
+              <container id="aspace_e466ccd3d22fbc925970398640a9f125" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_9417facdddf19928c7ddc3aeac1697a5" parent="aspace_e466ccd3d22fbc925970398640a9f125" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref276_ij3" level="file">
+            <did>
+              <unittitle>Volume 1 Proofs: pp. 100-199</unittitle>
+              <container id="aspace_63757270478ebfdd16a39cc3c635dfbd" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_1a702ec6d81831e3f315fbae3cefd6e1" parent="aspace_63757270478ebfdd16a39cc3c635dfbd" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref277_ty4" level="file">
+            <did>
+              <unittitle>Volume 1 Proofs: pp. 200-299</unittitle>
+              <container id="aspace_d66bbc2f0682637bb8b257f65ceca0eb" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_c42872e4be41dbaf842973d159455829" parent="aspace_d66bbc2f0682637bb8b257f65ceca0eb" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref278_oqm" level="file">
+            <did>
+              <unittitle>Volume 1 Proofs: pp. 300-399</unittitle>
+              <container id="aspace_557c5ca0b1c6d4eae60f7002ff7e803c" label="Mixed Materials [aspace.536064.box.31]" type="Box">31</container>
+              <container id="aspace_e0b48bb96e7f1e8387f382d254c67d01" parent="aspace_557c5ca0b1c6d4eae60f7002ff7e803c" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref279_qqc" level="file">
+            <did>
+              <unittitle>Volume 1 Proofs: pp. 400-499</unittitle>
+              <container id="aspace_1e1f9ee13b733fa329594c50672b9e7f" label="Mixed Materials [aspace.536064.box.32]" type="Box">32</container>
+              <container id="aspace_5e332e9e2f8911a4740c99a9c59280f1" parent="aspace_1e1f9ee13b733fa329594c50672b9e7f" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref280_a4v" level="file">
+            <did>
+              <unittitle>Volume 1 Proofs: pp. 500-624</unittitle>
+              <container id="aspace_b89a6893ad4cccd41bd83651a7e4be7a" label="Mixed Materials [aspace.536064.box.32]" type="Box">32</container>
+              <container id="aspace_37d6a28c7b878a0f49713cb7e6522c6e" parent="aspace_b89a6893ad4cccd41bd83651a7e4be7a" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref281_txr" level="file">
+            <did>
+              <unittitle>Volume 1 Bound Proof</unittitle>
+              <container id="aspace_da40739b0caf3864416b6b2711dc3764" label="Mixed Materials [aspace.536064.box.32]" type="Box">32</container>
+              <container id="aspace_4dfc0dcb5aeb04b255e28c15436eaf96" parent="aspace_da40739b0caf3864416b6b2711dc3764" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref282_2bf" level="file">
+            <did>
+              <unittitle>Volume 1 Index Proofs</unittitle>
+              <container id="aspace_281483a69fff0cf94fc532e7b3d4be8d" label="Mixed Materials [aspace.536064.box.33]" type="Box">33</container>
+              <container id="aspace_6cc14a7349a833d92d82859f4a8dd698" parent="aspace_281483a69fff0cf94fc532e7b3d4be8d" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref283_tm3" level="file">
+            <did>
+              <unittitle>Volume 2 illustration proofs</unittitle>
+              <container id="aspace_ddb0c2c4df7024c18902715950f8988f" label="Mixed Materials [aspace.536064.box.33]" type="Box">33</container>
+              <container id="aspace_ea0db749da01fd180f5c79e3e52ddfae" parent="aspace_ddb0c2c4df7024c18902715950f8988f" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref284_flx" level="file">
+            <did>
+              <unittitle>Volume 2 Proofs: Preface - p. 99</unittitle>
+              <container id="aspace_bcd23b1c50097eb1a73a7ffccc76aa35" label="Mixed Materials [aspace.536064.box.33]" type="Box">33</container>
+              <container id="aspace_19eef289ba69e4c5ba0c0fc175eaadf4" parent="aspace_bcd23b1c50097eb1a73a7ffccc76aa35" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref285_ugw" level="file">
+            <did>
+              <unittitle>Volume 2 Proofs: pp. 100-300</unittitle>
+              <container id="aspace_024c5ce259ebe51e0ab5b1535ce6496f" label="Mixed Materials [aspace.536064.box.33]" type="Box">33</container>
+              <container id="aspace_8a40adbf713d95c087d37e619b52c9d9" parent="aspace_024c5ce259ebe51e0ab5b1535ce6496f" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref286_nq8" level="file">
+            <did>
+              <unittitle>Volume 2 Proofs: pp. 301-500</unittitle>
+              <container id="aspace_7ee096c763d8420ce50828421b9dd995" label="Mixed Materials [aspace.536064.box.33]" type="Box">33</container>
+              <container id="aspace_a52e62873591627165f4bcaebdd3574a" parent="aspace_7ee096c763d8420ce50828421b9dd995" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref287_45u" level="file">
+            <did>
+              <unittitle>Volume 2 Proofs: pp. 501 - end</unittitle>
+              <container id="aspace_428df2ada7fc98c618fa78fee779622e" label="Mixed Materials [aspace.536064.box.33]" type="Box">33</container>
+              <container id="aspace_b9953b4e79506af5bfbaca96c45d63ad" parent="aspace_428df2ada7fc98c618fa78fee779622e" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref288_8tp" level="file">
+            <did>
+              <unittitle>Volume 2 Bound Proof</unittitle>
+              <container id="aspace_3618a7b92154e6880c02005f1eb4f876" label="Mixed Materials [aspace.536064.box.34]" type="Box">34</container>
+              <container id="aspace_aa115f644eb85d4863cb2a426e09b79f" parent="aspace_3618a7b92154e6880c02005f1eb4f876" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref289_yyk" level="file">
+            <did>
+              <unittitle>Volume 2 Index Proofs</unittitle>
+              <container id="aspace_aedf55b801dce5b0ec0d8419b6e74586" label="Mixed Materials [aspace.536064.box.34]" type="Box">34</container>
+              <container id="aspace_25471bfcbd75c0fff56170cb27fe9481" parent="aspace_aedf55b801dce5b0ec0d8419b6e74586" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref290_w41" level="file">
+            <did>
+              <unittitle>Volume 3 illustration proofs</unittitle>
+              <container id="aspace_e46dbcb83f585122905dcbd9bfe27b18" label="Mixed Materials [aspace.536064.box.34]" type="Box">34</container>
+              <container id="aspace_57ee022525beec75d1c0d42ad7edbd38" parent="aspace_e46dbcb83f585122905dcbd9bfe27b18" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref291_sr7" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Preface and section 5.2</unittitle>
+              <container id="aspace_0714c0a8027d9344569130b98f02caa8" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_a82dfeac9431237e7f667dd090682079" parent="aspace_0714c0a8027d9344569130b98f02caa8" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref292_1cf" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Section 5.2.1 - 5.2.3</unittitle>
+              <container id="aspace_202f1e5241c65f6ba63c2e33e1817156" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_69a50879d5d9b8a58dd75fa17db204fe" parent="aspace_202f1e5241c65f6ba63c2e33e1817156" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref293_y3w" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Section 5.2.4 - 5.3.3</unittitle>
+              <container id="aspace_ed0555ba26f25e1c7babfccdacce9c59" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_7a4c0b31443a402cb1ac03ccbc3c3991" parent="aspace_ed0555ba26f25e1c7babfccdacce9c59" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref294_gr0" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Section 5.3.4 - 5.4.4</unittitle>
+              <container id="aspace_12a27297cbad98995caab0f298f713a2" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_6e4b34f9522136173253da80bfd81dba" parent="aspace_12a27297cbad98995caab0f298f713a2" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref295_0hq" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Section 5.4.5 - 6.2.1</unittitle>
+              <container id="aspace_85a080407b9a5cfb1f47e079d76839dc" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_b7a5c5cc95c268147fe8d2041043adfa" parent="aspace_85a080407b9a5cfb1f47e079d76839dc" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref296_en6" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Section 6.2.2 - 6.3</unittitle>
+              <container id="aspace_8734697a1fb86fa96cc5783781bec567" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_3530b741e22ae59f8a4ef60ce0c10b1c" parent="aspace_8734697a1fb86fa96cc5783781bec567" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref297_kv6" level="file">
+            <did>
+              <unittitle>Volume 3 Proofs: Section 6.4 - end</unittitle>
+              <container id="aspace_1d6684bd8af9bb6f580ca18a564d2bc5" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_505544bd0a820c011eadc97ff53a17a6" parent="aspace_1d6684bd8af9bb6f580ca18a564d2bc5" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref298_yp3" level="file">
+            <did>
+              <unittitle>Volume 3 Index Proofs</unittitle>
+              <container id="aspace_9971e1357c79565e32a4e640e6563805" label="Mixed Materials [aspace.536064.box.35]" type="Box">35</container>
+              <container id="aspace_65e963d32abb209d5e70543b704e8674" parent="aspace_9971e1357c79565e32a4e640e6563805" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref299_odm" level="file">
+            <did>
+              <unittitle>Volume 3 Chapter 5 Bound Proof</unittitle>
+              <container id="aspace_b75aa36ac6dfeb630d4005b17f087b02" label="Mixed Materials [aspace.536064.box.36]" type="Box">36</container>
+              <container id="aspace_bc4169e75f2100a1fe375b927e715445" parent="aspace_b75aa36ac6dfeb630d4005b17f087b02" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref300_49m" level="file">
+            <did>
+              <unittitle>Volume 3 Chapter 6 Bound Proof</unittitle>
+              <container id="aspace_bc32be66a1e8a5511347ccf1265b5020" label="Mixed Materials [aspace.536064.box.36]" type="Box">36</container>
+              <container id="aspace_aca95bf615c925d6f88710da76bd98ff" parent="aspace_bc32be66a1e8a5511347ccf1265b5020" type="folder">2</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref256_tp7" level="file">
+          <did>
+            <unittitle>p. 467-505</unittitle>
+            <container id="aspace_112a3d8b96093cb10d4b44bf08756a56" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_988d93cf29e01bf4347e7ab1bdc9fb42" parent="aspace_112a3d8b96093cb10d4b44bf08756a56" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref257_360" level="file">
+          <did>
+            <unittitle>p. 506-546</unittitle>
+            <container id="aspace_18a033efb153d04fa7b311ded106e38a" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_d3d0cb159eaf2181fece6b54feedf602" parent="aspace_18a033efb153d04fa7b311ded106e38a" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref258_deu" level="file">
+          <did>
+            <unittitle>p. 601-647</unittitle>
+            <container id="aspace_1d8c406f090b22fdda2780fd144273e4" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_58a498474fda51a9d5bf912a5a2e6147" parent="aspace_1d8c406f090b22fdda2780fd144273e4" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref259_lj2" level="file">
+          <did>
+            <unittitle>Appendices</unittitle>
+            <container id="aspace_00bffc641f80459e073abc91c472a91a" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_1331d3f1fa6922fe8131077fb0d73e05" parent="aspace_00bffc641f80459e073abc91c472a91a" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref260_jlk" level="file">
+          <did>
+            <unittitle>p. v-99</unittitle>
+            <container id="aspace_203e9997562b7a11adf28630ea8ce836" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_1c39cea346b7209f2692451ca0050648" parent="aspace_203e9997562b7a11adf28630ea8ce836" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref261_zcg" level="file">
+          <did>
+            <unittitle>p. 100-199</unittitle>
+            <container id="aspace_24fb59ffcba182b4e3fd7c7ddc6d8f42" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_617f5da5972715591c61072958a2ac87" parent="aspace_24fb59ffcba182b4e3fd7c7ddc6d8f42" type="folder">12</container>
+          </did>
+        </c>
+        <c id="aspace_ref262_z7t" level="file">
+          <did>
+            <unittitle>p. 200-299</unittitle>
+            <container id="aspace_b5093d2319370358a090b086d48ba602" label="Mixed Materials [aspace.536064.box.9]" type="Box">9</container>
+            <container id="aspace_f4cd51e867f48dd1d715f55e2dce8889" parent="aspace_b5093d2319370358a090b086d48ba602" type="folder">13</container>
+          </did>
+        </c>
+        <c id="aspace_ref263_39r" level="file">
+          <did>
+            <unittitle>p. 300-399</unittitle>
+            <container id="aspace_b58b331d8bea19edd66b5321f37c4d37" label="Mixed Materials [aspace.536064.box.10]" type="Box">10</container>
+            <container id="aspace_ecb5e336dee71057fc097abf6c1a58c9" parent="aspace_b58b331d8bea19edd66b5321f37c4d37" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref264_y18" level="file">
+          <did>
+            <unittitle>p. 400-499</unittitle>
+            <container id="aspace_b61c4c0e601df2d8cc1f8841b54c3e3e" label="Mixed Materials [aspace.536064.box.10]" type="Box">10</container>
+            <container id="aspace_de3a724ffb66a6362cfd42b28bcf9f93" parent="aspace_b61c4c0e601df2d8cc1f8841b54c3e3e" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref265_6kh" level="file">
+          <did>
+            <unittitle>p. 500-599</unittitle>
+            <container id="aspace_f456a5d5e9155d4f4fccb8e5fc963cc9" label="Mixed Materials [aspace.536064.box.10]" type="Box">10</container>
+            <container id="aspace_c625c45157f4bb89ea558d9defaccc0a" parent="aspace_f456a5d5e9155d4f4fccb8e5fc963cc9" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref266_ddt" level="file">
+          <did>
+            <unittitle>p. 600-688</unittitle>
+            <container id="aspace_0e8fa14d54d50f7d77afcd941dc51e73" label="Mixed Materials [aspace.536064.box.10]" type="Box">10</container>
+            <container id="aspace_a265c9b01dd9bb5ce1a1821e29badf98" parent="aspace_0e8fa14d54d50f7d77afcd941dc51e73" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref267_ygx" level="file">
+          <did>
+            <unittitle>TeX form of the book</unittitle>
+            <container id="aspace_e051a19b9fec4e769bd0d1b40f5fa099" label="Mixed Materials [aspace.536064.box.11]" type="Box">11</container>
+            <container id="aspace_f6f2c41b29103e1f160ee873cd26614e" parent="aspace_e051a19b9fec4e769bd0d1b40f5fa099" type="folder">1-22</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_ref301_1j4" level="series">
+        <did>
+          <unittitle>
+            <title render="italic">Computers and Typesetting</title>
+          </unittitle>
+          <unitid>Series 2</unitid>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+        </did>
+        <scopecontent id="aspace_5d0ecb32208b877f4d409d04d9913f47">
+          <head>Scope and Contents note</head>
+          <p>This set of 14 boxes contains materials from nine years of work on computer systems for publishing at stanford. 'The main results of this work have been published in five volumes entitled Computers &amp; Typesetting, Volumes A--E (Reading, Mass.: Addison Wesley, 1986).</p>
+          <p>The research introduced three major computer systems: <list><item>1) TeX, a system for typesetting</item><item>2) METAFONT, a system for typeface design</item><item>3) Computer Modern, a family of typefaces</item></list> </p>
+          <p>Another important byproduct was the WEB system for structured documentation of computer programs.</p>
+          <p>Included are the original manuscripts, revised drafts, logbooks, commentary from other experts, research files, and correspondence pertaining to three major computer systems: TeX, a system for typesetting, METAFONT, a system for typeface design, and Computer Modern, a family of typefaces. Also included are keepsakes and specimens of early use of these systems.</p>
+          <p>The manuscripts were written by Knuth as these systems were being created, together with intermediate versions and log books that show how things developed and changed over the years. Critical comments by leading experts, who helped to refine the ideas, are included. Many of the "first" editions printed by these new methods, at stanford and at many other places around the world, are also preserved here. The period 1977 - 1986 was one of dramatic change in the world of book publishing; numerous keepsakes and specimens from TeX and other systems have been collected.</p>
+        </scopecontent>
+        <c id="aspace_ref303_6yp" level="file">
+          <did>
+            <unittitle>Legal size documents</unittitle>
+          </did>
+          <c id="aspace_ref304_eg5" level="file">
+            <did>
+              <unittitle>log book and test program for debugging TeX78</unittitle>
+              <container id="aspace_6747ebe5d1eaa4102189b7e7635f065e" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_be79cabb3f16baf66cb7e5298f554535" parent="aspace_6747ebe5d1eaa4102189b7e7635f065e" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref305_3wo" level="file">
+            <did>
+              <unittitle>The first pages of output by TeX, Mar--Jul 1978</unittitle>
+              <container id="aspace_98d5de11f8c534444ce2e1edcf84b665" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_4ca19492fd1a2b2c8543ebb77c99f602" parent="aspace_98d5de11f8c534444ce2e1edcf84b665" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref306_bof" level="file">
+            <did>
+              <unittitle>Manuscript of first TeX Manual, 1978</unittitle>
+              <container id="aspace_7262cff168064fbfd8ab4fbc9bc1ffc2" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_f977577d934431b3cfa377503ab238e6" parent="aspace_7262cff168064fbfd8ab4fbc9bc1ffc2" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref307_oj1" level="file">
+            <did>
+              <unittitle>Manuscript of first METAFONT Manual, 1979</unittitle>
+              <container id="aspace_ac99528165dbdfb91336cff19ebbcc23" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_3cfa2fdee93a0ad4ecd783570c424da5" parent="aspace_ac99528165dbdfb91336cff19ebbcc23" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref308_a0z" level="file">
+            <did>
+              <unittitle>original (inco:rrplete) draft of TeX82 , Aug--Sep 1981</unittitle>
+              <container id="aspace_c22ecf42d404f1485e8316f43370485a" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_879cc92bb9cd05ada852a056d401a402" parent="aspace_c22ecf42d404f1485e8316f43370485a" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref309_kiq" level="file">
+            <did>
+              <unittitle>Pencil draft of WEB, Sep--oct 1981</unittitle>
+              <container id="aspace_409b5e96643153a8ca36dd089d10b030" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_0d867d2750f2ad033a33dbee0ef9fc22" parent="aspace_409b5e96643153a8ca36dd089d10b030" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref310_moi" level="file">
+            <did>
+              <unittitle>First use of WEB with TeX82 before it was complete</unittitle>
+              <container id="aspace_f7b3332ca75d1f30261fdd3b0ef4e510" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_f2c33ceb08457ba0885d55c1af1c77c6" parent="aspace_f7b3332ca75d1f30261fdd3b0ef4e510" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref311_5oz" level="file">
+            <did>
+              <unittitle>Manuscript of TeX82 program, Jan--Jun 1982</unittitle>
+              <container id="aspace_5975d5039f1b8a9445f17eb10a52cd4a" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_baf85cfe2960da68497023306b7bbe06" parent="aspace_5975d5039f1b8a9445f17eb10a52cd4a" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref312_0b8" level="file">
+            <did>
+              <unittitle>Log of the first bugs fround in TeX82, Jul--Sep 1982</unittitle>
+              <container id="aspace_a50d764a5b15aa4897aaa0fc39b2bab2" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_3e1118d5695ae579cce15a1f59de91a1" parent="aspace_a50d764a5b15aa4897aaa0fc39b2bab2" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref313_lb0" level="file">
+            <did>
+              <unittitle>Original manuscript of the TeXBook, Oct 1982--Sep 1983</unittitle>
+              <container id="aspace_639ab8f3369d8fe0fa2a99096d678d24" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_4b5ad0fbfbb5b951c75a8e3c453da5d0" parent="aspace_639ab8f3369d8fe0fa2a99096d678d24" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref314_7b5" level="file">
+            <did>
+              <unittitle>Manuscript of the PROFILE program, Oct 1983</unittitle>
+              <container id="aspace_4216467fa9ee2cf2495e691f2e41aa55" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_db86f0c9a007c9594ef3057555368d64" parent="aspace_4216467fa9ee2cf2495e691f2e41aa55" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref315_frt" level="file">
+            <did>
+              <unittitle>Dcx::xnnentation of system used at Universities Press, Belfast, in</unittitle>
+              <unitdate datechar="creation">1977</unitdate>
+              <container id="aspace_98bcbe6f5cfbf2a17e8a3a404b9ffaec" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_cead73a57b3cacab09f628802af95008" parent="aspace_98bcbe6f5cfbf2a17e8a3a404b9ffaec" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref316_0ww" level="file">
+            <did>
+              <unittitle>CTI Math System</unittitle>
+              <container id="aspace_6bc5d8499248aa1aad9d5ffc121ad23e" label="Mixed Materials [aspace.536236.box.12]" type="Box">12</container>
+              <container id="aspace_781f7a744808b4552a58b01b028592e0" parent="aspace_6bc5d8499248aa1aad9d5ffc121ad23e" type="folder">13</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref317_8of" level="file">
+          <did>
+            <unittitle>Volume A, The TeXbook</unittitle>
+          </did>
+          <c id="aspace_ref318_nk0" level="file">
+            <did>
+              <unittitle>First TeX manual: draft copy for making the index, Jul 31 1978</unittitle>
+              <container id="aspace_3838892c4df0d28344664dc357374dba" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_d36c57908601aee5f78cd5093595b5b3" parent="aspace_3838892c4df0d28344664dc357374dba" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref319_dpm" level="file">
+            <did>
+              <unittitle>First TeX manual: as it was stored in the computer, Aug 27 1978</unittitle>
+              <container id="aspace_a76fa4be8b84ff2ff8ac2971a05681de" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_b3b5af42e52801548d9afe392df21f31" parent="aspace_a76fa4be8b84ff2ff8ac2971a05681de" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref320_mc6" level="file">
+            <did>
+              <unittitle>First TeX manual, Sep 1978</unittitle>
+              <container id="aspace_37e0d0bf6a2419d4df92eac36d1d1efd" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_bb4829cdc45c8bc1b97825f06f31c035" parent="aspace_37e0d0bf6a2419d4df92eac36d1d1efd" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref321_2aq" level="file">
+            <did>
+              <unittitle>The TeXbook: first printed drafts</unittitle>
+              <container id="aspace_e63cda2d1b1bdd5a5853d0dfd655d072" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_310ef58b1b90768b5b5e61140dca7129" parent="aspace_e63cda2d1b1bdd5a5853d0dfd655d072" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref322_7x3" level="file">
+            <did>
+              <unittitle>The TeXbook: second printed drafts</unittitle>
+              <container id="aspace_a0363560cea6c7cd34ba4d8e15e2d4a6" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_36169f9a9c8779529e3cbca3cfee5919" parent="aspace_a0363560cea6c7cd34ba4d8e15e2d4a6" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref323_bju" level="file">
+            <did>
+              <unittitle>The TeXbook: third printed drafts</unittitle>
+              <container id="aspace_cfe4b5150860e8b754d25a8245180aa1" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_a08eb32d6aa6cc466802348050d51e4a" parent="aspace_cfe4b5150860e8b754d25a8245180aa1" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref324_xwt" level="file">
+            <did>
+              <unittitle>The TeXbook: one-of-a-kind edition used to make the index</unittitle>
+              <container id="aspace_7c98e5e8cad7326a1bf2150d571b1c86" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_aceed9aebfce68ad4486460fed43d653" parent="aspace_7c98e5e8cad7326a1bf2150d571b1c86" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref325_7rx" level="file">
+            <did>
+              <unittitle>Experiments with TeX done while writing the TeXbook</unittitle>
+              <container id="aspace_424f6e7769de4aae8c812bf7f57dfcc4" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_3344d369b768d9b8de21caefb29b0c2f" parent="aspace_424f6e7769de4aae8c812bf7f57dfcc4" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref326_v3p" level="file">
+            <did>
+              <unittitle>The TeXbook illustrations by Duane Bibby</unittitle>
+              <container id="aspace_436063c13c782b1797423679669d198f" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_c8c88498760f77c86c6a967ec58e91a9" parent="aspace_436063c13c782b1797423679669d198f" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref327_uey" level="file">
+            <did>
+              <unittitle>The TeXbook: comments from readers of pre-publication drafts</unittitle>
+              <container id="aspace_fb047420f16ab371178334233a542788" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_4cdd433bb25fb6a395520ec4db27b6ee" parent="aspace_fb047420f16ab371178334233a542788" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref328_27a" level="file">
+            <did>
+              <unittitle>The TeXbook: as marked by Addison-Wesley copy editor</unittitle>
+              <container id="aspace_e4a5eae4cd44af366649b089fd0543a5" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_dd30e9757dfb444ae3e4c26a6e209b6b" parent="aspace_e4a5eae4cd44af366649b089fd0543a5" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref329_l3h" level="file">
+            <did>
+              <unittitle>The TeXbook: book and cover design</unittitle>
+              <container id="aspace_072234b80b0996cb66e02e64b8708c56" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_335e825ab92d2d420336981adf08b86d" parent="aspace_072234b80b0996cb66e02e64b8708c56" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref330_m4w" level="file">
+            <did>
+              <unittitle>The TeXbook: Permission letters</unittitle>
+              <container id="aspace_ccf411e4c56f4eade6ef6baee5921e72" label="Mixed Materials [aspace.536236.box.13]" type="Box">13</container>
+              <container id="aspace_befdd536ffdb43cebc6f9a1f56e08ef2" parent="aspace_ccf411e4c56f4eade6ef6baee5921e72" type="folder">13</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref331_0qu" level="file">
+          <did>
+            <unittitle>TeX milieu</unittitle>
+          </did>
+          <c id="aspace_ref332_1rl" level="file">
+            <did>
+              <unittitle>BBR System, world's first computer controlled printing of text</unittitle>
+              <container id="aspace_ccf5dbb693172ab15c33be13ce2af2af" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_d5626027b702da4c633a3b8ef8fc0cf2" parent="aspace_ccf5dbb693172ab15c33be13ce2af2af" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref333_dhf" level="file">
+            <did>
+              <unittitle>Hershey's typographic systems</unittitle>
+              <container id="aspace_c1af82a6b388d67c4869d79bff8ae902" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_2c1f82fc6f6917987388c668fb10a9b4" parent="aspace_c1af82a6b388d67c4869d79bff8ae902" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref334_erf" level="file">
+            <did>
+              <unittitle>American Math Society research on composition</unittitle>
+              <container id="aspace_d8869227049dc9ded75112598e9858cc" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_b81bbe93e594201c0e7af9b0a243b9f3" parent="aspace_d8869227049dc9ded75112598e9858cc" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref335_lfp" level="file">
+            <did>
+              <unittitle>composition systems from commercial vendors</unittitle>
+              <container id="aspace_fb0ddfa66155a31a177113afa4db7463" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_1b430a8bd77de9d2dadc82d52aceb5dd" parent="aspace_fb0ddfa66155a31a177113afa4db7463" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref336_p0b" level="file">
+            <did>
+              <unittitle>Typesetting research at universities</unittitle>
+              <container id="aspace_85ed0cc4d3b255a9aabbef775f894f16" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_3bdac143b688ac4d657bd7edf1b99c90" parent="aspace_85ed0cc4d3b255a9aabbef775f894f16" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref337_emn" level="file">
+            <did>
+              <unittitle>Typesetting research at Bell Laboratories</unittitle>
+              <container id="aspace_a10f29a72a52451f4f4f0a0cc7e5f535" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_bd4ea8fb0ced551b30de13a44a97c277" parent="aspace_a10f29a72a52451f4f4f0a0cc7e5f535" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref338_ezp" level="file">
+            <did>
+              <unittitle>Typesetting research at other laboratories</unittitle>
+              <container id="aspace_026a9bdc73a07cf99354edb48c7ff0e2" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_676c99b3fcc37e4af75ac44bf14e32e8" parent="aspace_026a9bdc73a07cf99354edb48c7ff0e2" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref339_3qj" level="file">
+            <did>
+              <unittitle>Fancy word processing with math</unittitle>
+              <container id="aspace_1ac649a1712f94608b5556ec04799657" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_22d89388933336461194bb508fd95992" parent="aspace_1ac649a1712f94608b5556ec04799657" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref340_gge" level="file">
+            <did>
+              <unittitle>TeX in the Bay Area</unittitle>
+              <container id="aspace_4fa7a1674da78855b8b1ecd3133c363d" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_97a93cb646f0a80eecaf813d5aebeb3e" parent="aspace_4fa7a1674da78855b8b1ecd3133c363d" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref341_q7r" level="file">
+            <did>
+              <unittitle>TeX elsewhere in the U.S.A.</unittitle>
+              <container id="aspace_8929c84e018b7700d986574d4a55074f" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_488a645aadaf12ff497913af91d00c08" parent="aspace_8929c84e018b7700d986574d4a55074f" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref342_st5" level="file">
+            <did>
+              <unittitle>TeX in other countries</unittitle>
+              <container id="aspace_f413d53e5d9dee30a677b0777f5c43f7" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_b8d17256ea00c20d54fb2a1ce904659f" parent="aspace_f413d53e5d9dee30a677b0777f5c43f7" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref343_l79" level="file">
+            <did>
+              <unittitle>Company business re: TeX</unittitle>
+              <container id="aspace_6222f345fbffc844a4566e3649d69cf4" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_f37afe99aacd01b64a990b0b551045ed" parent="aspace_6222f345fbffc844a4566e3649d69cf4" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref344_iqg" level="file">
+            <did>
+              <unittitle>Supplementary work on hyphenation and pagination</unittitle>
+              <container id="aspace_ca26f5541ecef744055cd9327568c02b" label="Mixed Materials [aspace.536236.box.14]" type="Box">14</container>
+              <container id="aspace_7e201d7056f14c55bb47e8a9f4a21d14" parent="aspace_ca26f5541ecef744055cd9327568c02b" type="folder">13</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref345_rb4" level="file">
+          <did>
+            <unittitle>TeX memorabilia and auxiliary systems</unittitle>
+          </did>
+          <c id="aspace_ref346_507" level="file">
+            <did>
+              <unittitle>The "DOC" system (father of "WEB")</unittitle>
+              <unitdate datechar="creation">Feb-Mar 1979</unitdate>
+              <container id="aspace_f7f7f5cd05a57e8aef5562c04a589dfb" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_f4b322af88c3a89554f19c28b87e1518" parent="aspace_f7f7f5cd05a57e8aef5562c04a589dfb" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref347_jdl" level="file">
+            <did>
+              <unittitle>The WEB manual</unittitle>
+              <container id="aspace_5005ce0800739674582691f980cc8eca" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_77d2ff79d2c619fc71523630ad1b4c1e" parent="aspace_5005ce0800739674582691f980cc8eca" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref348_jar" level="file">
+            <did>
+              <unittitle>TeXware" "</unittitle>
+              <container id="aspace_9c6caa9f575f56aa0124dc349440262a" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_cfc048376243b20e259be82f56575cb5" parent="aspace_9c6caa9f575f56aa0124dc349440262a" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref349_841" level="file">
+            <did>
+              <unittitle>Early use of WEB</unittitle>
+              <container id="aspace_694625852f07bc3beda3fc3eab01a2a7" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_09227429cf5eb4ab17ae92313b3b0879" parent="aspace_694625852f07bc3beda3fc3eab01a2a7" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref350_pmu" level="file">
+            <did>
+              <unittitle>Software for the Alphatype CRS</unittitle>
+              <container id="aspace_2ee8c2e4361683aebb9212dcdedc0265" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_e244ffe682b239d264f6a20cbc10c66b" parent="aspace_2ee8c2e4361683aebb9212dcdedc0265" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref351_wss" level="file">
+            <did>
+              <unittitle>Samples from first interfaces between TeX or METAFDNT and devices</unittitle>
+              <container id="aspace_1889fbeb5921e46c931f7b642f1b41e0" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_7d372909611b55471b3809910027a04d" parent="aspace_1889fbeb5921e46c931f7b642f1b41e0" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref352_t3q" level="file">
+            <did>
+              <unittitle>Examples of early TeX output: (A) Things I made myself or with Jill</unittitle>
+              <container id="aspace_4064fb5f2bbfb7ea9db843b759f4ac7a" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_cb1822c57f891f89cc64e033f19d4471" parent="aspace_4064fb5f2bbfb7ea9db843b759f4ac7a" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref353_h4v" level="file">
+            <did>
+              <unittitle>Examples of early TeX output: (B) Things made by others</unittitle>
+              <container id="aspace_7d49ca985ab72aca7fa8e61bae061340" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_1abb06c3f6e02c13e266ada8a62a5cc3" parent="aspace_7d49ca985ab72aca7fa8e61bae061340" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref354_p2t" level="file">
+            <did>
+              <unittitle>Examples of early TeX output: (C) Books</unittitle>
+              <container id="aspace_5dc210bfbc3dd3c7ea52791e880400ee" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_1aab50697a4be3c1a214bf29ab425d24" parent="aspace_5dc210bfbc3dd3c7ea52791e880400ee" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref355_g37" level="file">
+            <did>
+              <unittitle>Miscellaneous correspondence, clippings, etc. relevant to TeX</unittitle>
+              <container id="aspace_c9ebbcf2925b8ab5e26709269d4eaa63" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_4bdc8be73f9584a6fcac8c75b764f02e" parent="aspace_c9ebbcf2925b8ab5e26709269d4eaa63" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref356_rdw" level="file">
+            <did>
+              <unittitle>Correspondence with American Math Society</unittitle>
+              <container id="aspace_62630cd4b68a1f724865b195db366f0f" label="Mixed Materials [aspace.536236.box.15]" type="Box">15</container>
+              <container id="aspace_7cd7bee04fd9b301672970206aae26e3" parent="aspace_62630cd4b68a1f724865b195db366f0f" type="folder">11</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref357_epa" level="file">
+          <did>
+            <unittitle>Volume B, TeX: The Program</unittitle>
+          </did>
+          <c id="aspace_ref358_3ds" level="file">
+            <did>
+              <unittitle>Prototype implementation of TeX, Aug 25 1977</unittitle>
+              <container id="aspace_9500e1719f677e5c92c7bc93aac0cd1c" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_0651ea6835249747c50cf5d22b5e5136" parent="aspace_9500e1719f677e5c92c7bc93aac0cd1c" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref359_xiz" level="file">
+            <did>
+              <unittitle>Beginnings of first TeX implementation, Oct 14 1977</unittitle>
+              <container id="aspace_a946cb0f569576aa8889aa22a21fd994" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_24501d0180e2117b49899307a51950a0" parent="aspace_a946cb0f569576aa8889aa22a21fd994" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref360_c91" level="file">
+            <did>
+              <unittitle>First implementation almost complete, Jan 29 1978</unittitle>
+              <container id="aspace_863ea3ebfc4e208d467539bb68516ce1" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_5699c817fc3d7f4b9bb79623bc777a61" parent="aspace_863ea3ebfc4e208d467539bb68516ce1" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref361_39v" level="file">
+            <did>
+              <unittitle>First implementation complete and ready for debugging,</unittitle>
+              <unitdate datechar="creation">1978 Feb 10</unitdate>
+              <container id="aspace_9d7a5ca15d0be64522c27f09238e11bc" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_8a65acc70a6d1b9a6d2bddccee0c5738" parent="aspace_9d7a5ca15d0be64522c27f09238e11bc" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref362_5a8" level="file">
+            <did>
+              <unittitle>After initial debugging, Mar 29 1978</unittitle>
+              <container id="aspace_413c5cc87f9668a5063a144d9e330413" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_97534b35dbad774458b91c40a839eee6" parent="aspace_413c5cc87f9668a5063a144d9e330413" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref363_y6h" level="file">
+            <did>
+              <unittitle>The first version released" for general use</unittitle>
+              <unitdate datechar="creation">Aug 2 1978 "</unitdate>
+              <container id="aspace_a2011b381000de00da04187e0e943a73" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_baa935c41e6f83d54c490f679aa2a301" parent="aspace_a2011b381000de00da04187e0e943a73" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref364_t6e" level="file">
+            <did>
+              <unittitle>Fully debugged" version</unittitle>
+              <unitdate datechar="creation">Aug 1979 "</unitdate>
+              <container id="aspace_fbb5513e1dd3e7a854fed2ba19387d98" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_a71559605a10e4beecbd5a3b1739c7b0" parent="aspace_fbb5513e1dd3e7a854fed2ba19387d98" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref365_4ru" level="file">
+            <did>
+              <unittitle>TeX78 as it was in Jul 1981</unittitle>
+              <container id="aspace_081d2116fa404ee23c112bdda21d47f8" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_f96fd054c4044b81f4dd0b1b23de09fa" parent="aspace_081d2116fa404ee23c112bdda21d47f8" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref366_uyv" level="file">
+            <did>
+              <unittitle>TeX in Pascal, written by Ignacio Zabala</unittitle>
+              <container id="aspace_b405aa173504e6e76735c738706915cf" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_63c156cfd433e7773d393ac04e0afda9" parent="aspace_b405aa173504e6e76735c738706915cf" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref367_30d" level="file">
+            <did>
+              <unittitle>TeX in MESA, written by Leo Guibas, Bob Sedgewick, and Doug Wyatt</unittitle>
+              <container id="aspace_7cd840e1c7d48046218cdc8c85b6d356" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_433411b730262ea2e57e6405e3ee9f5e" parent="aspace_7cd840e1c7d48046218cdc8c85b6d356" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref368_q5f" level="file">
+            <did>
+              <unittitle>First draft of TeX82, Sep 6 1981 (incomplete)</unittitle>
+              <container id="aspace_a5eb3e51284495f2cc730784a4febe76" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_85df1db924d0d5d2209fef3958be6dd9" parent="aspace_a5eb3e51284495f2cc730784a4febe76" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref369_ley" level="file">
+            <did>
+              <unittitle>Early draft of TeX82 , Jan 2 1982</unittitle>
+              <container id="aspace_28f895ef0b6e314d57a9a6d07ccb8f25" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_d88dfe945c28b53c67d6bbf7011468ae" parent="aspace_28f895ef0b6e314d57a9a6d07ccb8f25" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref370_ex1" level="file">
+            <did>
+              <unittitle>A more complete draft of TeX82, Mar 28 1982</unittitle>
+              <container id="aspace_eb20e503967fe64f3929bd15d3ce7ce7" label="Mixed Materials [aspace.536236.box.16]" type="Box">16</container>
+              <container id="aspace_dd2178a0cd6605135bd7aa0e36994b69" parent="aspace_eb20e503967fe64f3929bd15d3ce7ce7" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref371_x0t" level="file">
+            <did>
+              <unittitle>"Nearly complete" draft</unittitle>
+              <unitdate datechar="creation">Jun 14 1982 "</unitdate>
+              <container id="aspace_d049944f5bc674f90a1c4297bdf89ec6" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_221260d6a5513e534bf4102afcf5bd48" parent="aspace_d049944f5bc674f90a1c4297bdf89ec6" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref372_l1s" level="file">
+            <did>
+              <unittitle>The first complete draft of TeX82, Jun 29</unittitle>
+              <container id="aspace_cc553afdeeb839d33b25d1365e35be8f" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_24c4cf397a2e021c2b500bec0087afec" parent="aspace_cc553afdeeb839d33b25d1365e35be8f" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref373_wkr" level="file">
+            <did>
+              <unittitle>TeX82 initial debugging, Jul 13 1982</unittitle>
+              <container id="aspace_ab380e75a504655d455c9d6b8bdafdaa" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_1f3d928ce6fe7c5a813234bf4b65df38" parent="aspace_ab380e75a504655d455c9d6b8bdafdaa" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref374_q60" level="file">
+            <did>
+              <unittitle>Version -0.25" of TeX82</unittitle>
+              <unitdate datechar="creation">Jul 25 1982</unitdate>
+              <container id="aspace_eed77545ec086363321fc79279a7c788" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_6180e7aadcf35c98332b7bfe0d4cca02" parent="aspace_eed77545ec086363321fc79279a7c788" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref375_iab" level="file">
+            <did>
+              <unittitle>Version 0 of TeX82, Sep 1982</unittitle>
+              <container id="aspace_bcbb95857f3fad702e57bdcb673cc524" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_08bb52f50f235b81f2e676c7d69610a3" parent="aspace_bcbb95857f3fad702e57bdcb673cc524" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref376_gy9" level="file">
+            <did>
+              <unittitle>Version 0.999 of TeX82, Jul 1983</unittitle>
+              <container id="aspace_dc9db3c5405de6d62d94a988a86cf6bc" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_a59f155ac99d0c8dd0ef4cce0671e378" parent="aspace_dc9db3c5405de6d62d94a988a86cf6bc" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref377_odj" level="file">
+            <did>
+              <unittitle>Empirical runtime analysis of TeX</unittitle>
+              <container id="aspace_3ce663acb96b3ef72d95c8fcb4f043d8" label="Mixed Materials [aspace.536236.box.17]" type="Box">17</container>
+              <container id="aspace_86406a9dd4aa809a3a76ebed4c047513" parent="aspace_3ce663acb96b3ef72d95c8fcb4f043d8" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref378_c63" level="file">
+            <did>
+              <unittitle>Version 1.0 of TeX82, Dec 3 1983</unittitle>
+              <container id="aspace_37e3bfe65a8e30299c272f84e714f71d" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_c1c39e7e62ad7f2afed23307ffccce00" parent="aspace_37e3bfe65a8e30299c272f84e714f71d" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref379_t0p" level="file">
+            <did>
+              <unittitle>Version 1.3 of TeX82, Dec 1984</unittitle>
+              <container id="aspace_7e682682602c16880d5f07004acb5767" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_15c5c49dfc1e94dcaefee20b90ec248f" parent="aspace_7e682682602c16880d5f07004acb5767" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref380_kho" level="file">
+            <did>
+              <unittitle>Version 2.0 of TeX82, Nov 11 1985</unittitle>
+              <container id="aspace_12a1e3decf7efe84400a91d798e45d16" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_9826987c462ca2fb83520607b8500630" parent="aspace_12a1e3decf7efe84400a91d798e45d16" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref381_afn" level="file">
+            <did>
+              <unittitle>Copy editor's corrections to Volume B, Jan 1986</unittitle>
+              <container id="aspace_bf45a65378d41a9452eb36e94202c3a5" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_dfe4981a450ce9fca05b74d0493622a2" parent="aspace_bf45a65378d41a9452eb36e94202c3a5" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref382_wxn" level="file">
+            <did>
+              <unittitle>Profiles (timing information) for TeX82, 1984</unittitle>
+              <container id="aspace_bf5023693553f771f49094a5721a56dc" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_f38cb298f67e1823c0bb2afaf44f6163" parent="aspace_bf5023693553f771f49094a5721a56dc" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref383_4um" level="file">
+            <did>
+              <unittitle>TWILL (special variant of WEAVE for Volumes B and</unittitle>
+              <unitdate datechar="creation">D)</unitdate>
+              <container id="aspace_30ac1dd55dcaac87ab3dd0a7c98b7858" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_2897e0e9039f0d52e4e336493edeaaf0" parent="aspace_30ac1dd55dcaac87ab3dd0a7c98b7858" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref384_zih" level="file">
+            <did>
+              <unittitle>Volume B, front matter</unittitle>
+              <container id="aspace_09425b0fb0c7a7254f89f64510b61786" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_477b52fe17397b86801d2a9146bcc57e" parent="aspace_09425b0fb0c7a7254f89f64510b61786" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref385_76q" level="file">
+            <did>
+              <unittitle>TeXHAX"</unittitle>
+              <unitdate datechar="creation">messages among early users "</unitdate>
+              <container id="aspace_03ca07bcd08506a2d4f16ad694f74902" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_d40612aab844fc9cac4952ddc698de64" parent="aspace_03ca07bcd08506a2d4f16ad694f74902" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref386_ufk" level="file">
+            <did>
+              <unittitle>TUG (TeX Users Group)</unittitle>
+              <container id="aspace_967ce3f50157f76d81e0be84f3079667" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_72ae34c891a36e10900bc862647e2c1e" parent="aspace_967ce3f50157f76d81e0be84f3079667" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref387_udy" level="file">
+            <did>
+              <unittitle>First uses" of TeX</unittitle>
+              <unitdate datechar="creation">continued "</unitdate>
+              <container id="aspace_4bc751fafb0e9b55ab110d278a0cbd5d" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_19cd13918a6ac446f192995651eb0774" parent="aspace_4bc751fafb0e9b55ab110d278a0cbd5d" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref388_f1g" level="file">
+            <did>
+              <unittitle>Addison-Wesley pUblicity brochures</unittitle>
+              <container id="aspace_1beac888e7b45a321ee60e4c8b1fb79e" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_df5b826c13892d49e32a363724fcae8a" parent="aspace_1beac888e7b45a321ee60e4c8b1fb79e" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref389_2go" level="file">
+            <did>
+              <unittitle>Other systems based on TeX</unittitle>
+              <container id="aspace_7842cc930d7bd7f9d18d1cbe5279c63e" label="Mixed Materials [aspace.536236.box.18]" type="Box">18</container>
+              <container id="aspace_e0938cb512503e0c6f39241e880f544c" parent="aspace_7842cc930d7bd7f9d18d1cbe5279c63e" type="folder">12</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref390_1q2" level="file">
+          <did>
+            <unittitle>TeX addenda; Volume C, The METAFONTbook</unittitle>
+          </did>
+          <c id="aspace_ref391_vrl" level="file">
+            <did>
+              <unittitle>Miscellaneous correspondence from users</unittitle>
+              <container id="aspace_d42959fab077a67eb425559e8b5f4f4f" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_7b1b924770cf189df0d524b132aaf754" parent="aspace_d42959fab077a67eb425559e8b5f4f4f" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref392_ixv" level="file">
+            <did>
+              <unittitle>A simple system that came before TeX, Jun 1976</unittitle>
+              <container id="aspace_d27cc9b5cad5ac21f19c3c7d1161a207" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_434aef40e9d26c99c68217c30e094eb1" parent="aspace_d27cc9b5cad5ac21f19c3c7d1161a207" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref393_ium" level="file">
+            <did>
+              <unittitle>Experiments with the first hyphenation algorithm, 1978</unittitle>
+              <container id="aspace_946e431c7a4e9281e8a611dfb4f35a38" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_e0a8ea00a53ab087a012d47d93cba0a6" parent="aspace_946e431c7a4e9281e8a611dfb4f35a38" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref394_rwf" level="file">
+            <did>
+              <unittitle>Hyphenation: TeX versus Webster's Collegiate, 1984</unittitle>
+              <container id="aspace_660cba154de04c02d57e61564f40c06f" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_2be89bdaa88bd603ab7bc859391f72ef" parent="aspace_660cba154de04c02d57e61564f40c06f" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref395_vmt" level="file">
+            <did>
+              <unittitle>TeX, the name</unittitle>
+              <container id="aspace_41ab01f68cafffbd55a4f571e9c01e35" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_06bac2c5f517e5c86cb3dceacc31d048" parent="aspace_41ab01f68cafffbd55a4f571e9c01e35" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref396_mn6" level="file">
+            <did>
+              <unittitle>Commercial software based on TeX</unittitle>
+              <container id="aspace_2f9482828c3279651377aa18527c8acf" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_3800fdde2aa4246a7c6c54fceb859566" parent="aspace_2f9482828c3279651377aa18527c8acf" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref397_o24" level="file">
+            <did>
+              <unittitle>Computers and Typesetting: cover designs</unittitle>
+              <container id="aspace_ae1449f40e8a630baef4b54f5a23242d" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_de428255020b690d3a5b7d4db8e6bd29" parent="aspace_ae1449f40e8a630baef4b54f5a23242d" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref398_wz8" level="file">
+            <did>
+              <unittitle>Redesign of METAFONT logo, summer 1984</unittitle>
+              <container id="aspace_2d9b52637c802ea9ab453a393aef59c6" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_1510c9efdca32e5525dd9b69ee41d088" parent="aspace_2d9b52637c802ea9ab453a393aef59c6" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref399_8mv" level="file">
+            <did>
+              <unittitle>First draft copies of the METAFONTbook, Chapters 1--13</unittitle>
+              <container id="aspace_be3e9d5bde4663867897a442144d70f4" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_4f42d97a4e3b6eb32e2b2001f448633c" parent="aspace_be3e9d5bde4663867897a442144d70f4" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref400_pco" level="file">
+            <did>
+              <unittitle>First draft copies of the METAFONTbook, Chapters 14--D</unittitle>
+              <container id="aspace_78d361dbc3f7cb39722d9a49ce4f8474" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_820550b3c21fc44c230abb9c463d2a4e" parent="aspace_78d361dbc3f7cb39722d9a49ce4f8474" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref401_jlo" level="file">
+            <did>
+              <unittitle>Readers' comments on METAFONTbook first draft</unittitle>
+              <container id="aspace_92e5925a7d624ce245724c4aed46c4c7" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_b6b2125108a555cf86a7f24df8e37f56" parent="aspace_92e5925a7d624ce245724c4aed46c4c7" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref402_wsd" level="file">
+            <did>
+              <unittitle>Penultimate draft of METAFONTbook</unittitle>
+              <container id="aspace_83e8f87ab552d64dfe00bc893bd635cb" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_ffa17c3e10912619957429c592903bef" parent="aspace_83e8f87ab552d64dfe00bc893bd635cb" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref403_d7h" level="file">
+            <did>
+              <unittitle>METAFONTbook: quotations</unittitle>
+              <container id="aspace_1806e4deb895851886afe9eafb00d0bc" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_234f7dfd1fb96d2127b9709450332951" parent="aspace_1806e4deb895851886afe9eafb00d0bc" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref404_ezy" level="file">
+            <did>
+              <unittitle>METAFONTbook: illustrations by Duane Bibby</unittitle>
+              <container id="aspace_61cf809251c1c8cdef4a0866627e4b10" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_1bfe8bdad59d94256d4c328aa616c0ea" parent="aspace_61cf809251c1c8cdef4a0866627e4b10" type="folder">14</container>
+            </did>
+          </c>
+          <c id="aspace_ref405_1yu" level="file">
+            <did>
+              <unittitle>METAFONTbook: illustrations by computer</unittitle>
+              <container id="aspace_787d8f28d6992cc42147eb68dc317806" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_323bcac85f9c9ce6591dd7c051f55085" parent="aspace_787d8f28d6992cc42147eb68dc317806" type="folder">15</container>
+            </did>
+          </c>
+          <c id="aspace_ref406_fic" level="file">
+            <did>
+              <unittitle>METAFONTbook: copy editor's corrections</unittitle>
+              <container id="aspace_fc1186eef6bece3a1d14c6863846eeab" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_9a7ff8186687a1e27bd1a50918d3cf9f" parent="aspace_fc1186eef6bece3a1d14c6863846eeab" type="folder">16</container>
+            </did>
+          </c>
+          <c id="aspace_ref407_hl5" level="file">
+            <did>
+              <unittitle>Proto-METAFONT, 1977</unittitle>
+              <container id="aspace_d6b16894cfee57127c37ff97ffa1787b" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_83ce33b1d90332f03102f004529219df" parent="aspace_d6b16894cfee57127c37ff97ffa1787b" type="folder">17</container>
+            </did>
+          </c>
+          <c id="aspace_ref408_je7" level="file">
+            <did>
+              <unittitle>Initial design of METAFONT, summer 1978</unittitle>
+              <container id="aspace_2aff5ec67d22ff9cdf8ee05b4baf484c" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_8ba584663c6372a736b091cab2fd5829" parent="aspace_2aff5ec67d22ff9cdf8ee05b4baf484c" type="folder">18</container>
+            </did>
+          </c>
+          <c id="aspace_ref409_cxx" level="file">
+            <did>
+              <unittitle>Handwritten code for the first METAFONT</unittitle>
+              <container id="aspace_d34fe352c23ef9ee70bbc41aef7da6be" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_303436ae2abc9aede239273772b622e3" parent="aspace_d34fe352c23ef9ee70bbc41aef7da6be" type="folder">19</container>
+            </did>
+          </c>
+          <c id="aspace_ref410_fa6" level="file">
+            <did>
+              <unittitle>Complete logs for TeX, METAFONT, Computer Modern</unittitle>
+              <container id="aspace_535a35a20888b07e74b4d13f18272c18" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_216e9d063d58c6f289c1565f063814ef" parent="aspace_535a35a20888b07e74b4d13f18272c18" type="folder">20</container>
+            </did>
+          </c>
+          <c id="aspace_ref411_kc9" level="file">
+            <did>
+              <unittitle>Knuth, Donald E., The Errors of TEX</unittitle>
+              <unitdate datechar="creation">1989</unitdate>
+              <container id="aspace_ecabd4114ef21aa21a0d248255fbd378" label="Mixed Materials [aspace.536236.box.19]" type="Box">19</container>
+              <container id="aspace_8d04146e865d700e150b690d247fa898" parent="aspace_ecabd4114ef21aa21a0d248255fbd378" type="folder">21</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref412_4su" level="file">
+          <did>
+            <unittitle>Volume D, METAFONT: The Program</unittitle>
+          </did>
+          <c id="aspace_ref413_m9e" level="file">
+            <did>
+              <unittitle>First draft of METAFONT interpreter, Dec 15 1978</unittitle>
+              <container id="aspace_9bcf83c575c1be226a073aa804ebdad5" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_0d4165b792ba2876519ead72897cd675" parent="aspace_9bcf83c575c1be226a073aa804ebdad5" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref414_esc" level="file">
+            <did>
+              <unittitle>First draft of METAFONT with raster routines, Jan 1 1979</unittitle>
+              <container id="aspace_116f64a29d5986bfbbdfbc712c6bb623" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_bbfc5a59c60e7e889e0570e7e3a2aa71" parent="aspace_116f64a29d5986bfbbdfbc712c6bb623" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref415_dj3" level="file">
+            <did>
+              <unittitle>First draft of testable METAFONT system, Apr 15 1979</unittitle>
+              <container id="aspace_b79bf91b3ad21ebf0d18ab8b103466d6" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_839469068de25004331384bfb9585d51" parent="aspace_b79bf91b3ad21ebf0d18ab8b103466d6" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref416_qnb" level="file">
+            <did>
+              <unittitle>First complete" METAFONT system</unittitle>
+              <container id="aspace_bde193471ace5ed5cbce1338b2c68764" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_a8e40ce1875ddd534dc4d4c207925bd1" parent="aspace_bde193471ace5ed5cbce1338b2c68764" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref417_5lj" level="file">
+            <did>
+              <unittitle>Released" METAFONT</unittitle>
+              <container id="aspace_98ce0ffdaf11c2b7010c0333f13c283d" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_8f54bba210da9ce47adf97452919338d" parent="aspace_98ce0ffdaf11c2b7010c0333f13c283d" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref418_kkb" level="file">
+            <did>
+              <unittitle>Tom Spencer's original algorithms for drawing in linear time</unittitle>
+              <container id="aspace_904646ad2dde129ae5cb7d3363d06fb7" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_4d444561e4fdfb9d5a12339e0cbbc280" parent="aspace_904646ad2dde129ae5cb7d3363d06fb7" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref419_bac" level="file">
+            <did>
+              <unittitle>Interim METAFONT manual, used from spring 1984 to fall 1985</unittitle>
+              <container id="aspace_bbbf1bd51ab89f840aa58e7b6990030d" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_6b813ab857fd42414658df1004338fba" parent="aspace_bbbf1bd51ab89f840aa58e7b6990030d" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref420_8ox" level="file">
+            <did>
+              <unittitle>State of METAFONT code on Mar 11 1984</unittitle>
+              <container id="aspace_ae2d08bd84be89247f1b28840d780d96" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_9bfcffb15f18d57d1ff030b2966c24a8" parent="aspace_ae2d08bd84be89247f1b28840d780d96" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref421_e2w" level="file">
+            <did>
+              <unittitle>The first camplete draft of METAFONT84, Mar 18 1984</unittitle>
+              <container id="aspace_a145c1d298be4b18b6f957b63fa1573e" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_d0f3e24e97038d0dc1f93ea5c89747bc" parent="aspace_a145c1d298be4b18b6f957b63fa1573e" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref422_pb3" level="file">
+            <did>
+              <unittitle>First working draft of METAFONT84</unittitle>
+              <container id="aspace_d5a715bd39f8931d4c576eecb7b53a99" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_9dba48ae3e277fb8485041ed6ee0b7c0" parent="aspace_d5a715bd39f8931d4c576eecb7b53a99" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref423_66q" level="file">
+            <did>
+              <unittitle>First version of METAFONT to pass the TRAP" test</unittitle>
+              <container id="aspace_eee142f1aeba4ec1c03017aa3a6cef69" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_a10b4a2bf7ec8c1977959bc0e5eed1cb" parent="aspace_eee142f1aeba4ec1c03017aa3a6cef69" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref424_q4f" level="file">
+            <did>
+              <unittitle>Version 0.3 of METAFONT, Sep 27 1984</unittitle>
+              <container id="aspace_98df3289b297091d12b3e7dfdb113607" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_4ef23edb3ff38e574c24a881c4b5096a" parent="aspace_98df3289b297091d12b3e7dfdb113607" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref425_ubq" level="file">
+            <did>
+              <unittitle>Version 0.7 of METAFONT, Jan 17 1985</unittitle>
+              <container id="aspace_cb64fc2a64212ada83d64a3293758ce2" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_d725aead6a58f1ca0d208bc1b8b90489" parent="aspace_cb64fc2a64212ada83d64a3293758ce2" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref426_f87" level="file">
+            <did>
+              <unittitle>Version 0.95 of METAFONT, Aug 12 1985</unittitle>
+              <container id="aspace_5b6a818d52bf420d2d845c3f131df626" label="Mixed Materials [aspace.536236.box.20]" type="Box">20</container>
+              <container id="aspace_831507eb124f5d85eef405fa919346c2" parent="aspace_5b6a818d52bf420d2d845c3f131df626" type="folder">14</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref427_7mn" level="file">
+          <did>
+            <unittitle>Volume D, continued; METAFONT milieu</unittitle>
+          </did>
+          <c id="aspace_ref428_vea" level="file">
+            <did>
+              <unittitle>Version 1.0 of METAFONT, Jan 4 1986</unittitle>
+              <container id="aspace_4b0d995ecda7943a90497ae8c84476bd" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_f34f03a1b8f25ada14d44ff9f3953f91" parent="aspace_4b0d995ecda7943a90497ae8c84476bd" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref429_zy0" level="file">
+            <did>
+              <unittitle>Profile (running time estimate) of METAFONT, Oct 1985</unittitle>
+              <container id="aspace_fb6a62744bc6af174bd0dae72f4c5573" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_58c87ebd95821c1a218d838f3c8e04e7" parent="aspace_fb6a62744bc6af174bd0dae72f4c5573" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref430_lkz" level="file">
+            <did>
+              <unittitle>Profile gathering program</unittitle>
+              <container id="aspace_66c64f6bae532f19c575e24cdc01d271" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_724418b24c6c1da1466b512948299fdf" parent="aspace_66c64f6bae532f19c575e24cdc01d271" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref431_c8t" level="file">
+            <did>
+              <unittitle>Typography course, spring 1984, with Bigelow and Southall</unittitle>
+              <container id="aspace_17c26cb4e868de0dc130d32405223466" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_d2bc563880bad2604025aac06dd43687" parent="aspace_17c26cb4e868de0dc130d32405223466" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref432_q4j" level="file">
+            <did>
+              <unittitle>Typography course homework: El Palo Alto and border designs</unittitle>
+              <container id="aspace_202829efaf6d402e8c7d5b9336b3e548" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_f07d636688570d77e4b5feb011821150" parent="aspace_202829efaf6d402e8c7d5b9336b3e548" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref433_9mf" level="file">
+            <did>
+              <unittitle>Typography course homework: Font 1" "</unittitle>
+              <container id="aspace_f45c0cb1f5b5cf19a1f988c4d9e1950a" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_8ba0c3836cc7e40ba1dc9c6f6fb3658d" parent="aspace_f45c0cb1f5b5cf19a1f988c4d9e1950a" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref434_0ao" level="file">
+            <did>
+              <unittitle>Equipment brochures, manuals, and samples</unittitle>
+              <container id="aspace_3847f8df6cdc5ba7d14f31b1cb3342a4" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_13eaf8391f23d4961be20872ecaa9306" parent="aspace_3847f8df6cdc5ba7d14f31b1cb3342a4" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref435_ouk" level="file">
+            <did>
+              <unittitle>Interfacing METAFONT84 to devices</unittitle>
+              <container id="aspace_bf9259947fd56295f2417b98a10972bb" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_8c5a71409be066487e5e2d7397e49565" parent="aspace_bf9259947fd56295f2417b98a10972bb" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref436_vm9" level="file">
+            <did>
+              <unittitle>Use of my own laser printer!</unittitle>
+              <container id="aspace_cda2a66c76511730cdb5d3d39374b2d8" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_bf5dff771044ebdb9d2b87ce035ef47e" parent="aspace_cda2a66c76511730cdb5d3d39374b2d8" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref437_tfp" level="file">
+            <did>
+              <unittitle>other letterform design systems</unittitle>
+              <container id="aspace_5263705af4a6d5dd0b65e81f9c0bc4b8" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_00a87429c0602e3e21b8bae8b352e7fa" parent="aspace_5263705af4a6d5dd0b65e81f9c0bc4b8" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref438_c3g" level="file">
+            <did>
+              <unittitle>Legibility</unittitle>
+              <container id="aspace_25d4911c9399836aa4f4e82767c323ca" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_f13ef1286bd7de986c0c0cebaae1fe85" parent="aspace_25d4911c9399836aa4f4e82767c323ca" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref439_usw" level="file">
+            <did>
+              <unittitle>Correspondence concerning fonts</unittitle>
+              <container id="aspace_b391335e03e0618d6263d22f38cfe7fe" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_82f80579ee9c53939d9610105d7e3ecc" parent="aspace_b391335e03e0618d6263d22f38cfe7fe" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref440_crk" level="file">
+            <did>
+              <unittitle>METAFONT connuentary</unittitle>
+              <container id="aspace_6dd32a3fe40b2e75638cfec985db0998" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_585b872933d308b97ac487a70f971dfa" parent="aspace_6dd32a3fe40b2e75638cfec985db0998" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref441_6t2" level="file">
+            <did>
+              <unittitle>Type specimens</unittitle>
+              <container id="aspace_1b27ba9ba0455febe73017005b791c41" label="Mixed Materials [aspace.536236.box.21]" type="Box">21</container>
+              <container id="aspace_71096327cecb8591094e4bb89d076a09" parent="aspace_1b27ba9ba0455febe73017005b791c41" type="folder">14</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref442_ji2" level="file">
+          <did>
+            <unittitle>Volume E, Computer Modern Typefaces</unittitle>
+          </did>
+          <c id="aspace_ref443_4xk" level="file">
+            <did>
+              <unittitle>What preceded Computer Modern</unittitle>
+              <container id="aspace_c3ab101ebcada32a64905316c27e17d8" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_92905ddeed1827fd4accc5dcaba28568" parent="aspace_c3ab101ebcada32a64905316c27e17d8" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref444_ayb" level="file">
+            <did>
+              <unittitle>Computer Modern, 1977</unittitle>
+              <container id="aspace_dbbcd96b1e922a23adadb9b939aac405" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_0b683bec2c65727fdaf8e8ea831b55d0" parent="aspace_dbbcd96b1e922a23adadb9b939aac405" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref445_8rk" level="file">
+            <did>
+              <unittitle>Computer Modern, 1978</unittitle>
+              <container id="aspace_e13377d8d2e54e744f937bba0770ce61" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_21f79ad2f3030d208016009119d11edc" parent="aspace_e13377d8d2e54e744f937bba0770ce61" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref446_a4o" level="file">
+            <did>
+              <unittitle>Computer Modern, 1979</unittitle>
+              <container id="aspace_15508718daa07e89e9eed07c52cdc1e6" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_e8850fcebbe8f8aa49b6ed4149f94656" parent="aspace_15508718daa07e89e9eed07c52cdc1e6" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref447_7vi" level="file">
+            <did>
+              <unittitle>Computer Modern published as a Stanford report, Jan 1980</unittitle>
+              <container id="aspace_e1803e7794fd17e1bf49abe7a30314ec" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_4e49d14f71fb0d8374651857b74fc727" parent="aspace_e1803e7794fd17e1bf49abe7a30314ec" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref448_4p4" level="file">
+            <did>
+              <unittitle>Computer Modern, 1980</unittitle>
+              <container id="aspace_7b4ccbbca4aa2d51917a390c354b404c" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_a3bcee9ca4784e0e8674e2979d1cd396" parent="aspace_7b4ccbbca4aa2d51917a390c354b404c" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref449_qga" level="file">
+            <did>
+              <unittitle>Computer Modern, 1981</unittitle>
+              <container id="aspace_5b3017ab67be6314a69daae32dee611f" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_068d90d5bc2d60fdd4c91eb8a8e5a8b6" parent="aspace_5b3017ab67be6314a69daae32dee611f" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref450_phc" level="file">
+            <did>
+              <unittitle>Computer Modern, early 1982</unittitle>
+              <container id="aspace_574043fffccbbf1492f73f821bc00d04" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_a9eb27b8ba84eba4268525df61d690fa" parent="aspace_574043fffccbbf1492f73f821bc00d04" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref451_2cd" level="file">
+            <did>
+              <unittitle>Major revision of p~r 1982: lowercase letters</unittitle>
+              <container id="aspace_db384a20539bbdb948ff8309565ed653" label="Mixed Materials [aspace.536236.box.22]" type="Box">22</container>
+              <container id="aspace_2bbec82413e2770dfe7db09fdd0cc76e" parent="aspace_db384a20539bbdb948ff8309565ed653" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref452_b6z" level="file">
+            <did>
+              <unittitle>Major revision of Apr 1982: uppercase letters</unittitle>
+              <container id="aspace_635a555afa4f40cb68d0ea794ade4884" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_369a0c2426f78ec6cf7b049d47b2ceec" parent="aspace_635a555afa4f40cb68d0ea794ade4884" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref453_pqt" level="file">
+            <did>
+              <unittitle>Major revision of Apr 1982: numerals</unittitle>
+              <container id="aspace_5c3bce76f621132cbd40b8dbaa033ef6" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_63ca6597df77a36b7a016d1dbfbbfc73" parent="aspace_5c3bce76f621132cbd40b8dbaa033ef6" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref454_9bi" level="file">
+            <did>
+              <unittitle>Major revision of Apr 1982: punctuation and accents</unittitle>
+              <container id="aspace_e84200cc3fd3d735f079509878383e44" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_f1eb3fe3871a8555fce6a50c3310acab" parent="aspace_e84200cc3fd3d735f079509878383e44" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref455_sb1" level="file">
+            <did>
+              <unittitle>Major revision of Apr 1982: math symbols</unittitle>
+              <container id="aspace_89870a67ca2447f1290173cec405bb25" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_fff9d71392f11395cf87d428783feea7" parent="aspace_89870a67ca2447f1290173cec405bb25" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref456_ie5" level="file">
+            <did>
+              <unittitle>Computer Modern, summer 1982</unittitle>
+              <container id="aspace_e0ed5f95e55d751fffff2cf7abda4be6" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_d5e3f8f80b1dd8167eed55ceec9ca9fd" parent="aspace_e0ed5f95e55d751fffff2cf7abda4be6" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref457_6zz" level="file">
+            <did>
+              <unittitle>Computer Modern, 1983</unittitle>
+              <container id="aspace_6af1e9147e83d743b87c3e7ac6606fd2" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_352e2f71feeb077f83aa741e310fdb0c" parent="aspace_6af1e9147e83d743b87c3e7ac6606fd2" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref458_irn" level="file">
+            <did>
+              <unittitle>Almost Computer Modern Roman</unittitle>
+              <unitdate datechar="creation">1984</unitdate>
+              <container id="aspace_0ecf70d588cf0ca2840789ceaaaa7757" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_b3075ba98fddce4f38d2434a2d995b07" parent="aspace_0ecf70d588cf0ca2840789ceaaaa7757" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref459_zwf" level="file">
+            <did>
+              <unittitle>Almost Computer Modern Italic</unittitle>
+              <unitdate datechar="creation">1984</unitdate>
+              <container id="aspace_0ae45abb8c4f2615026b0b4ea9d83f7c" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_1b164eb52bae989c29788685386ca9a1" parent="aspace_0ae45abb8c4f2615026b0b4ea9d83f7c" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref460_xjy" level="file">
+            <did>
+              <unittitle>Almost Computer Modern Symbols</unittitle>
+              <unitdate datechar="creation">1984</unitdate>
+              <container id="aspace_c607d336df91e037e11b7cd63b82751e" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_3f5a59f4b12635df4a257b52980c19ab" parent="aspace_c607d336df91e037e11b7cd63b82751e" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref461_jb3" level="file">
+            <did>
+              <unittitle>Almost Computer Modern Extensib1es"</unittitle>
+              <unitdate datechar="creation">1984</unitdate>
+              <container id="aspace_7773c9bc7cfe9ccce9a4f945279f6f60" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_f9078772035929f3d69c931a8e86abf5" parent="aspace_7773c9bc7cfe9ccce9a4f945279f6f60" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref462_jiw" level="file">
+            <did>
+              <unittitle>Computer Modern Roman, Jan--Apr 1985</unittitle>
+              <container id="aspace_fb600ab3ed44681502f451de61f524d7" label="Mixed Materials [aspace.536236.box.23]" type="Box">23</container>
+              <container id="aspace_321281e73074d7f35020963503c1057a" parent="aspace_fb600ab3ed44681502f451de61f524d7" type="folder">11</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref463_jgt" level="file">
+          <did>
+            <unittitle>Volume E, continued; font milieu</unittitle>
+          </did>
+          <c id="aspace_ref464_lla" level="file">
+            <did>
+              <unittitle>Computer Modern: final tests, May 1985--Jan 1986</unittitle>
+              <container id="aspace_1d266e913c2dd5dd52b60a29dbe814bf" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_4b8f7f74dfaae7aab5c771e5680afe34" parent="aspace_1d266e913c2dd5dd52b60a29dbe814bf" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref465_nm1" level="file">
+            <did>
+              <unittitle>Christmas card, 1985: Celtic knot font</unittitle>
+              <container id="aspace_bfcbc2458fc856a17726c773285e1b20" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_f301913cf1044cc4e57f57ca471efcd7" parent="aspace_bfcbc2458fc856a17726c773285e1b20" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref466_5lm" level="file">
+            <did>
+              <unittitle>Manuscript copy for Volume E, 1986</unittitle>
+              <container id="aspace_d32bf47da77c1ca636628f4a9bd6248a" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_8f1da185e5d9b7785fadc037184d6a63" parent="aspace_d32bf47da77c1ca636628f4a9bd6248a" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref467_lu1" level="file">
+            <did>
+              <unittitle>Miscellaneous documents about fonts</unittitle>
+              <container id="aspace_5b486c4d421fb73901d6f909e401b56f" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_acfde6f363732103d0f005b329c6c833" parent="aspace_5b486c4d421fb73901d6f909e401b56f" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref468_b2s" level="file">
+            <did>
+              <unittitle>Miscellaneous typographic keepsakes</unittitle>
+              <container id="aspace_6966a38222bd55883b816b45c5cb8302" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_62b6e99f54d3d2fd09f4071bec1300b5" parent="aspace_6966a38222bd55883b816b45c5cb8302" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref469_4cf" level="file">
+            <did>
+              <unittitle>Arabic and Hebrew</unittitle>
+              <container id="aspace_1ad872eb894072abd847ac2b784285f2" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_4e5939006c3a7c88d5b958a5e955b33a" parent="aspace_1ad872eb894072abd847ac2b784285f2" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref470_fe1" level="file">
+            <did>
+              <unittitle>Math Symbols</unittitle>
+              <container id="aspace_da4361a58c7e74d3c8fe06bf64454199" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_28d9de2dab40fad8f802c461d46bd26b" parent="aspace_da4361a58c7e74d3c8fe06bf64454199" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref471_dem" level="file">
+            <did>
+              <unittitle>Chinese and Japanese</unittitle>
+              <container id="aspace_97243181d0345a3b026db3107431f1fc" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_3e67f4aa6a9f026d34c40a36f47f7427" parent="aspace_97243181d0345a3b026db3107431f1fc" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref472_dsy" level="file">
+            <did>
+              <unittitle>Indian</unittitle>
+              <container id="aspace_8a9ddcf2d99a86707907481192a80a43" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_d58ec22f5e2f7881149e22fcfb5d5ad0" parent="aspace_8a9ddcf2d99a86707907481192a80a43" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref473_ckm" level="file">
+            <did>
+              <unittitle>Cyrillic</unittitle>
+              <container id="aspace_4dcd3623cd7ed764776352eb3d497afd" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_96c89848b970049ee6c99cfd67c55274" parent="aspace_4dcd3623cd7ed764776352eb3d497afd" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref474_wcl" level="file">
+            <did>
+              <unittitle>Work of Nazneen N. Bi11awa1a</unittitle>
+              <container id="aspace_f55ce880d0df817926400b902b36e7e7" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_c2e6f0b0980e4920639484fd07c981f0" parent="aspace_f55ce880d0df817926400b902b36e7e7" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref475_y8j" level="file">
+            <did>
+              <unittitle>Work of Charles A. Bigelow</unittitle>
+              <container id="aspace_008a64643f155d80e222f1bd8d4745a3" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_58f4f169e313f95e4b6ed3889f96628c" parent="aspace_008a64643f155d80e222f1bd8d4745a3" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref476_f9x" level="file">
+            <did>
+              <unittitle>Work of Georgia Tobin</unittitle>
+              <container id="aspace_396245204b56f459b626f90db76db820" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_48dd2ae6146a9b77d84b96380584f963" parent="aspace_396245204b56f459b626f90db76db820" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref477_wnt" level="file">
+            <did>
+              <unittitle>Work of Rudiger Pfeiffer-Rupp</unittitle>
+              <container id="aspace_946c13926712bdf4d5a7087972033f15" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_02625fde17596f0cd1a0f9c7653cc0a0" parent="aspace_946c13926712bdf4d5a7087972033f15" type="folder">14</container>
+            </did>
+          </c>
+          <c id="aspace_ref478_dxk" level="file">
+            <did>
+              <unittitle>Work of Philippe Coueignoux</unittitle>
+              <container id="aspace_71a25a5474f27bfbfde3103150fe9176" label="Mixed Materials [aspace.536236.box.24]" type="Box">24</container>
+              <container id="aspace_a6d657acb0d7c4456bb3afb313e3d3f7" parent="aspace_71a25a5474f27bfbfde3103150fe9176" type="folder">15</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref479_9ll" level="file">
+          <did>
+            <unittitle>Miscellaneous additions</unittitle>
+          </did>
+          <c id="aspace_ref480_z1t" level="file">
+            <did>
+              <unittitle>The METAFONTbook: original manuscript</unittitle>
+              <container id="aspace_35d583bfbf910fbd94f092221bc8480a" label="Mixed Materials [aspace.536236.box.25]" type="Box">25</container>
+              <container id="aspace_b14a94c96779d0286f15180527758f56" parent="aspace_35d583bfbf910fbd94f092221bc8480a" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref481_0bb" level="file">
+            <did>
+              <unittitle>METAFONT: The Program: original manuscript</unittitle>
+              <container id="aspace_aa238a613c4d7805f2eac9423bff36ee" label="Mixed Materials [aspace.536236.box.25]" type="Box">25</container>
+              <container id="aspace_e1e628eef3ec54eeb650511c8faf9689" parent="aspace_aa238a613c4d7805f2eac9423bff36ee" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref482_qq2" level="file">
+            <did>
+              <unittitle>Computer Modern in I new METAFONT I: original manuscript, spring</unittitle>
+              <unitdate datechar="creation">1985</unitdate>
+              <container id="aspace_4403892a7419dabe502c4104b75cc539" label="Mixed Materials [aspace.536236.box.25]" type="Box">25</container>
+              <container id="aspace_3940e92785369a8fd15ba19aa89200b1" parent="aspace_4403892a7419dabe502c4104b75cc539" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref483_4y0" level="file">
+            <did>
+              <unittitle>Drafts of original TeX implementation</unittitle>
+              <container id="aspace_8e6baecbc08aa34c9eece082c1e84c65" label="Mixed Materials [aspace.536236.box.25]" type="Box">25</container>
+              <container id="aspace_8d8c4f3d2a9a02d526305cd62faec071" parent="aspace_8e6baecbc08aa34c9eece082c1e84c65" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref484_f7y" level="file">
+            <did>
+              <unittitle>The original memo that led to TeX: handwritten draft, May 1977</unittitle>
+              <container id="aspace_4a1fe140601860f35a0232df464cd52e" label="Mixed Materials [aspace.536236.box.25]" type="Box">25</container>
+              <container id="aspace_c1d96d0bd767ef1d2c23dc971dcab1b7" parent="aspace_4a1fe140601860f35a0232df464cd52e" type="folder">5</container>
+            </did>
+          </c>
+        </c>
+      </c>
+      <c id="aspace_ref485_4kj" level="series">
+        <did>
+          <unittitle>
+            <title render="italic">Concrete Mathematics</title>
+          </unittitle>
+          <unitid>Series 3</unitid>
+          <langmaterial><language langcode="eng">English</language>.</langmaterial>
+        </did>
+        <scopecontent id="aspace_1ad69be895039374d1a0d6fa4e03ac6f">
+          <head>Scope and Contents note</head>
+          <p>Archives from the development of Concrete Mathematics, a textbook by Ronald L. Graham, Donald E. Knuth and Oren Patashnik. 'This book, published in the surmner of 1988, is based on a Stanford course of the same name that I introduced in 1970 (and it has been taught ever since). It represents sort of a "manifesto" of the way I like to do mathematics, especially the mathematics associated with computer prograrrnning. After nearly twenty years teaching the course, I knew that it was time to put this textbook together and export the ideas to other universities. My goal was to produce the best exposition of mathematical manipulations since, say, cauchy's famous Cours de Mathematigue of the 1820's and 1830's. Ron Graham was a visiting professor who taught the Stanford course twice during my sabbatical leaves, both times with great success. Oren Patashnik was a graduate student in Computer Science who served as teaching assistant in the class several times, under both Graham and me.</p>
+          <p>Drafts, proofs, and correspondence pertaining to the textbook by Ronald L. Graham, Donald E. Knuth and Oren Patashnik, which was based on a Stanford course taught by Knuth.</p>
+        </scopecontent>
+        <c id="aspace_ref487_b44" level="file">
+          <did>
+            <unittitle>Original Drafts</unittitle>
+          </did>
+          <scopecontent id="aspace_8406f4f2e8bf32af078ac61e44478879">
+            <head>Scope and Contents note</head>
+            <p>Patashnik created a draft of the entire book, which was used by Stanford students for two or three years. During the last half of 1987 and the first half of 1988, I rewrote this draft and the result was used as a trial text at Stanford, Princeton, Brown, Columbia, Rice and CUNY. My handwritten manuscripts appear here, together with marked-up copies of Oren's draft, together with high-level notes I made to Graham letting him know the thrust of what I was doing so that he could provide maximum input. Correspondence and preprints of unpublished papers I consul ted during this time are also included.</p>
+            <p>This part of the archive consists of ten legal-size folders. <list><item>1.0 Preface, Graffiti and permissions (see below)</item><item>1.1 Chapter One, Recurrent Problems</item><item>1.2 Chapter Two, Sums</item><item>1.3 Chapter Three, Integer Functions</item><item>1.4 Chapter Four, Number Theory</item><item>1.5 Chapter Five, Binomial Coefficients</item><item>1.6 Chapter Six, Special Numbers</item><item>1.7 Chapter Seven, Generating Functions</item><item>1.8 Chapter Eight, Discrete Probability</item><item>1.9 Chapter Nine, Asymptotics</item></list> </p>
+            <p> Each folder has comments written on the outside that were notes to myself about what sources to read as I was writing the material. 'Ihese references are keyed to sixteen years worth of classnotes from the Stanford course; those classnotes are not part of the archive but they do exist in Stanford's Mathematical Sciences Library.</p>
+            <p>Our book introduces a novel feature called "graffiti," borrowed from the non-mathematical brochure called Approaching Stanford. We asked stUdents to contribute their own cormnents so that we could print them in the margins of our book. These student contributions are included in folder I.O.</p>
+          </scopecontent>
+          <c id="aspace_ref489_7em" level="file">
+            <did>
+              <unittitle>Preface, Graffiti, Permission</unittitle>
+              <container id="aspace_30939f9ce8946c71ec6e6e74daae0db1" label="Mixed Materials [aspace.536419.box.26]" type="Box">26</container>
+              <container id="aspace_7697056e9bb258af836b755468713ce1" parent="aspace_30939f9ce8946c71ec6e6e74daae0db1" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref490_kei" level="file">
+            <did>
+              <unittitle>Chapter One: Recurrent Problems</unittitle>
+              <container id="aspace_5e52509672f96e0dcb1a5f806027ae78" label="Mixed Materials [aspace.536419.box.26]" type="Box">26</container>
+              <container id="aspace_0c920233a51df80f05c2205498c4fe72" parent="aspace_5e52509672f96e0dcb1a5f806027ae78" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref491_zq0" level="file">
+            <did>
+              <unittitle>Chapter 'Two: Sums</unittitle>
+              <container id="aspace_83b7eb713f14eb9db6e648e604b78670" label="Mixed Materials [aspace.536419.box.26]" type="Box">26</container>
+              <container id="aspace_28d04688ab0de7219f94ae35bd9c3bab" parent="aspace_83b7eb713f14eb9db6e648e604b78670" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref492_o23" level="file">
+            <did>
+              <unittitle>Chapter 'Three: Integer Functions</unittitle>
+              <container id="aspace_1c0e4b13c094db10a7c068233b4e57ca" label="Mixed Materials [aspace.536419.box.26]" type="Box">26</container>
+              <container id="aspace_e84058d6833f7a7b7b37fb13d1a19334" parent="aspace_1c0e4b13c094db10a7c068233b4e57ca" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref493_66w" level="file">
+            <did>
+              <unittitle>Chapter Four: Number Theory</unittitle>
+              <container id="aspace_690b3b67daeca72e3b26119d0ff68da6" label="Mixed Materials [aspace.536419.box.26]" type="Box">26</container>
+              <container id="aspace_e50c9194937a5df16fd0db5c7eeae054" parent="aspace_690b3b67daeca72e3b26119d0ff68da6" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref494_ciu" level="file">
+            <did>
+              <unittitle>Chapter Five: Binomial Coefficients</unittitle>
+              <container id="aspace_0352366b81fe9adc5a96d4fe37cb7a60" label="Mixed Materials [aspace.536419.box.26]" type="Box">26</container>
+              <container id="aspace_847eee68390aa361115ddf99b0acc857" parent="aspace_0352366b81fe9adc5a96d4fe37cb7a60" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref495_vm3" level="file">
+            <did>
+              <unittitle>Chapter Six: Special Numbers</unittitle>
+              <container id="aspace_52cca30dff497551d7282cf10ef41f1e" label="Mixed Materials [aspace.536419.box.27]" type="Box">27</container>
+              <container id="aspace_798c5190f5057bc423f6b039eaa74746" parent="aspace_52cca30dff497551d7282cf10ef41f1e" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref496_p8i" level="file">
+            <did>
+              <unittitle>Chapter Seven: Generating Function</unittitle>
+              <container id="aspace_349c534787d8ca0d746cd5bd7134eea7" label="Mixed Materials [aspace.536419.box.27]" type="Box">27</container>
+              <container id="aspace_e972dd900be597baa495f8cd2dcb625e" parent="aspace_349c534787d8ca0d746cd5bd7134eea7" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref497_502" level="file">
+            <did>
+              <unittitle>Chapter Eight: Discrete Probability</unittitle>
+              <container id="aspace_c0818cf3efb2c5276d0b43e1d60f1054" label="Mixed Materials [aspace.536419.box.27]" type="Box">27</container>
+              <container id="aspace_afb65bf072ca1ec5b167202c6dc53290" parent="aspace_c0818cf3efb2c5276d0b43e1d60f1054" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref498_2ob" level="file">
+            <did>
+              <unittitle>Chapter Nine: Asymptotics</unittitle>
+              <container id="aspace_975a1b1b2cf06074572130eaa2eccf97" label="Mixed Materials [aspace.536419.box.27]" type="Box">27</container>
+              <container id="aspace_d5b93cf9a5ac0f2cd5dccdf280083084" parent="aspace_975a1b1b2cf06074572130eaa2eccf97" type="folder">4</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref499_c1v" level="file">
+          <did>
+            <unittitle>Correspondence with the publisher</unittitle>
+          </did>
+          <scopecontent id="aspace_0377c77406d64a493f23689ca3c8dccd">
+            <head>Scope and Contents note</head>
+            <p>Here are relevant letters from the production editor and book designer. These are of some interest because we wrote this book at a time when the process of book production is changing dramatically. Instead of sending a manuscript to the publisher and letting them carry the ball, this book was typeset by its authors. Still, we did not want to lose the professional services of a book designer, so we received advice on suitable format before we did the typesetting.</p>
+            <p>Our book is interesting from another standpoint because it is the first book to be published with a new family of typefaces designed by Hermann Zapf, especially for mathematics, called AMS Euler. Part of my work on this book, was devoted to fine tuning of these fonts, so that they can be used in other mathematical publications. With the book designers help I was able to create a compatible text face (called Concrete Roman and Italic) to complement Zapf's mathematical characters.</p>
+          </scopecontent>
+          <c id="aspace_ref501_lfv" level="file">
+            <did>
+              <unittitle>Correspondence with Addison-Wesley</unittitle>
+              <container id="aspace_5a2689ab6d7dc5b792779372f65a91b7" label="Mixed Materials [aspace.536419.box.27]" type="Box">27</container>
+              <container id="aspace_d063e0fe4e4f331a27c20ceffdca8fb6" parent="aspace_5a2689ab6d7dc5b792779372f65a91b7" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref502_c0q" level="file">
+            <did>
+              <unittitle>Duplicate and erroneous pages from manuscript</unittitle>
+              <container id="aspace_82975c66b7a9b584fcee1da4f4e39bc7" label="Mixed Materials [aspace.536419.box.27]" type="Box">27</container>
+              <container id="aspace_bda14487522d9d0f72a5d76f949c58ac" parent="aspace_82975c66b7a9b584fcee1da4f4e39bc7" type="folder">6</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref503_afu" level="file">
+          <did>
+            <unittitle>First Early Draft</unittitle>
+          </did>
+          <scopecontent id="aspace_21300d288e9d43e2997a2dbd76df3b24">
+            <head>Scope and Contents note</head>
+            <p>Here are the pages used by students at Stanford, Princeton, 1987-1988, etc., together with corrections I noted in response to their feedback.</p>
+          </scopecontent>
+          <c id="aspace_ref505_r2s" level="file">
+            <did>
+              <unittitle>Preface, Chapters One, Two and Three</unittitle>
+              <container id="aspace_38a842d2a5f3ba6612b23028722c153a" label="Mixed Materials [aspace.536419.box.28]" type="Box">28</container>
+              <container id="aspace_193f91633038624cd3c936efd12f1fd9" parent="aspace_38a842d2a5f3ba6612b23028722c153a" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref506_qfj" level="file">
+            <did>
+              <unittitle>Chapters Four and Five</unittitle>
+              <container id="aspace_6eca5a3c5f0408b92ca3e143d8504300" label="Mixed Materials [aspace.536419.box.28]" type="Box">28</container>
+              <container id="aspace_0c24fed3c208d78dd29e21615c22d741" parent="aspace_6eca5a3c5f0408b92ca3e143d8504300" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref507_uld" level="file">
+            <did>
+              <unittitle>Chapters six and Seven</unittitle>
+              <container id="aspace_fd1589d7664408c25c6f678e24a6f4cb" label="Mixed Materials [aspace.536419.box.28]" type="Box">28</container>
+              <container id="aspace_792faec467a5f9dcae7dda99b4ccfed3" parent="aspace_fd1589d7664408c25c6f678e24a6f4cb" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref508_wm4" level="file">
+            <did>
+              <unittitle>Chapters Eight, Nine and Exercises</unittitle>
+              <container id="aspace_9542b33237d8e551b0dd042c9c534386" label="Mixed Materials [aspace.536419.box.28]" type="Box">28</container>
+              <container id="aspace_3a53bf4921e75d6822e67c6ff3136cbf" parent="aspace_9542b33237d8e551b0dd042c9c534386" type="folder">4</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref509_ns9" level="file">
+          <did>
+            <unittitle>Ron Graham's Remarks</unittitle>
+          </did>
+          <scopecontent id="aspace_04a9a704ae1bca89ab00cb0946916757">
+            <head>Scope and Contents note</head>
+            <p>Ron took the responsibility for preparing the index; he marked up a copy of (III) with index terms and made other comments.</p>
+          </scopecontent>
+          <c id="aspace_ref511_ayx" level="file">
+            <did>
+              <unittitle>Preface, Chapters One, Two, Three and Four</unittitle>
+              <container id="aspace_747ad46e2a7f3574bc3c35987efab2fb" label="Mixed Materials [aspace.536419.box.28]" type="Box">28</container>
+              <container id="aspace_4912c82209d248873430a3253a9f1e6c" parent="aspace_747ad46e2a7f3574bc3c35987efab2fb" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref512_94u" level="file">
+            <did>
+              <unittitle>Chapters Five and six</unittitle>
+              <container id="aspace_50c3c468e27262c3955cfd9f0a3751e2" label="Mixed Materials [aspace.536419.box.28]" type="Box">28</container>
+              <container id="aspace_453d293f9126751fcd62d571a05c134b" parent="aspace_50c3c468e27262c3955cfd9f0a3751e2" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref513_in5" level="file">
+            <did>
+              <unittitle>Chapters Seven, Eight, Nine and Exercises</unittitle>
+              <container id="aspace_9ef4d1d03bc8da0e726fb1b0f0ce1ca8" label="Mixed Materials [aspace.536419.box.29]" type="Box">29</container>
+              <container id="aspace_6745b1c21dbe4acb25a6df0cb1180d5b" parent="aspace_9ef4d1d03bc8da0e726fb1b0f0ce1ca8" type="folder">1</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref514_f2n" level="file">
+          <did>
+            <unittitle>Copy editor's Remarks</unittitle>
+          </did>
+          <scopecontent id="aspace_263793a1a21918dd37699565545d0a87">
+            <head>Scope and Contents note</head>
+            <p>Another aspect of typesetting-by-author is shown here. We wanted the help of a professional copy editor as well as a book designer. In this case the copy editor could mark freely anything that needed to be double-checked, knowing that we would ignore all advice that we didn't like. The result, we think, is much better than in previous methods under which the copy editor would have supreme authority but would then be limited to making changes that would not upset the authors when page proofs appeared. This part of the archive also includes some correspondence I had with the copy editor.</p>
+          </scopecontent>
+          <c id="aspace_ref516_9q3" level="file">
+            <did>
+              <unittitle>Correspondence, Style-sheet, Preface, Chapters One and Two</unittitle>
+              <container id="aspace_7e37862a99cab79f70d3a365fb5ecb74" label="Mixed Materials [aspace.536419.box.29]" type="Box">29</container>
+              <container id="aspace_d9bd0b1f1801bb52ef955c18253823bc" parent="aspace_7e37862a99cab79f70d3a365fb5ecb74" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref517_py7" level="file">
+            <did>
+              <unittitle>Correspondence, Chapters Three and Four</unittitle>
+              <container id="aspace_c79c198ceb551a031dc5f186aed53d09" label="Mixed Materials [aspace.536419.box.29]" type="Box">29</container>
+              <container id="aspace_c10cd9731ae98882c4509bfe7e303e33" parent="aspace_c79c198ceb551a031dc5f186aed53d09" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref518_uld" level="file">
+            <did>
+              <unittitle>Chapters Five and six</unittitle>
+              <container id="aspace_895d5c86f5fce61d1a61038e56d5076a" label="Mixed Materials [aspace.536419.box.29]" type="Box">29</container>
+              <container id="aspace_c6ac5ab36b01b16caf65af3eeb827a07" parent="aspace_895d5c86f5fce61d1a61038e56d5076a" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref519_88m" level="file">
+            <did>
+              <unittitle>Chapters Seven and Eight</unittitle>
+              <container id="aspace_6b9d95a6278ee9f9215698f08e87956f" label="Mixed Materials [aspace.536419.box.29]" type="Box">29</container>
+              <container id="aspace_cc061bf7c9d35206c04156a80d1dafed" parent="aspace_6b9d95a6278ee9f9215698f08e87956f" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref520_3bx" level="file">
+            <did>
+              <unittitle>Chapter Nine</unittitle>
+              <container id="aspace_c4f2373ef06ab3afbc85d5d5a4a49b15" label="Mixed Materials [aspace.536419.box.29]" type="Box">29</container>
+              <container id="aspace_32d3a389d5f27abfc178c48165ac2ad5" parent="aspace_c4f2373ef06ab3afbc85d5d5a4a49b15" type="folder">6</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref521_bom" level="file">
+          <did>
+            <unittitle>Semi-final proofs</unittitle>
+          </did>
+          <scopecontent id="aspace_ed3190db0c2e38bd2d4110aefa2d4ab6">
+            <head>Scope and Contents note</head>
+            <p>The corrections to (III) based on (IV), (V) and other feedback are shown here in a special format that shows the first raw index we constructed. Final changes and graffiti are written on these laserprinted proofs.</p>
+          </scopecontent>
+          <c id="aspace_ref523_l6p" level="file">
+            <did>
+              <unittitle>Preface, Chapters One and Two</unittitle>
+              <container id="aspace_697833a21af41ce2b48c6af4b25273a8" label="Mixed Materials [aspace.536419.box.30]" type="Box">30</container>
+              <container id="aspace_9bdae6ab1a2ab47468a21e3cc3f7f489" parent="aspace_697833a21af41ce2b48c6af4b25273a8" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref524_g37" level="file">
+            <did>
+              <unittitle>Chapters Three and Four</unittitle>
+              <container id="aspace_24f6e79d664c0addfe44fb92285824d7" label="Mixed Materials [aspace.536419.box.30]" type="Box">30</container>
+              <container id="aspace_618f6f8937d754759c6a80ec207c56d5" parent="aspace_24f6e79d664c0addfe44fb92285824d7" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref525_ync" level="file">
+            <did>
+              <unittitle>Chapters Five and six</unittitle>
+              <container id="aspace_35ab5fc012274a6dd08ae63e679cc166" label="Mixed Materials [aspace.536419.box.30]" type="Box">30</container>
+              <container id="aspace_efeb19f033d2c755f5ad8661728a6866" parent="aspace_35ab5fc012274a6dd08ae63e679cc166" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref526_5bx" level="file">
+            <did>
+              <unittitle>Chapters Seven, Eight and Nine</unittitle>
+              <container id="aspace_8c883ab387db00965e2fa5dda1a16648" label="Mixed Materials [aspace.536419.box.30]" type="Box">30</container>
+              <container id="aspace_50d22bdfb51bc5ee84d194a689ab7a4d" parent="aspace_8c883ab387db00965e2fa5dda1a16648" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref527_icw" level="file">
+            <did>
+              <unittitle>Appendices A: Exercises, B: Bibliography, C: Credits</unittitle>
+              <container id="aspace_ddb5235bd343bd891118a9ab493854ba" label="Mixed Materials [aspace.536419.box.30]" type="Box">30</container>
+              <container id="aspace_f3c1b301942525a38d9154221f33b1ef" parent="aspace_ddb5235bd343bd891118a9ab493854ba" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref528_gqr" level="file">
+            <did>
+              <unittitle>Index</unittitle>
+              <container id="aspace_0aea976bb6d578e277a55326e7de9f45" label="Mixed Materials [aspace.536419.box.30]" type="Box">30</container>
+              <container id="aspace_42615c085c341ecc86c719499ab69f50" parent="aspace_0aea976bb6d578e277a55326e7de9f45" type="folder">6</container>
+            </did>
+          </c>
+        </c>
+      </c>
+      <c id="aspace_ref1215_1kr" level="series">
+        <did>
+          <unittitle>Addenda, 1989-278</unittitle>
+          <unitid>Accession ARCH-1989-278</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <c id="aspace_18c8f0984e812eea1f693b8a2b5c8420" level="file">
+          <did>
+            <unittitle>Galleys and proofs for The Art of Programming</unittitle>
+            <container id="aspace_9c25df5d810079ab7a128b2db2ad4c01" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_307ef75aabac09a0ea2f36e524471726" level="file">
+          <did>
+            <unittitle>Galleys and proofs for The Art of Programming</unittitle>
+            <container id="aspace_d8fccaf0dcc8c21adb615799198a2d24" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_b993136b07325763408d021006959e52" level="file">
+          <did>
+            <unittitle>Galleys and proofs for The Art of Programming</unittitle>
+            <container id="aspace_2bcf6709dfc003b29e230da4ae05014b" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_5ad286c50ec4b43bdd7c729efbf87190" level="file">
+          <did>
+            <unittitle>Galleys and proofs for The Art of Programming</unittitle>
+            <container id="aspace_1e062a798f2bc74df69fb9a78c3b5d2d" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_ref826_4bz" level="series">
+        <did>
+          <unittitle>Addenda, 1996-147</unittitle>
+          <unitid>Accession ARCH-1996-147</unitid>
+        </did>
+        <scopecontent id="aspace_9df1f87aaf6b3ed50fc9d1e0999aa96e">
+          <head>Scope and Contents note</head>
+          <p>Addendum to the archives of the TeX-METAFONT project drafts, proofs, articles, notes, and other records pertaining to the project, as well as keepsakes and published materials using TeX and/or METAFONT.</p>
+        </scopecontent>
+        <c id="aspace_ref828_7f1" level="file">
+          <did>
+            <unittitle>Galley proofs the second edition of <title render="italic">The Art of Computer Programming</title>, Volume 1, 1973</unittitle>
+            <container id="aspace_65e037ab4c1a5a5e33a9774941005de8" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_d9271f600149e65e6492b5c9ff23ddf3" parent="aspace_65e037ab4c1a5a5e33a9774941005de8" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref829_7lw" level="file">
+          <did>
+            <unittitle>Samples of repro copy used to make Volume 1 with Monotype by Wolf Composition</unittitle>
+            <container id="aspace_17025308f41fdde64df7e5066a4a9345" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_efc1eb82fec55a96d7f450257519778c" parent="aspace_17025308f41fdde64df7e5066a4a9345" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref830_f85" level="file">
+          <did>
+            <unittitle>Samples of repro copy used to make Surreal Numbers with Monotype by Clowes</unittitle>
+            <container id="aspace_7638c7699d7b8de55931f7f517cd1977" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_34a54417ca65acca4e31c084c6d8e82e" parent="aspace_7638c7699d7b8de55931f7f517cd1977" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref831_ltk" level="file">
+          <did>
+            <unittitle>Samples of repro copy used to make volume 2, second edition, with TeX and METAFONT - Knuth's first production output with the Alphatype</unittitle>
+            <container id="aspace_06a679c913c1937390eb321eceb407f9" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_681dca7ecb21e537f09eca01ca3e9c5a" parent="aspace_06a679c913c1937390eb321eceb407f9" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref832_u49" level="file">
+          <did>
+            <unittitle>The WEB system, preliminary pre-release version, November 1981 (one of the first documents of what has become known as Literate Programming)</unittitle>
+            <container id="aspace_ab2b9571b2f7764c1143fa3674e9ea0e" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_9600dc89b4945bd7ca802973d71832b3" parent="aspace_ab2b9571b2f7764c1143fa3674e9ea0e" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref833_quu" level="file">
+          <did>
+            <unittitle>The GFtoDVI processor: Version 0, April 1984</unittitle>
+            <container id="aspace_d1f4b0b4c0b115c48632fa457f5f5907" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_cb31a65629bbb4cbd88df41880b36665" parent="aspace_d1f4b0b4c0b115c48632fa457f5f5907" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref834_a7n" level="file">
+          <did>
+            <unittitle>The GFtoDVI processor: Version 1.6, September 1985</unittitle>
+            <container id="aspace_10ff9b06e3fe77a35e422371b98aebbc" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_e89c0d8fba23a768819cbd813139204f" parent="aspace_10ff9b06e3fe77a35e422371b98aebbc" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref835_q98" level="file">
+          <did>
+            <unittitle>Complete listing of TeX with frequency counts of actual usage, 22 October 1986</unittitle>
+            <container id="aspace_e2c9962a40f592b9806e7012a3a51359" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_c07c0e4080527c348748746f1cb86200" parent="aspace_e2c9962a40f592b9806e7012a3a51359" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref836_dcy" level="file">
+          <did>
+            <unittitle>Keepsakes from the early days of TeX:</unittitle>
+            <container id="aspace_8763a2d8cf5b72f70f3befeeb58a77d9" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_6720ab58320ca2ed8a71fdc7dc15d697" parent="aspace_8763a2d8cf5b72f70f3befeeb58a77d9" type="folder">9</container>
+          </did>
+          <scopecontent id="aspace_e9bb45d7e6c451627e7a88d186a1b77b">
+            <head>Scope and Contents note</head>
+            <p>System uptime report for the SAIL computer on which Knuth worked The first proofs of proto-Computer Modern type, July 1977; Cover art for the first TeX user manual. American Math Society, 1978; Cover design by Scott Kim for Stanford Computer Forum, using an early draft of the AMS Euler lowercase, Fall 1981; Handouts for TeX mini-courses, Spring 1981; Photo of California vanity plate "DON TEX", n.d.; Formal invitation to TeX's "coming of age" party, December 9, 1983</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref838_wfl" level="file">
+          <did>
+            <unittitle>Notes made by Knuth while preparing revision of METAFONT, December 21, 1982 - January 18, 1984</unittitle>
+            <container id="aspace_562c955d3d9ccadbd91e5ae5c4aa166c" label="Mixed Materials [aspace.536457.box.1]" type="Box">1</container>
+            <container id="aspace_ec63b28fa7fd3afac5120dd6b2298015" parent="aspace_562c955d3d9ccadbd91e5ae5c4aa166c" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref839_dl8" level="file">
+          <did>
+            <unittitle>Technical notes related to the inner workings of TeX and METAFONT:</unittitle>
+            <container id="aspace_d3fa3d996f9ed996a404ab52c9517588" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_590bc8dbfeaf8a3e94ef0df0dfda29bd" parent="aspace_d3fa3d996f9ed996a404ab52c9517588" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref840_cj4" level="file">
+          <did>
+            <unittitle>Computer-aided footwear design by J.R. Manning, December 1972</unittitle>
+            <container id="aspace_a91add3a87e78644a068678d06087115" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_e8de1ea03c2e230759d8be9a907860ea" parent="aspace_a91add3a87e78644a068678d06087115" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref841_skn" level="file">
+          <did>
+            <unittitle>SCRIBE: A document specification language by Brian Reid, October 1980</unittitle>
+            <container id="aspace_0ba7db06a263608b67205af3efb786dd" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_2227483ccb3619fd875358cb1e7b99f3" parent="aspace_0ba7db06a263608b67205af3efb786dd" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref842_ih6" level="file">
+          <did>
+            <unittitle>Geometric construction of Bernstein poly curves by G.M. Chaikin, Fall 1980</unittitle>
+            <container id="aspace_cc8a4dcd453371f5fe1b6ae65b67d7bc" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_0608633524ac283e053dd918c57c5fe6" parent="aspace_cc8a4dcd453371f5fe1b6ae65b67d7bc" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref843_tac" level="file">
+          <did>
+            <unittitle>Choosing spline directions at knots by John Hobby, Spring 1983</unittitle>
+            <container id="aspace_0278d0a03a863f0f21308f9a172c5d4a" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_6b0252678ae03596d4e99c3973a7af3c" parent="aspace_0278d0a03a863f0f21308f9a172c5d4a" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref844_yig" level="file">
+          <did>
+            <unittitle>Choosing velocity parameters for cubic splines by John Hobby, Spring 1983</unittitle>
+            <container id="aspace_83934e2d1ae50a5c2f29633f22bdb3cb" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_a9516fdb3d60e7eb4cced25df25eb7b9" parent="aspace_83934e2d1ae50a5c2f29633f22bdb3cb" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref845_slz" level="file">
+          <did>
+            <unittitle>Correcting outlines for pen width by John Hobby March 1983</unittitle>
+            <container id="aspace_13475cd5fc84285bc76f0777804747c3" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_c7349b8211b65af5f1568142989cdc76" parent="aspace_13475cd5fc84285bc76f0777804747c3" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref846_3wk" level="file">
+          <did>
+            <unittitle>A Chinese mete-font by John Hobby and Gu Guoan, ICTP83 proceedings, October 1983</unittitle>
+            <container id="aspace_4a5100eec6f48ea774332094fe0c0af0" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_a2e429ffbef2d4813f106a57e56d34b8" parent="aspace_4a5100eec6f48ea774332094fe0c0af0" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref847_w4a" level="file">
+          <did>
+            <unittitle>Ideas for the new METAFONT by John Hobby, Fall 1983</unittitle>
+            <container id="aspace_ae2933bd9d793f696d92c769e04ecd47" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_e11f835df74fdb8b71dbcfce7464a1cd" parent="aspace_ae2933bd9d793f696d92c769e04ecd47" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref848_y6t" level="file">
+          <did>
+            <unittitle>METAFONT programming style by Per Bothner, December 12, 1983</unittitle>
+            <container id="aspace_5418b09305d0de7b4380b9e0e97c1ce1" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_25d62bcfad44b6bea8db0cb58753333d" parent="aspace_5418b09305d0de7b4380b9e0e97c1ce1" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref849_k99" level="file">
+          <did>
+            <unittitle>The 6-register method for plotting cubic spines by John Hobby, December 14, 1983</unittitle>
+            <container id="aspace_9dc5ea89d3f83655520e1df0a6915bc0" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_8effe4950f99d39dd98536cfb23ddecb" parent="aspace_9dc5ea89d3f83655520e1df0a6915bc0" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref850_9on" level="file">
+          <did>
+            <unittitle>Tension and mock curvature by John Hobby, December 15, 1983</unittitle>
+            <container id="aspace_9f6ba5af597e344fc51105cd1c44c4ad" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_872fd7d617060146770f4639a46bf2fc" parent="aspace_9f6ba5af597e344fc51105cd1c44c4ad" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref851_05t" level="file">
+          <did>
+            <unittitle>Adjustment to the raster by John Hobby, December 15, 1983</unittitle>
+            <container id="aspace_0fe1bc2dc441297abf6fffc54287a9f5" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_9289e07dcf74dc5b98af38960f4b4425" parent="aspace_0fe1bc2dc441297abf6fffc54287a9f5" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref852_far" level="file">
+          <did>
+            <unittitle>Joints between Bezier curves by Lyle Ramshaw, December 15, 1983</unittitle>
+            <container id="aspace_2dd6ab551ae913c6501baeba32df9dab" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_57cb347b786dc868bd71c1b8649a50b6" parent="aspace_2dd6ab551ae913c6501baeba32df9dab" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref853_g91" level="file">
+          <did>
+            <unittitle>Convolving graph paper tracings by Lyle Ramshaw, December 16, 1983</unittitle>
+            <container id="aspace_ae26e0a4a70faf309ea35e4013f6265b" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_77ac4ab86b4775b45f17861a803cb8eb" parent="aspace_ae26e0a4a70faf309ea35e4013f6265b" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref854_6pw" level="file">
+          <did>
+            <unittitle>Alternatives to the splines of Manning by John Hobby, December 31, 1983-January 1, 1984</unittitle>
+            <container id="aspace_8c760a1d7664b07ee469cef9c04627b0" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_081c4289114962851754d03b04bd20d8" parent="aspace_8c760a1d7664b07ee469cef9c04627b0" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref855_nrm" level="file">
+          <did>
+            <unittitle>Comments on curves by Leo Guibas and Knuth, January 1, 1984</unittitle>
+            <container id="aspace_7c9cc201ea189bad4b6de461b050f824" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_2944c2ce720c54fb72f54cf5545a57b8" parent="aspace_7c9cc201ea189bad4b6de461b050f824" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref856_btr" level="file">
+          <did>
+            <unittitle>Reparameterization and other things by Lyle Ramshaw, January 3, 1984</unittitle>
+            <container id="aspace_f42ff5bd0d82fe25760334282f45cb87" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_28365df10de99ceb63751877f0165472" parent="aspace_f42ff5bd0d82fe25760334282f45cb87" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref857_qht" level="file">
+          <did>
+            <unittitle>Compromise values of r and s by John Hobby, January 3 1984</unittitle>
+            <container id="aspace_9aa880e0ce4ebf65bc42148e74782e98" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_db484b6f931ec9a9d3115215367ca942" parent="aspace_9aa880e0ce4ebf65bc42148e74782e98" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref858_78u" level="file">
+          <did>
+            <unittitle>Nifty labeling of Bezier intermediate points by Lyle Ramshaw, February 8, 1985</unittitle>
+            <container id="aspace_6fcebb29b51b12056f3afbcf99ce1f96" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_48af115d797bad2dc4e451dda067f7f0" parent="aspace_6fcebb29b51b12056f3afbcf99ce1f96" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref859_sdr" level="file">
+          <did>
+            <unittitle>Proposed raster image processor by Victor Ostromoukhov, Spring 1988</unittitle>
+            <container id="aspace_a02243c98e5d5221648a835bdfad2630" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_d0d1d9270b915d0c54a48a272be6fc5f" parent="aspace_a02243c98e5d5221648a835bdfad2630" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref860_y4w" level="file">
+          <did>
+            <unittitle>Adaptation of Liang's hyphenation to Russian by Dimitri Vulis 1988</unittitle>
+            <container id="aspace_6139082f18dbe106b5510378c975c0d1" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_0e87c2fa400171d01f5eac3c281e46b4" parent="aspace_6139082f18dbe106b5510378c975c0d1" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref861_exs" level="file">
+          <did>
+            <unittitle>Proposed changes to TeX by Jan Rynning, August 16, 1989</unittitle>
+            <container id="aspace_79b13d9f06f3c6fbfa08ca055224b920" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_ddd838b6058b6a8f024a9cddd2c4d5b8" parent="aspace_79b13d9f06f3c6fbfa08ca055224b920" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref862_zdd" level="file">
+          <did>
+            <unittitle>ISO standards for extended 8-bit codes, August 1989</unittitle>
+            <container id="aspace_ea3a0d414a76c33e2b7e70aef3f35710" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_acf52c8eef16e672e92d14f1874a3c4b" parent="aspace_ea3a0d414a76c33e2b7e70aef3f35710" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref863_6jv" level="file">
+          <did>
+            <unittitle>Subtle bugs in METAFONT, October 1989</unittitle>
+            <container id="aspace_a11a21e6249dd438f5e8854d78678d8d" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_ede17c03331e7a688390d1f301e9dce4" parent="aspace_a11a21e6249dd438f5e8854d78678d8d" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref864_lis" level="file">
+          <did>
+            <unittitle>Samples of AMS Euler before re-tuning of Fraktur and script, March 1991</unittitle>
+            <container id="aspace_d8cf03a05d3d6bd1730547ac2d659e16" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_5a6a9f4aea9852628c258a1f02abf6c0" parent="aspace_d8cf03a05d3d6bd1730547ac2d659e16" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref865_7ep" level="file">
+          <did>
+            <unittitle>Demillo and Mathur, Applying grammar-based fault classification to TeX, 1995</unittitle>
+            <container id="aspace_9ae5b04fcd06e7c6e1ea8705acca5a9f" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_33db2a58631b0ec33b5d9522f29db156" parent="aspace_9ae5b04fcd06e7c6e1ea8705acca5a9f" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref866_u50" level="file">
+          <did>
+            <unittitle>Samples of repro copy used to make Computers &amp; Typesetting:</unittitle>
+            <container id="aspace_b771540a5a716e66ff393feb2cb73b97" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_bf977cb9be19e26c0a563cb241208a5c" parent="aspace_b771540a5a716e66ff393feb2cb73b97" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref867_d9e" level="file">
+          <did>
+            <unittitle>Volume A - The TeXbook (includes all chapter openers with Duane Bibby art) 1983</unittitle>
+            <container id="aspace_39a6716c9eb8b35dd8451d586b7af107" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_800752944b4d881a1cfb8357ce328651" parent="aspace_39a6716c9eb8b35dd8451d586b7af107" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref868_yc2" level="file">
+          <did>
+            <unittitle>Volume B - TeX: The Program 1986</unittitle>
+            <container id="aspace_2647d1ba36c5d6627396c34fc0227e22" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_300c9dc9b4636a11b9f076f410ad5b29" parent="aspace_2647d1ba36c5d6627396c34fc0227e22" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref869_0jl" level="file">
+          <did>
+            <unittitle>Volume D - METAFONT: The Program 1986</unittitle>
+            <container id="aspace_f2b7da6734ba0fa30310b7701ffa707b" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_ac0e96b5c754fea79b49de6d591e356e" parent="aspace_f2b7da6734ba0fa30310b7701ffa707b" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref870_9cy" level="file">
+          <did>
+            <unittitle>Volume E - Computer Modern Typefaces 1986</unittitle>
+            <container id="aspace_2bf54d692eea05ea9089084475c08c47" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_2a2b2460f741b7f53e319afccfb853ab" parent="aspace_2bf54d692eea05ea9089084475c08c47" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref871_mp3" level="file">
+          <did>
+            <unittitle>Samples of repro copy for Concrete Mathematics (the first major use of the AMS Euler typeface; 1988 sheets on Autologic 720dpi; 1990 on Linotron 1270dpi) 1988-1990</unittitle>
+            <container id="aspace_d054f5c7e5da919aed5e557a8f2d628b" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_fdcb01058d55a06f719ed681e726ccbe" parent="aspace_d054f5c7e5da919aed5e557a8f2d628b" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref872_hcr" level="file">
+          <did>
+            <unittitle>Miscellaneous publications of the TeX Users Group:</unittitle>
+            <container id="aspace_9215fd27a77fa006f07192b1963f2fa5" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_e82a7ec02ca19c9ae6c8be4617297d0a" parent="aspace_9215fd27a77fa006f07192b1963f2fa5" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref873_cyq" level="file">
+          <did>
+            <unittitle>Membership list</unittitle>
+            <unitdate datechar="creation">September 26, 1986</unitdate>
+            <container id="aspace_4fafd49ffa062aab36c24d8876a172bc" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_f8b60a0200f5eca023cc56b465e1da67" parent="aspace_4fafd49ffa062aab36c24d8876a172bc" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref874_74b" level="file">
+          <did>
+            <unittitle>Errata and changes for Computers &amp; Typesetting, June 15, 1987</unittitle>
+            <container id="aspace_b8a93c17d0e739becdc897b42a539814" label="Mixed Materials [aspace.536457.box.2]" type="Box">2</container>
+            <container id="aspace_3b485e9c82a49bbd8affef1102c9744e" parent="aspace_b8a93c17d0e739becdc897b42a539814" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref875_cro" level="file">
+          <did>
+            <unittitle>Keepsakes from the later days of TeX and METAFONT</unittitle>
+            <container id="aspace_5aa277155bbcea7fcb7b9686af485e86" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_4665f5a59da3554f91bda7777f74f60a" parent="aspace_5aa277155bbcea7fcb7b9686af485e86" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref876_8gy" level="file">
+          <did>
+            <unittitle>Duane Bibby's announcement of his new home n.d.</unittitle>
+            <container id="aspace_9ce6092bafaa70ffc61235f08687c1e9" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_78b47500cd9c0ca41d910fac4c0e4842" parent="aspace_9ce6092bafaa70ffc61235f08687c1e9" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref877_or2" level="file">
+          <did>
+            <unittitle>TeX Christmas from Irene Hyna, December 1986</unittitle>
+            <container id="aspace_b280aabdaaeeb7fb14f2de28a3f535c6" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_f8ec617c98d0661e3a5be27509982ba1" parent="aspace_b280aabdaaeeb7fb14f2de28a3f535c6" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref878_uhc" level="file">
+          <did>
+            <unittitle>METAFONT Christmas card from Georgia Tobin, December 1986</unittitle>
+            <container id="aspace_38173e5f532c6246e167b52570bd1199" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_e3572402518feb904924710c64e3e945" parent="aspace_38173e5f532c6246e167b52570bd1199" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref879_2n5" level="file">
+          <did>
+            <unittitle>METAFONT Valentine for Jill, February 1987</unittitle>
+            <container id="aspace_7c86bed679734f79d22677e6ec42a080" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_72c1de5cef5b78b8cc32efd04d95fd13" parent="aspace_7c86bed679734f79d22677e6ec42a080" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref880_34h" level="file">
+          <did>
+            <unittitle>Wedding program for Diana Barnes and Robert Nicholus, August 29, 1987</unittitle>
+            <container id="aspace_b94b53d3c16df9cefe2b8c7cb0565f0b" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_7741c578f613bd059c0cc33e6de2e56f" parent="aspace_b94b53d3c16df9cefe2b8c7cb0565f0b" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref881_zcn" level="file">
+          <did>
+            <unittitle>(one of the first uses of Computer Modern Sans Serif)</unittitle>
+            <container id="aspace_8403f34195bc1a3ddbcdacfad5e377d1" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_d1749876e3e692d0cad725188cc3ffef" parent="aspace_8403f34195bc1a3ddbcdacfad5e377d1" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref882_4ph" level="file">
+          <did>
+            <unittitle>Example DVIRGB output, IBM colorjet printer by Norman Naugle, November 1987</unittitle>
+            <container id="aspace_e6ec4da1047c9738801cd5039d3d9198" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_6721ef649b219029cd7d4f723397d1d9" parent="aspace_e6ec4da1047c9738801cd5039d3d9198" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref883_gzy" level="file">
+          <did>
+            <unittitle>"A dragon for you" text and picture by Norman Naugle n.d.</unittitle>
+            <container id="aspace_72b6a2c27e753b6be5459326f57518d4" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_c0298a1606e730ada044cadcf87731cd" parent="aspace_72b6a2c27e753b6be5459326f57518d4" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref884_a1e" level="file">
+          <did>
+            <unittitle>Announcement of Knuth's lecture to Stanford Library Associates, December 1987</unittitle>
+            <container id="aspace_e152b06963dc60252928fff8c4ce4877" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_65cdf0a60d78fd73f3bd8e37de31ed73" parent="aspace_e152b06963dc60252928fff8c4ce4877" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref885_5am" level="file">
+          <did>
+            <unittitle>Poster with Computer Modern, received from Oc\'e in Netherlands, April 1988</unittitle>
+            <container id="aspace_e9290cd9e510948b295c7090863393aa" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_b5e25582665d9de0eecbf3c8cbd4fa29" parent="aspace_e9290cd9e510948b295c7090863393aa" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref886_p9y" level="file">
+          <did>
+            <unittitle>Registration form when Knuth joined cyrTUG, the Russian TeX users group, May 1994</unittitle>
+            <container id="aspace_aba27029aeaa35de21ba9252011ff9f5" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_a9bf0394f03e5fb996abc1dc10f1d8cb" parent="aspace_aba27029aeaa35de21ba9252011ff9f5" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref887_kmv" level="file">
+          <did>
+            <unittitle>Examples of TeX and METAFONT as used by Josef Gerbrich in Brno 1995</unittitle>
+            <container id="aspace_d079ede6f37ba28f58e7d54601d6d506" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_57f5eb9ccd7164aa742f7b56dc21bb75" parent="aspace_d079ede6f37ba28f58e7d54601d6d506" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref888_5pq" level="file">
+          <did>
+            <unittitle>Examples of TeX output for posted tram schedules in Brno and Prague 1995</unittitle>
+            <container id="aspace_b32b732692960655da2bb70668baad74" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_0965b5f52cffc6d82bf73afeacdd9445" parent="aspace_b32b732692960655da2bb70668baad74" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref889_m81" level="file">
+          <did>
+            <unittitle>Early examples of TeX and METAFONT used in non-English languages:</unittitle>
+            <container id="aspace_f2b97a235a1f0df3e7e9e661b2fdfbec" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_ee010f3751af107881faf0e4cf986416" parent="aspace_f2b97a235a1f0df3e7e9e661b2fdfbec" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref890_er3" level="file">
+          <did>
+            <unittitle>Irish</unittitle>
+            <container id="aspace_0f623e4d2147712b487e64e7e37d1b38" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_3419ceef965feedbaac1425f7083f4c4" parent="aspace_0f623e4d2147712b487e64e7e37d1b38" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref891_uxn" level="file">
+          <did>
+            <unittitle>Icelandic</unittitle>
+            <container id="aspace_9c3c9930d192bd7186983ece9b90618d" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_d7019797575748833af359277f0a9d00" parent="aspace_9c3c9930d192bd7186983ece9b90618d" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref892_zsi" level="file">
+          <did>
+            <unittitle>Russian (includes Cyrillic fonts to match Computer Modern Concrete Russian)</unittitle>
+            <container id="aspace_2b830f2bb1f21de2b40b6e2456179cc3" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_91d4a4305db30a0fcc3685903af50a28" parent="aspace_2b830f2bb1f21de2b40b6e2456179cc3" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref893_a2j" level="file">
+          <did>
+            <unittitle>Old Church Slavonic</unittitle>
+            <container id="aspace_e772513deb06b4597a8382f8983efc6d" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_c3ae898e111c2170d88eb551bab314b0" parent="aspace_e772513deb06b4597a8382f8983efc6d" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref894_wei" level="file">
+          <did>
+            <unittitle>Polish (includes Samizdat literature for Solidarity!)</unittitle>
+            <container id="aspace_1a42ff48eb6a8638904fb4fe218aebf9" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_3dbb5853bdfb49a9560ff178657c60af" parent="aspace_1a42ff48eb6a8638904fb4fe218aebf9" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref895_pw5" level="file">
+          <did>
+            <unittitle>Turkish</unittitle>
+            <container id="aspace_05b0e6ac2a58179d01f07c33e70c22ae" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_80890d53f5241937777db653e8eed69b" parent="aspace_05b0e6ac2a58179d01f07c33e70c22ae" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref896_flk" level="file">
+          <did>
+            <unittitle>Arabic</unittitle>
+            <container id="aspace_6dd5469b588a2823f9f34b7f2a6d5a36" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_217cd7efa082bb8ed01782d699ce798e" parent="aspace_6dd5469b588a2823f9f34b7f2a6d5a36" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref897_ixq" level="file">
+          <did>
+            <unittitle>Farsi</unittitle>
+            <container id="aspace_f82d562a2d7279faf289ee6423c67cb8" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_4a10277104450131dd649d17a29861ee" parent="aspace_f82d562a2d7279faf289ee6423c67cb8" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ref898_bf2" level="file">
+          <did>
+            <unittitle>Greek, Gothic, Hebrew, Sanskrit, etc.</unittitle>
+            <container id="aspace_aabf552831e6d0401e28f16998159cdf" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_53d0ba3565ce8184aeee695f07f88c6a" parent="aspace_aabf552831e6d0401e28f16998159cdf" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref899_exk" level="file">
+          <did>
+            <unittitle>ScholarTeX by Yannis Haralambous, 1991</unittitle>
+            <container id="aspace_76020019148067d666c1f07b5b8fb654" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_16f7cf0b766f382c1f89e35b3aa82872" parent="aspace_76020019148067d666c1f07b5b8fb654" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref900_g61" level="file">
+          <did>
+            <unittitle>TeX et las Langues Orientales by M. Fanton and Y. Haralambous, 1992</unittitle>
+            <container id="aspace_86925cdccaf92648ec7397a82b562c74" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_75265dc5729b9d201d1812fb1cbb8fbb" parent="aspace_86925cdccaf92648ec7397a82b562c74" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_ref901_yan" level="file">
+          <did>
+            <unittitle>Amharic</unittitle>
+            <container id="aspace_d896a08a755dbd5f82a5ccef0e36ecc7" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_a6bd413d202210d3877f3b2dfc0bacda" parent="aspace_d896a08a755dbd5f82a5ccef0e36ecc7" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_ref902_xie" level="file">
+          <did>
+            <unittitle>Chinese</unittitle>
+            <container id="aspace_87fc6d8f235b817f7c0f758787fe63e3" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_229c0ba294c87a77f56422cac8f9c47f" parent="aspace_87fc6d8f235b817f7c0f758787fe63e3" type="folder">12</container>
+          </did>
+        </c>
+        <c id="aspace_ref903_fea" level="file">
+          <did>
+            <unittitle>Japanese</unittitle>
+            <container id="aspace_94321e5f606d4e0ef8d8787158ca6f33" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_38c1910c53a318508fbdcf00829e4a1c" parent="aspace_94321e5f606d4e0ef8d8787158ca6f33" type="folder">13</container>
+          </did>
+        </c>
+        <c id="aspace_ref904_oyq" level="file">
+          <did>
+            <unittitle>Conference publications and handouts from TeX/METAFONT user groups:</unittitle>
+            <container id="aspace_143e5cb512e199a9d275105f2ca12d36" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_7ff06998cf1ca01a105eacd57c9901ba" parent="aspace_143e5cb512e199a9d275105f2ca12d36" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref905_y9c" level="file">
+          <did>
+            <unittitle>America -</unittitle>
+            <container id="aspace_d25a546fb1718bee78914bdde3694167" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_b8b862d68cc435b2f486edc19500efd9" parent="aspace_d25a546fb1718bee78914bdde3694167" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref906_a16" level="file">
+          <did>
+            <unittitle>Delaware and Washington 1987</unittitle>
+            <container id="aspace_560bf7924e1d0afc78f39d5d1d4ee2d8" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_6469ef883aa6ee13b4784d92e43324e9" parent="aspace_560bf7924e1d0afc78f39d5d1d4ee2d8" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref907_kej" level="file">
+          <did>
+            <unittitle>Stanford 1989</unittitle>
+            <container id="aspace_c351981401a05c15f2f5bd0e86ff4fbf" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_ae53444ba82f239d423d0c9c86da1b7a" parent="aspace_c351981401a05c15f2f5bd0e86ff4fbf" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref908_s48" level="file">
+          <did>
+            <unittitle>College Station, Texas 1990</unittitle>
+            <container id="aspace_98f6b6577b65201aed442b236b46b9e5" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_5d3bb716c541b4b52ddc7a374bdf1b0f" parent="aspace_98f6b6577b65201aed442b236b46b9e5" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref909_rh0" level="file">
+          <did>
+            <unittitle>Boston 1991</unittitle>
+            <container id="aspace_c8581da49b3a3e443a855424cc59151e" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_806bfa0f4219d9156d1188b3d72cdaf6" parent="aspace_c8581da49b3a3e443a855424cc59151e" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref910_nmi" level="file">
+          <did>
+            <unittitle>Santa Barbara 1994 (preprints)</unittitle>
+            <container id="aspace_3ce14db3f50203e440506c25d5bdee10" label="Mixed Materials [aspace.536457.box.3]" type="Box">3</container>
+            <container id="aspace_5b88da5774b74c3d95570590b5d439b1" parent="aspace_3ce14db3f50203e440506c25d5bdee10" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_ref911_taq" level="file">
+          <did>
+            <unittitle>Florida 1995 (preprints and handouts)</unittitle>
+            <container id="aspace_8ce652074b428ccf27c6cd6b27a80a26" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_90b2c7d8b2234dac5e8bb2a373863163" parent="aspace_8ce652074b428ccf27c6cd6b27a80a26" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref912_du5" level="file">
+          <did>
+            <unittitle>Europe -</unittitle>
+            <container id="aspace_f374eaa63a8dc0e2cbca7a75b6eeb623" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_8a71205f9f9c09543c3960b975efd331" parent="aspace_f374eaa63a8dc0e2cbca7a75b6eeb623" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref913_q29" level="file">
+          <did>
+            <unittitle>First European TeX Conference, Cork, Ireland 1990</unittitle>
+            <container id="aspace_cfcb5ca0fb5065624526dad3f44755b1" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_b9adbf1467d577f16e6e7b418ea6f489" parent="aspace_cfcb5ca0fb5065624526dad3f44755b1" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref914_ln2" level="file">
+          <did>
+            <unittitle>Cahiers GUTenberg no 8 (1991)</unittitle>
+            <container id="aspace_41b4e76cb6f4bfde10d86c0386929fb1" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_5758a8cd52567c048578c0edabd75cbe" parent="aspace_41b4e76cb6f4bfde10d86c0386929fb1" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref915_01o" level="file">
+          <did>
+            <unittitle>Nordic TeX Users Group, Stockholm 1991</unittitle>
+            <container id="aspace_00ba19215c9cd5c6f6d35bd37d7747cf" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_1f317dfb17a9f83fa51d2cac04654966" parent="aspace_00ba19215c9cd5c6f6d35bd37d7747cf" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref916_vgw" level="file">
+          <did>
+            <unittitle>Asia -</unittitle>
+            <container id="aspace_1356ca322ae19b3f80e02b2f491cfdd0" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_c81365c1f69010556c710fc4e3358fbb" parent="aspace_1356ca322ae19b3f80e02b2f491cfdd0" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref917_bng" level="file">
+          <did>
+            <unittitle>cyrTUG publications and fonts</unittitle>
+            <container id="aspace_ccefa13bd53b18021e5bc0dfdf4cfc28" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_365e601d0d8651761bfdfdb1be0695f0" parent="aspace_ccefa13bd53b18021e5bc0dfdf4cfc28" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref918_hzm" level="file">
+          <did>
+            <unittitle>Proceedings of the 7th UNICODE conference, September 1995</unittitle>
+            <container id="aspace_ef0bbde3b835da3ee220a18df685cc19" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_80dcb28a510d8dcf72cc65ca6c5d219f" parent="aspace_ef0bbde3b835da3ee220a18df685cc19" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref919_nxn" level="file">
+          <did>
+            <unittitle>Part 1</unittitle>
+            <container id="aspace_425289436827a7fc40c92f85e7cb28b2" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_c362a5f5085ba53b1c6beafa19efeebc" parent="aspace_425289436827a7fc40c92f85e7cb28b2" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref920_f7c" level="file">
+          <did>
+            <unittitle>Part 2</unittitle>
+            <container id="aspace_574fb7aa8a33820260e7864ecaccca33" label="Mixed Materials [aspace.536457.box.4]" type="Box">4</container>
+            <container id="aspace_cc5f20b60301eab21347bb7647a1bad1" parent="aspace_574fb7aa8a33820260e7864ecaccca33" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref921_9xm" level="file">
+          <did>
+            <unittitle>Miscellaneous typographic keepsakes given to Knuth by Mell Hall and Bob McCann (former employees of Stanford News and Publications)</unittitle>
+            <container id="aspace_b28d6f4b0810e55dc3bdcddf3a9c4169" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_77078d758a9a54e58a8bd2ae627ebbf7" parent="aspace_b28d6f4b0810e55dc3bdcddf3a9c4169" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref922_hoc" level="file">
+          <did>
+            <unittitle>_____.</unittitle>
+            <container id="aspace_7c5fdf682b98eb9fd1f10fb2bb98bfeb" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_49bca623c367eab443188c3b0f9109a1" parent="aspace_7c5fdf682b98eb9fd1f10fb2bb98bfeb" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref923_38k" level="file">
+          <did>
+            <unittitle>Miscellaneous typography - related keepsakes that Knuth acquired over the years:</unittitle>
+            <container id="aspace_8dade6193fcebee944385921d1d365c4" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_307a330f136eca97b21c826dbc8e5af5" parent="aspace_8dade6193fcebee944385921d1d365c4" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref924_036" level="file">
+          <did>
+            <unittitle>Demo page by leader of Lisa software at Apple Computer 1983</unittitle>
+            <container id="aspace_fb43f28d9b625a12625506d9d3d4882e" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_0d1567e882e1d58cc2bd93f184850a9a" parent="aspace_fb43f28d9b625a12625506d9d3d4882e" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref925_7we" level="file">
+          <did>
+            <unittitle>Peter Koch, printer 1995</unittitle>
+            <container id="aspace_ddc22cbadef9ace77f704b8c13fc2f75" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_1cf2ec696744d86f3dd6492ac104a572" parent="aspace_ddc22cbadef9ace77f704b8c13fc2f75" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref926_odk" level="file">
+          <did>
+            <unittitle>Printing at the Wittington Press, 1972-1994</unittitle>
+            <container id="aspace_abf7e3112c7afa4103d0fd5c30366330" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_90d7d127658c55558e59a211adcbac58" parent="aspace_abf7e3112c7afa4103d0fd5c30366330" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref927_khd" level="file">
+          <did>
+            <unittitle>Sample of Scripps College Oldstyle type (Goudy)</unittitle>
+            <container id="aspace_e149cd6b3f8be623f7638ea29c15f6e6" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_9add3ed25bb2ab42b7f239e8cf6e9632" parent="aspace_e149cd6b3f8be623f7638ea29c15f6e6" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref928_9o6" level="file">
+          <did>
+            <unittitle>Typography: Basic principles and applications--Oc\'e, Netherlands</unittitle>
+            <container id="aspace_ebf63889bf46d7d59acf0d25c56ac2ba" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_8c6655f119c9fed3ccaf99e864b0c685" parent="aspace_ebf63889bf46d7d59acf0d25c56ac2ba" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref929_zt8" level="file">
+          <did>
+            <unittitle>Character language resources: International software buyer's guide 1995</unittitle>
+            <container id="aspace_7e5e89d4e4f4370f3968d6239a680033" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_53a9f7c312b87580b7ab08e8465110b2" parent="aspace_7e5e89d4e4f4370f3968d6239a680033" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref930_fok" level="file">
+          <did>
+            <unittitle>Sample graphics from 1991 Stanford Art Directors Invitational</unittitle>
+            <container id="aspace_384ffd82903860d851df5e4c7262615d" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_60a4fddc0c5890c05fc1376e8f806844" parent="aspace_384ffd82903860d851df5e4c7262615d" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref931_8cc" level="file">
+          <did>
+            <unittitle>Samples of David Kindersley's SuperVision spacing method 1985 &amp; 1987</unittitle>
+            <container id="aspace_d540cb90a9b2e07338e6650c7a3986f6" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_2ac7213280f6d506138e980289fdd7c8" parent="aspace_d540cb90a9b2e07338e6650c7a3986f6" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref932_lqh" level="file">
+          <did>
+            <unittitle>Samples of Chinese fonts by Gu Guoan, Shanghai IKARUS Limited 1989</unittitle>
+            <container id="aspace_052efc44882b974ea19378359d77d72c" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_0f33dcddda40ecc79528c0c2a8a6da7c" parent="aspace_052efc44882b974ea19378359d77d72c" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref933_fzn" level="file">
+          <did>
+            <unittitle>Early example of Dave Siegel's Tekton font, used in PhoneNET poster 1991</unittitle>
+            <container id="aspace_0800e630f463c751c2db8611504ec809" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_e215cc5c1d68afcacb7f66944a3154c2" parent="aspace_0800e630f463c751c2db8611504ec809" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref934_wbp" level="file">
+          <did>
+            <unittitle>Poster made at Donnelley research laboratory 1988 (poor typesetting!)</unittitle>
+            <container id="aspace_7078013d59783ecb95e6b1b82611224c" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_d5e7e4e0af3c10fe0f86770af75e59cd" parent="aspace_7078013d59783ecb95e6b1b82611224c" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref935_ne1" level="file">
+          <did>
+            <unittitle>Fonts from Judith Sutcliffe of Santa Barbara</unittitle>
+            <container id="aspace_5edd8a256401fac03d2667b65319fad6" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_629867a7491d2ae90b15598f7ba7806f" parent="aspace_5edd8a256401fac03d2667b65319fad6" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref936_w75" level="file">
+          <did>
+            <unittitle>INRIA poster that mixes Computer Modern Sans with Univers</unittitle>
+            <container id="aspace_8adcb4dab9677d07900f51ee4c1f78cf" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_b557bd3709c2286896d37f2a463eea90" parent="aspace_8adcb4dab9677d07900f51ee4c1f78cf" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref937_gkk" level="file">
+          <did>
+            <unittitle>Correspondence and samples from Sumner Stone's type foundry</unittitle>
+            <container id="aspace_1a10d225f450ae9488a8b297d1982597" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_44e90cf10282f453062f0ea70c0659be" parent="aspace_1a10d225f450ae9488a8b297d1982597" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref938_dfx" level="file">
+          <did>
+            <unittitle>Font coding system used in Beijing, November 1991</unittitle>
+            <container id="aspace_5b2a157fc29756abd29f79db17fd04a4" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_59cac7bd12fc5a1797da60c42f564fad" parent="aspace_5b2a157fc29756abd29f79db17fd04a4" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref939_t1j" level="file">
+          <did>
+            <unittitle>SERIF: A typography magazine produced with TeX 1994</unittitle>
+            <container id="aspace_6381260910373d88d7496bd758170c46" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_76931feec919d4fc8f096653d4b44944" parent="aspace_6381260910373d88d7496bd758170c46" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref940_9h5" level="file">
+          <did>
+            <unittitle>Keepsake from Andrew Hoyem using types of Rudolph Koch</unittitle>
+            <container id="aspace_103873a73bba77e6b6217d178ae9740e" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_64eea733c0b38ece4481a41824b8f51f" parent="aspace_103873a73bba77e6b6217d178ae9740e" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref941_0zf" level="file">
+          <did>
+            <unittitle>Specimens of ITC Bodoni type</unittitle>
+            <container id="aspace_b4329d1e8099b1f149cb63eaaad64902" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_4809b8af27d16dcf8de83a3b3753dfd6" parent="aspace_b4329d1e8099b1f149cb63eaaad64902" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref942_39i" level="file">
+          <did>
+            <unittitle>ITC font brochure 1994</unittitle>
+            <container id="aspace_1a9880f3949f387d0734742e395d6256" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_40a82619359b2896c8ab11520c7f6cc3" parent="aspace_1a9880f3949f387d0734742e395d6256" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref943_v20" level="file">
+          <did>
+            <unittitle>Fundacion Tipografica Neufville font brochure 1994</unittitle>
+            <container id="aspace_55e9fbe2224c72bd1eebad8d75662d64" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_27762f617c2602c40a67fb55c1d30356" parent="aspace_55e9fbe2224c72bd1eebad8d75662d64" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref944_xmr" level="file">
+          <did>
+            <unittitle>Linotype font brochure 1994</unittitle>
+            <container id="aspace_6d34351b2641773c0f9b49d1fccc3f9b" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_3dbbaf97abcaff99ec29f8f36717d916" parent="aspace_6d34351b2641773c0f9b49d1fccc3f9b" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref945_53r" level="file">
+          <did>
+            <unittitle>Bitstream GX fonts 1994</unittitle>
+            <container id="aspace_1d5bf8b2b0eb18bd99b10ce885e75d4d" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_7753ec9e1b4e4091c7475307fc866cbe" parent="aspace_1d5bf8b2b0eb18bd99b10ce885e75d4d" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref946_3m0" level="file">
+          <did>
+            <unittitle>ATypI Congress 1994, San Francisco, brochure and program</unittitle>
+            <container id="aspace_48944d7da1255f5cccce7b905fb18805" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_0bff03f2c08e605d7af0a08a3b17a844" parent="aspace_48944d7da1255f5cccce7b905fb18805" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref947_87b" level="file">
+          <did>
+            <unittitle>D\"urer: So will I be perfect; keepsake by Jeff Level, Robert Kobodaishi</unittitle>
+            <container id="aspace_bb93535d82f3c6419c9ffb13aa42fb04" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_0d308959e8f515f4d681bb5ee6ef079c" parent="aspace_bb93535d82f3c6419c9ffb13aa42fb04" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref948_nwk" level="file">
+          <did>
+            <unittitle>Miscellaneous handouts from ATypI Congress 94: TypeLab, etc.</unittitle>
+            <container id="aspace_20bf42f54bd21fd462d13c5078fb6c9d" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_33eb61df3102d291ca4d22f5e130c591" parent="aspace_20bf42f54bd21fd462d13c5078fb6c9d" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref949_7uy" level="file">
+          <did>
+            <unittitle>Decorated Hebrew alphabet from Jerusalem</unittitle>
+            <container id="aspace_856987abfccb1e0cea3f598707559271" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_74905091f36b725642d82b5788d6e584" parent="aspace_856987abfccb1e0cea3f598707559271" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref950_2rs" level="file">
+          <did>
+            <unittitle>Erich Wronker, Picture portfolio of printing medals 1993</unittitle>
+            <container id="aspace_a2e807b8de130cb489628865903dbc79" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_ed055ffcdc4d638b9079167fead06c8d" parent="aspace_a2e807b8de130cb489628865903dbc79" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref951_o4d" level="file">
+          <did>
+            <unittitle>Bigelow and Holmes, examples of new Lucida mathematics fonts 1992</unittitle>
+            <container id="aspace_e4445ae4c7b39075b103c0d776914955" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_60da5bd7c1e1a094f28255811522f326" parent="aspace_e4445ae4c7b39075b103c0d776914955" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref952_pbs" level="file">
+          <did>
+            <unittitle>A "meta-painting" (printed 1977 in Munich, but probably from 19th century)</unittitle>
+            <container id="aspace_f0e721365c22ed1db0d7f943e31f5803" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_ac70f760c2b90b1b3e7930d2ae2f82b4" parent="aspace_f0e721365c22ed1db0d7f943e31f5803" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref953_udu" level="file">
+          <did>
+            <unittitle>Samples from correspondence from Sumner Stone's type foundry</unittitle>
+            <container id="aspace_c0cb65741d9593fb96f9c73609cb13ae" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_c8bb845833362c89b1b19e701b8024e0" parent="aspace_c0cb65741d9593fb96f9c73609cb13ae" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref954_piz" level="file">
+          <did>
+            <unittitle>Samples from Gunnlaugur Briem</unittitle>
+            <container id="aspace_d29c7888f1737d9c01b0cea4a6835302" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_f20391da2127e8bb786a16a12318e1d0" parent="aspace_d29c7888f1737d9c01b0cea4a6835302" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref955_zzs" level="file">
+          <did>
+            <unittitle>Christmas and New Year's Cards:</unittitle>
+            <container id="aspace_970e3f752a04dab59576c6b35fbc8103" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_8aa43d967d6203d73753cd0d62d5c6a0" parent="aspace_970e3f752a04dab59576c6b35fbc8103" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref956_0ps" level="file">
+          <did>
+            <unittitle>Andrea Grimes, Susie Taylor; Sheila and Julian Waters; Friedrich and Edith Neugebauer; Gunnlaugur Briem; Christine and Friedrich Peter; Gudrun and Hermann Zapf</unittitle>
+            <container id="aspace_34d9461e3469c413d4a38c79338efb63" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_5916ca8b735e1d364d67da223cb45bd0" parent="aspace_34d9461e3469c413d4a38c79338efb63" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref957_4lg" level="file">
+          <did>
+            <unittitle>Brochures and Publications of TeX and/or METAFONT Vendors:</unittitle>
+            <container id="aspace_5bfb639244c9ef1944c6801c3f64c165" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_4dbca78f2e2503780a4276d60b3d2b0e" parent="aspace_5bfb639244c9ef1944c6801c3f64c165" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref958_lga" level="file">
+          <did>
+            <unittitle>Preliminary user guide to Micro-TeX 1986</unittitle>
+            <container id="aspace_a4601f606629d80ac1be1c3709f9cce0" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_fb95d28ae34228ffb588938ea132acb3" parent="aspace_a4601f606629d80ac1be1c3709f9cce0" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref959_3z3" level="file">
+          <did>
+            <unittitle>Donald E. Knuth und MicroTeX im Gutenbergmuseum zu Mainz, September 17, 1987</unittitle>
+            <container id="aspace_6ee90eec8eb649edd834f8dbd2bcd5e9" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_6a1d21466bd9463ba3631c2857a72213" parent="aspace_6ee90eec8eb649edd834f8dbd2bcd5e9" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref960_l8h" level="file">
+          <did>
+            <unittitle>Handouts from Jonathan Fine 1993</unittitle>
+            <container id="aspace_acb96e4aabfbc23b26c543a9e8ac6098" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_4bb06a2c159335e6d95c42d968bd49ba" parent="aspace_acb96e4aabfbc23b26c543a9e8ac6098" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref961_j7f" level="file">
+          <did>
+            <unittitle>Alex Warman's letter describing TeXworks publishing in Australia</unittitle>
+            <container id="aspace_52e91d743234e20a876bac9f948171e9" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_243092a347edd81f50e5aefaed1b56fe" parent="aspace_52e91d743234e20a876bac9f948171e9" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref962_vba" level="file">
+          <did>
+            <unittitle>St\"urtz typesetting of TeC documents</unittitle>
+            <container id="aspace_fcaac9044b53c3f6cba8dea0d4251481" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_1b6ab9f3a5395f26d4dbd1bb5d143c8e" parent="aspace_fcaac9044b53c3f6cba8dea0d4251481" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref963_lhx" level="file">
+          <did>
+            <unittitle>TeX-to-type at Cambridge University Press</unittitle>
+            <container id="aspace_4ebc9e98c202d7d3baafb42c803bf2b6" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_29389d9f71c752f40afff38ab6e6c4e0" parent="aspace_4ebc9e98c202d7d3baafb42c803bf2b6" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref964_w4l" level="file">
+          <did>
+            <unittitle>Look to Springer for the latest in TeXnology</unittitle>
+            <container id="aspace_88abd946f9a7a0394f5783a10b7d8e5a" label="Mixed Materials [aspace.536457.box.5]" type="Box">5</container>
+            <container id="aspace_8a08bdbc5b6e92f20f3d07d7f54ee249" parent="aspace_88abd946f9a7a0394f5783a10b7d8e5a" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_ref965_pgj" level="file">
+          <did>
+            <unittitle>Talaris Systems Newsletters: The Laser Line 1986-1988</unittitle>
+            <container id="aspace_30223f9e3233e4314fbf51e3dac5cbf3" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_24077d1a176c7dd7ae09bb4a91f92965" parent="aspace_30223f9e3233e4314fbf51e3dac5cbf3" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref966_ypr" level="file">
+          <did>
+            <unittitle>Kinch Computer Company: TurboTeX buyer's guide</unittitle>
+            <container id="aspace_75bea5bcb528db375995981676688559" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_f61d5c7787fb1b50fc75490ebeaba4a9" parent="aspace_75bea5bcb528db375995981676688559" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref967_mu5" level="file">
+          <did>
+            <unittitle>Mimi Lafrenz's letter about ETP composition services in Portland</unittitle>
+            <container id="aspace_fc5c3cefc31903397b82f7af135ee9b9" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_659d685363c648e39c69f99d9552e1aa" parent="aspace_fc5c3cefc31903397b82f7af135ee9b9" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref968_qg1" level="file">
+          <did>
+            <unittitle>Oc\'e's new 508dpi laserprinter with Computer Modern samples 1988</unittitle>
+            <container id="aspace_81f373859924653712ee97a256ad9b18" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_4f386e5b6a2ff5e8430f66414753eaf0" parent="aspace_81f373859924653712ee97a256ad9b18" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref969_grn" level="file">
+          <did>
+            <unittitle>Lance Carnes' letter about his typesetting services for DVI files 1988</unittitle>
+            <container id="aspace_dc6cd1e7d1c2d414a5d009da0ddaa1d6" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_7115f2fac0644905a713db3b9e10df31" parent="aspace_dc6cd1e7d1c2d414a5d009da0ddaa1d6" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref970_iyq" level="file">
+          <did>
+            <unittitle>Brochure from FTL systems 1987</unittitle>
+            <container id="aspace_f44fdc7e104a0d12ecee9aa61b542770" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_480c2fe6db5f6957cab3aac5d5ab0efd" parent="aspace_f44fdc7e104a0d12ecee9aa61b542770" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref971_3hu" level="file">
+          <did>
+            <unittitle>Paul M. Muller's letter and proposal for Chinese typesetting 1987</unittitle>
+            <container id="aspace_d9ae5983936f955ed9e34ed6317bb4f6" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_0cb9c7c557f97ce551ec3445ef15e179" parent="aspace_d9ae5983936f955ed9e34ed6317bb4f6" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref972_fg2" level="file">
+          <did>
+            <unittitle>FaSTeX flip card by Norman Paul 1986</unittitle>
+            <container id="aspace_1c02461537c39af96cd5458626321fe0" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_1aea09986f6b0c707888183e6ce8a163" parent="aspace_1c02461537c39af96cd5458626321fe0" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref973_o5w" level="file">
+          <did>
+            <unittitle>ST-TeX and ST-METAFONT from TOOLS GMBH, Bonn 1986</unittitle>
+            <container id="aspace_013896705adf41dfff30e914821d05c7" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_1e2812e5b80fb7dad8fd35881889df86" parent="aspace_013896705adf41dfff30e914821d05c7" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref974_kft" level="file">
+          <did>
+            <unittitle>The Publisher from ArborText, Inc. 1987</unittitle>
+            <container id="aspace_af86f40a1b901e13d8e7999e4d73461f" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_d4ca954921c621130bc9d4d3d5567b6b" parent="aspace_af86f40a1b901e13d8e7999e4d73461f" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref975_vnp" level="file">
+          <did>
+            <unittitle>Georgia Tobin's fonts (1980-1987):</unittitle>
+            <container id="aspace_c271b567b394f07e93590dad455f79f8" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_f7c65c85df014ec9394984617a70b1b2" parent="aspace_c271b567b394f07e93590dad455f79f8" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref976_h59" level="file">
+          <did>
+            <unittitle>Hebrew and Decorative</unittitle>
+            <container id="aspace_51911f4db7c2f966d6c66089ed7e99ff" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_21e3c0b5f77bc0409349ac76cba463bf" parent="aspace_51911f4db7c2f966d6c66089ed7e99ff" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_ref977_zsn" level="file">
+          <did>
+            <unittitle>Roman</unittitle>
+            <container id="aspace_06610a4c56d0818b662b4b65fe178e23" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_9598cfedbe2f0af8fbcbabbb331d322e" parent="aspace_06610a4c56d0818b662b4b65fe178e23" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_ref978_s4s" level="file">
+          <did>
+            <unittitle>Chel</unittitle>
+            <container id="aspace_7d3c0255e6be14475ca4806e6aa79139" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_1018f49458abefc358ea793c37e2028f" parent="aspace_7d3c0255e6be14475ca4806e6aa79139" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_ref979_k9f" level="file">
+          <did>
+            <unittitle>Slavic</unittitle>
+            <container id="aspace_4059ebbb6ed469be4a69f990bd9b072b" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_349f7d40500f53f22d3891f7e9af6e94" parent="aspace_4059ebbb6ed469be4a69f990bd9b072b" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_ref980_4no" level="file">
+          <did>
+            <unittitle>M. D. Spivak, Mathtime fonts (PostScript Times Roman and Italic for mathematics)</unittitle>
+            <container id="aspace_12696697a2c64154dbe7de038e4c5f94" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_9272b9124f425482092ef45b89e8d049" parent="aspace_12696697a2c64154dbe7de038e4c5f94" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref981_d0e" level="file">
+          <did>
+            <unittitle>Douglas Henderson, pcMF manual (for the METAFONT system to accompany pcTeX)</unittitle>
+            <container id="aspace_e6aaec349c5e01d1b2c73eee0856def4" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_b246ba1c03d024566f75c05a01adeddf" parent="aspace_e6aaec349c5e01d1b2c73eee0856def4" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref982_c5n" level="file">
+          <did>
+            <unittitle>Scientific Word and Scientific WorkPlace, from TCI Software Research</unittitle>
+            <container id="aspace_025980b051199e6b01fb0607186b2cfa" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_33679137493dfa49c65d4c600bbf5385" parent="aspace_025980b051199e6b01fb0607186b2cfa" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref983_pq2" level="file">
+          <did>
+            <unittitle>NAR Associates: Mathematical, scientific, and historical typesetting</unittitle>
+            <container id="aspace_0839351ec0a70f1b62a09cc3259a2964" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_81a9040525657f79534130f6a2d07f84" parent="aspace_0839351ec0a70f1b62a09cc3259a2964" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref984_nlm" level="file">
+          <did>
+            <unittitle>Blue Sky Research brochures (1989-1995)</unittitle>
+            <container id="aspace_f502b5b593fb0e7bc7a5ac475a729653" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_155f6d62fc66c9f5c83b0c20c4a8b485" parent="aspace_f502b5b593fb0e7bc7a5ac475a729653" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_ref985_jbg" level="file">
+          <did>
+            <unittitle>Projective Solutions on converting bitmap fonts to outline fonts</unittitle>
+            <container id="aspace_97ca81e8ab8ce26b2339f364609b263d" label="Mixed Materials [aspace.536457.box.6]" type="Box">6</container>
+            <container id="aspace_bfd74aa3da494fdb065b59e72c94554a" parent="aspace_97ca81e8ab8ce26b2339f364609b263d" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_ref986_2qe" level="file">
+          <did>
+            <unittitle>Books and publications using TeX and/or METAFONT</unittitle>
+          </did>
+          <c id="aspace_ref987_9w8" level="file">
+            <did>
+              <unittitle>Robert Messer. Introduction to Topology 1981 (first TeX use at Vanderbilt University)</unittitle>
+              <container id="aspace_0f73365f77a43db69f503acd0bb753b3" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref988_wvb" level="file">
+            <did>
+              <unittitle>Canzii, Lucarella, &amp; Pilenga. TeX: Primo rapporto. Milano, 1981</unittitle>
+              <container id="aspace_17d3169fa1e5631689f4de1640435511" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref989_ezz" level="file">
+            <did>
+              <unittitle>Philosophie de la recherche pedagogique en Suede (first TeX book in Sweden)</unittitle>
+              <container id="aspace_accbc1408aa6bc7cb4eb6e22cf6e0d9a" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref990_yg8" level="file">
+            <did>
+              <unittitle>Lecture Notes in Physics 189, 1983 (first book in TeX in Mexico)</unittitle>
+              <container id="aspace_c830b671a6c9bf0367e1fd11954f16da" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref991_79m" level="file">
+            <did>
+              <unittitle>Arthur Keller. Programmare in PASCAL 1984 (first book in TeX in Italy)</unittitle>
+              <container id="aspace_025513e12d5ed66b83068ad15907f2b3" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref992_4pp" level="file">
+            <did>
+              <unittitle>Middle East Studies Association Bulletin 18, 1984 (their switch to TeX)</unittitle>
+              <container id="aspace_183b1c63044681bddc00ea308dbf96f2" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref993_gzw" level="file">
+            <did>
+              <unittitle>The Political Economy of Saudi Arabia 1984 (early use of Computer Modern)</unittitle>
+              <container id="aspace_a9ad121dc54f50d4147a1405e4f602f3" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref994_e4w" level="file">
+            <did>
+              <unittitle>Walter Gander. Computer Mathematik 1985. (first Book in TeX in Switzerland)</unittitle>
+              <container id="aspace_5e2c757fc09ca4a25fbbd11f86b697d5" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref995_ffo" level="file">
+            <did>
+              <unittitle>D\'esarm\'enien. La division par ordinateur des nots francais 1986</unittitle>
+              <container id="aspace_a2fa7b93ee960e3491ed92e20908222d" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref996_20f" level="file">
+            <did>
+              <unittitle>TeX in Osnabr\'uck 1986</unittitle>
+              <container id="aspace_6eac22a587c27b63a5ab9afce3722587" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref997_p69" level="file">
+            <did>
+              <unittitle>Tsunetoshi Hayashi. Guide to TeX implementation at Hokkaido University 1986</unittitle>
+              <container id="aspace_b8a3b9f7210ed74ed0becc3a05b147fd" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref998_vy1" level="file">
+            <did>
+              <unittitle>Tsunetoshi Hayashi. Improvement of DVIwrite for Japanese text</unittitle>
+              <container id="aspace_68da2087fd50ed73a38be45dbec6d3ff" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref999_ld6" level="file">
+            <did>
+              <unittitle>NRL Memo 6044. TeXing the Formulary 1987 (shows TeX input, formulas output)</unittitle>
+              <container id="aspace_db85bc339860c0dd49134f5a5b6f9476" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1000_jxg" level="file">
+            <did>
+              <unittitle>Spivak's T2D4: Tables to Die For 1987 (with illustrations by Duane Bibby)</unittitle>
+              <container id="aspace_ce6033428eb54a31193128021e67d299" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1001_lj3" level="file">
+            <did>
+              <unittitle>Borde. An absolute beginner's guide to using TeX 1987</unittitle>
+              <container id="aspace_dcb3dc1d074bf446ba2e1abebd37ad0c" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1002_ybe" level="file">
+            <did>
+              <unittitle>Miguel Navarro Saad. Aztec calendar formatted with TeX macros 1987</unittitle>
+              <container id="aspace_b8e016219ba18038c773b892cc7e0a1a" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1003_tvr" level="file">
+            <did>
+              <unittitle>ABC om TeX og LsTeX n.d. (from computer center at Oslo University)</unittitle>
+              <container id="aspace_c2e3820c4a1bf93c04d3fa9f5f293df5" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1004_n3j" level="file">
+            <did>
+              <unittitle>Lokale utvidelser I TeX ved USEs VAX-cluster 1988 (Oslo University)</unittitle>
+              <container id="aspace_12bcf883c36633a1e5719d696f6d7457" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1005_zrf" level="file">
+            <did>
+              <unittitle>Nobuo Saito. Sample pages of Japanese translation of the TeXbook 1988</unittitle>
+              <container id="aspace_9e1ba909a008199cb4ad52693c382920" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1006_bpa" level="file">
+            <did>
+              <unittitle>Peter Bruun. PiTeX: A graphical editor for pictures in LaTeX 1988</unittitle>
+              <container id="aspace_25614fe7091f9d108063be9db6c59704" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1007_dwd" level="file">
+            <did>
+              <unittitle>Maarten van Emden. Slitex-sized poems for font freaks 1989</unittitle>
+              <container id="aspace_b69dd867f76bbf6c0eb34e62c5ea708b" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1008_eyi" level="file">
+            <did>
+              <unittitle>Sherry P. Ketterer. TeXnical typesetting 1989 (by a secretary for secretaries)</unittitle>
+              <container id="aspace_14a835470033c314d2740def2d18b875" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1009_ydv" level="file">
+            <did>
+              <unittitle>Kim Kubik. Bibliography of publications related to TeX and METAFONT 1990</unittitle>
+              <container id="aspace_851eaab089a0b21f2d5b1cb3b3047158" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1010_p0f" level="file">
+            <did>
+              <unittitle>User manual for Japanese TeX 1990</unittitle>
+              <container id="aspace_5af8297c646398a1377dd4604f0961c8" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1011_fz8" level="file">
+            <did>
+              <unittitle>Sandra Wimbish. Introduction to Pagu 1991 (interlinear texts done with TeX)</unittitle>
+              <container id="aspace_024ab719a217d20c51d700708d2cc586" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1012_ara" level="file">
+            <did>
+              <unittitle>Charles Bortle. Poetry books done on his PC 1991</unittitle>
+              <container id="aspace_3ecefaa8e4e9386100f6f6a019e1f535" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1013_wla" level="file">
+            <did>
+              <unittitle>Kai Borre. Mindste Kvadraters Princip 1992 (Danish book using AMS Euler)</unittitle>
+              <container id="aspace_86d362e815cca99357bf55325dcf005b" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1014_79j" level="file">
+            <did>
+              <unittitle>ASCII Corporation PC software for TeX 1992 (for Japanese texts)</unittitle>
+              <container id="aspace_c6489dbceb07d69ceeb5f3df1d89968d" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1015_cwx" level="file">
+            <did>
+              <unittitle>Vzgliahi na dom svoi, Pytnik! (one of several Russian novels published in New York)</unittitle>
+              <container id="aspace_cc4d9b5f2edd1ac04ba90b2e7b2595d1" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1016_doa" level="file">
+            <did>
+              <unittitle>Programmirovanie 1992 (Russian technical journal typeset in TeX)</unittitle>
+              <container id="aspace_e258b24e3f2d16216f050ac1f21cdd44" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1017_7wp" level="file">
+            <did>
+              <unittitle>Mnogoiazychnyi LaTeX 1993 (one of many Czech publications in TeX/METAFONT)</unittitle>
+              <container id="aspace_e428d97e05de4befd6cd14374e438f65" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1018_wz6" level="file">
+            <did>
+              <unittitle>Magicke rostliny 1994 ("Multilingual LaTeX")</unittitle>
+              <container id="aspace_976fdf07469d9bc89110143b419d2735" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1019_fpk" level="file">
+            <did>
+              <unittitle>Shinsaku Fujita. Examples of chemical formulas typeset with XuMTeX 1992-1995</unittitle>
+              <container id="aspace_b663778e11840051051e469d34419fcf" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1020_rns" level="file">
+            <did>
+              <unittitle>W{\l}odek Byzl. Plain TeX 1995 (literate programming applied to TeX macros)</unittitle>
+              <container id="aspace_bc2cb3db87b241246270357fbab6ebc3" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1021_cfd" level="file">
+            <did>
+              <unittitle>Yannis Haralambous. METAFONT improves on multiple master fonts. Preprint, 1995</unittitle>
+              <container id="aspace_44d2e53128a9772d53f9e43391bfeb8c" label="Mixed Materials [aspace.536457.box.7]" type="Box">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1022_f23" level="file">
+            <did>
+              <unittitle>Samples by Gloria Stuart and Ward Ritchie 1994</unittitle>
+              <container id="aspace_924e36c740476700e0a109a1633c4051" label="Mixed Materials [aspace.536457.box.8]" type="Box">8</container>
+            </did>
+          </c>
+        </c>
+      </c>
+      <c id="aspace_ref10_7xf" level="series">
+        <did>
+          <unittitle>Addenda, 1996-148 (GraphBase project records)</unittitle>
+          <unitid>Accession ARCH-1996-148</unitid>
+        </did>
+        <scopecontent id="aspace_ed2745157f83b407f6fa7e4506520d26">
+          <head>Scope and Contents note</head>
+          <p>Material from the making of <title render="italic" type="simple">The Stanford GraphBase</title>, a book published by ACM Press and Addison-Wesley Publishing Company in 1993. It includes the notes I made to myself and to Stanford students during the 20-year period I was compiling material for that book. The book is based on a series of interesting computer programs and interesting data from which many experiments in computer science have been made; I expect many additional researches to be based on this system in the years to come, because experimental computer science is expanding rapidly. The book itself was named the Best New Book in Computer Science by the Association of American Publishers in 1994.</p>
+        </scopecontent>
+        <c id="aspace_ref12_236" level="file">
+          <did>
+            <unittitle>Notes from student meetings of the GraphBase Project</unittitle>
+            <container id="aspace_90b0f98fb436d9f4ac92560312f11308" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref13_nz2" level="file">
+          <did>
+            <unittitle>GB_BOOKS: Novels and when their characters meet</unittitle>
+            <container id="aspace_04d7be5f7514f866403ec88886be0ccb" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref14_hwp" level="file">
+          <did>
+            <unittitle>GB_ECON: Input-output data for the US economy</unittitle>
+            <container id="aspace_5eb0f139ff475fa35df1dde2ca9f7e51" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref15_j86" level="file">
+          <did>
+            <unittitle>GB_GAMES: College football scores</unittitle>
+            <container id="aspace_617ee4d413c12d58753ceda8615ea936" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref16_uy0" level="file">
+          <did>
+            <unittitle>GB_LISA: Pixels of Mona Lisa</unittitle>
+            <container id="aspace_f70512314254439347d6590468a28b1e" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref17_2ta" level="file">
+          <did>
+            <unittitle>GB_MILES: Highway distances between US cities</unittitle>
+            <container id="aspace_8116fbca82617cfd16e8c33896d17018" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref18_ggv" level="file">
+          <did>
+            <unittitle>GB_ROGET: Thesaurus cross-reference</unittitle>
+            <container id="aspace_e6b29e05ed23d98fdb1f2f0000fb2ea0" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref19_bt7" level="file">
+          <did>
+            <unittitle>GB_WORDS: Five-letter words of English</unittitle>
+            <container id="aspace_30e596ff6194079db1fbbda89e273030" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref20_he8" level="file">
+          <did>
+            <unittitle>Pencil draft of the book manuscript, except for the programs</unittitle>
+            <container id="aspace_d1b7f6d83cf5a20318850a6462652ea9" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref21_f8n" level="file">
+          <did>
+            <unittitle>First typeset draft of the GraphBase programs (August 1992)</unittitle>
+            <container id="aspace_e3208a69ab2b4435f3bca5befcd72350" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref22_cah" level="file">
+          <did>
+            <unittitle>Second typeset draft of the entire book (March 1993)</unittitle>
+            <container id="aspace_3e441cb95d3f5e5d526b313baff9b37f" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref23_si1" level="file">
+          <did>
+            <unittitle>Copy editor's remarks (June 1993)</unittitle>
+            <container id="aspace_2a3b41e2e4e6af40c0f3b2255fc724d4" label="Mixed Materials [aspace.536652.box.1]" type="Box">1</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_ref24_kgz" level="series">
+        <did>
+          <unittitle>Addenda, 1998-154 (videorecordings)</unittitle>
+          <unitid>Accession ARCH-1998-154</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <scopecontent id="aspace_f655325386fadfb1572ccaa355186e04">
+          <head>Scope and Contents</head>
+          <p>Computer Science 209, Mathematical Writing, lectures</p>
+        </scopecontent>
+        <c id="aspace_ref25_00v" level="file">
+          <did>
+            <unitid>174.1</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Sep 30</unitdate>
+            <physdesc id="aspace_8e2dc7cd9944b1579c872e5ca1116942" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_a17adace46f33b06ddd7247019bb66d4" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref27_tle" level="file">
+          <did>
+            <unitid>174.2</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 2</unitdate>
+            <physdesc id="aspace_4776b0a71d5a5ab74cbaaa34cb848b29" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_be031767da92e4979e1d5d86a441fe57" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref29_uye" level="file">
+          <did>
+            <unitid>174.3</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 5</unitdate>
+            <physdesc id="aspace_422dfc816a40d14a3c7a3e939678195b" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_b2c050021fc0a39c98fc4dc2fe45d3e6" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref31_87i" level="file">
+          <did>
+            <unitid>174.4</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 7</unitdate>
+            <physdesc id="aspace_c4c70d98f785d4044b5c78d4474f2427" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_4384a4c6c41ae84805327d258062cf6c" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_ref33_thm" level="file">
+          <did>
+            <unitid>174.5</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 9</unitdate>
+            <physdesc id="aspace_b7fe9fb41e8169f8fb834d1e0a9b4f23" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_ac850351d22bfe1385df76c5ada00cd2" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="vz772ry6707" xlink:show="new" xlink:title="Comments on student answers (2)" xlink:type="simple">
+              <daodesc>
+                <p>Comments on student answers (2): 10/19/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref35_hw3" level="file">
+          <did>
+            <unitid>174.6</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 12</unitdate>
+            <physdesc id="aspace_0493502f73522b7169c006d17afb0ce9" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_6a36163b2bd59e24d070504a935dec3b" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="zc892pd6364" xlink:show="new" xlink:title="Preparing books for publication (1)" xlink:type="simple">
+              <daodesc>
+                <p>Preparing books for publication (1): 10/12/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref37_j2a" level="file">
+          <did>
+            <unitid>174.7</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 14</unitdate>
+            <physdesc id="aspace_8f66848ae414e28f9700b1605de4d687" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_c5528d26b4234202d696f0cdb37c8f25" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="qq030pn8958" xlink:show="new" xlink:title="Preparing books for publication (2)" xlink:type="simple">
+              <daodesc>
+                <p>Preparing books for publication (2): 10/14/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref39_o3u" level="file">
+          <did>
+            <unitid>174.8</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 16</unitdate>
+            <physdesc id="aspace_941e209f14c53052eb86b69b261b695b" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_a464edd6aae59a32692fbe09fb353db8" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="jp131ht4213" xlink:show="new" xlink:title="Preparing books for publication (3)" xlink:type="simple">
+              <daodesc>
+                <p>Preparing books for publication (3): 10/16/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref41_c9m" level="file">
+          <did>
+            <unitid>174.9</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 19</unitdate>
+            <physdesc id="aspace_b7641feb2b7eab785af906d061cb2320" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_f9f14a0e042cd101a0e037050ebd4afd" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="nk311nk9097" xlink:show="new" xlink:title="Herbert Wilf, guest lecturer, Presenting Algorithms" xlink:type="simple">
+              <daodesc>
+                <p>Herbert Wilf, guest lecturer, Presenting Algorithms: 10/19/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref43_obo" level="file">
+          <did>
+            <unitid>174.1</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 21</unitdate>
+            <physdesc id="aspace_d032abeeac656f6e9b033e5a5bbf42a1" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_9abd59d3622753251753da24ebc9ccbb" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="wm094dx1354" xlink:show="new" xlink:title="Literate Programming (1)" xlink:type="simple">
+              <daodesc>
+                <p>Literate Programming (1): 10/21/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref45_0x3" level="file">
+          <did>
+            <unitid>174.11</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 23</unitdate>
+            <physdesc id="aspace_c1fc949327b9d5c31772dca0ccacbbc6" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_174efe86afd9f327c01a40d1bd89822b" label="Mixed Materials [aspace.536665.box.1]" type="Box">1</container>
+            <dao xlink:actuate="onRequest" xlink:href="dz766qx7300" xlink:show="new" xlink:title="Literate Programming (2)" xlink:type="simple">
+              <daodesc>
+                <p>Literate Programming (2): 10/23/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref47_qtl" level="file">
+          <did>
+            <unitid>174.12</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 26</unitdate>
+            <physdesc id="aspace_a90a1fe56ce7597eb70b728ddcbdac7f" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_1d24e7a6a467886ffde37b3b16788a28" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="nj866sq1701" xlink:show="new" xlink:title="User manuals; Galley proofs" xlink:type="simple">
+              <daodesc>
+                <p>User manuals; Galley proofs: 10/26/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref49_ivs" level="file">
+          <did>
+            <unitid>174.13</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 28</unitdate>
+            <physdesc id="aspace_6920e57d9f8fff3ebaf089e1cfcef532" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_df39261e3ec62364cbbc7016c9e13245" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="wk108jg0236" xlink:show="new" xlink:title="Herb Wilf, guest lecturer, on Mathematical Writing" xlink:type="simple">
+              <daodesc>
+                <p>Herb Wilf, guest lecturer, on Mathematical Writing: 10/28/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+          <scopecontent id="aspace_d050d6afadce28c1a457f1fa7e5ebaf7">
+            <head>Scope and Contents note</head>
+            <p>Herbert Wilf, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref52_2fr" level="file">
+          <did>
+            <unitid>174.14</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Oct 30</unitdate>
+            <physdesc id="aspace_19aa90dc66e0f09b1b22cf4dedbe57b3" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_0b51267bd5b2e4dedfc4d378d2820dee" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="gh283xp3302" xlink:show="new" xlink:title="Refereeing (1)" xlink:type="simple">
+              <daodesc>
+                <p>Refereeing (1): 10/30/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref54_7tc" level="file">
+          <did>
+            <unitid>174.15</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 2</unitdate>
+            <physdesc id="aspace_3a6e660bfde770471cdc4603c87f7808" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_b14dc4ac680da113dcb1d191cce7e554" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="fm813sn1247" xlink:show="new" xlink:title="Refereeing (2)" xlink:type="simple">
+              <daodesc>
+                <p>Refereeing (2): 11/2/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref56_dw7" level="file">
+          <did>
+            <unitid>174.16</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 4</unitdate>
+            <physdesc id="aspace_ccd40fcdd01d552508335e4216c1fb52" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_5bea96a6965fdf231eac8e9397b49a31" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="jk140rb5123" xlink:show="new" xlink:title="Illustrations (1)" xlink:type="simple">
+              <daodesc>
+                <p>Illustrations (1): 11/4/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref58_jtj" level="file">
+          <did>
+            <unitid>174.17</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 6</unitdate>
+            <physdesc id="aspace_4ad2f2cf521ff8cf56dfb590803a0b27" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_12b16f2a3cd4ddb669e2c7afa8f3b43f" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="wp507cs5053" xlink:show="new" xlink:title="Illustrations (2)" xlink:type="simple">
+              <daodesc>
+                <p>Illustrations (2): 11/6/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref60_007" level="file">
+          <did>
+            <unitid>174.18</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 9</unitdate>
+            <physdesc id="aspace_b43dc10d0556a131cb652cfb766c9387" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_b277c6885dee375aa67b237a21ddd14b" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="fx096jt0817" xlink:show="new" xlink:title="Quotations" xlink:type="simple">
+              <daodesc>
+                <p>Quotations: 11/9/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref62_3cy" level="file">
+          <did>
+            <unitid>174.19</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 11</unitdate>
+            <physdesc id="aspace_b0d4a4cb4487308152565a66e7ad2000" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_7bd7913b06e844dbd224f94e4a8afc9f" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="zy951my9502" xlink:show="new" xlink:title="Scientific American Saga (1)" xlink:type="simple">
+              <daodesc>
+                <p>Scientific American Saga (1): 11/11/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref64_z5c" level="file">
+          <did>
+            <unitid>174.2</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 13</unitdate>
+            <physdesc id="aspace_daea4db1d03986d570f20ca9be611627" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_edb6ee59d35d697015236819d36de8e9" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="jm961br5182" xlink:show="new" xlink:title="Scientific American Saga (2)" xlink:type="simple">
+              <daodesc>
+                <p>Scientific American Saga (2): 11/13/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref66_5tl" level="file">
+          <did>
+            <unitid>174.21</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 16</unitdate>
+            <physdesc id="aspace_2517a31305637703982355df951c9117" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_548ea6bc1045e273888297fa89cd80e3" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="tn649sn9436" xlink:show="new" xlink:title="Examples of good style" xlink:type="simple">
+              <daodesc>
+                <p>Examples of good style: 11/16/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref68_cnf" level="file">
+          <did>
+            <unitid>174.22</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 18</unitdate>
+            <physdesc id="aspace_0b48dfd056c88698ab54848f95a17c89" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_0d6bf3dab952b0752a2ff7ee0fefce38" label="Mixed Materials [aspace.536665.box.2]" type="Box">2</container>
+            <dao xlink:actuate="onRequest" xlink:href="dr285dt6689" xlink:show="new" xlink:title="Jeff Ullman, guest lecturer, on Getting Rich" xlink:type="simple">
+              <daodesc>
+                <p>Jeff Ullman, guest lecturer, on Getting Rich: 11/18/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+          <scopecontent id="aspace_f13631f2741dcdbc4e3c07c3c075c9d0">
+            <head>Scope and Contents note</head>
+            <p>Jeff Ullman, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref71_c3f" level="file">
+          <did>
+            <unitid>174.23</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 20</unitdate>
+            <physdesc id="aspace_fc21f4308eb07415e8c075acfcdd0490" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_da2a4a39edee051116d0d290a0000f2b" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="kb402tt3652" xlink:show="new" xlink:title="Leslie Lamport, guest professor, on Writing Papers" xlink:type="simple">
+              <daodesc>
+                <p>Leslie Lamport, guest professor, on Writing Papers: 11/20/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+          <scopecontent id="aspace_0dc3ca69a4bd55065ea9412d9a6b2532">
+            <head>Scope and Contents note</head>
+            <p>Leslie Lamport, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref74_lf3" level="file">
+          <did>
+            <unitid>174.24</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 23</unitdate>
+            <physdesc id="aspace_2a0066896116988bec031b3e7148b424" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_f85fb2e30f9b23c78ba84c7b6d329ea7" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="pr907vp0860" xlink:show="new" xlink:title="Nils Nilsson, guest lecturer, on Art and Writing" xlink:type="simple">
+              <daodesc>
+                <p>Nils Nilsson, guest lecturer, on Art and Writing: 11/23/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+          <scopecontent id="aspace_cbb507743f9e1af249ecd92d57d210e0">
+            <head>Scope and Contents note</head>
+            <p>Nils Nilsson, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref77_hxl" level="file">
+          <did>
+            <unitid>174.25</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 25</unitdate>
+            <physdesc id="aspace_49ff022166408510eacbe6a3a321c246" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_d7397b6160db0cde260934d203eec3ae" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+          </did>
+          <scopecontent id="aspace_adb189415b55d866687fdd54a0905c7b">
+            <head>Scope and Contents note</head>
+            <p>Mary-Claire van Leunen, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref80_jhz" level="file">
+          <did>
+            <unitid>174.26</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Nov 30</unitdate>
+            <physdesc id="aspace_ef25870323c3bd340c33e61d42a67843" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_f3cfcec1f0cc4bf35dc3b6b4c00b3ccc" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="pb902pd8527" xlink:show="new" xlink:title="Comments on student work" xlink:type="simple">
+              <daodesc>
+                <p>Comments on student work: 11/30/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref82_orc" level="file">
+          <did>
+            <unitid>174.27</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Dec 2</unitdate>
+            <physdesc id="aspace_1e7d361225384f914e6d850e65f23678" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_6e771d694791441a0957e1aff1e6f552" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+          </did>
+          <scopecontent id="aspace_71d43db740a1ec7791c7f5f144248ba9">
+            <head>Scope and Contents note</head>
+            <p>Mary-Claire van Leunen, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref85_5io" level="file">
+          <did>
+            <unitid>174.28</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Dec 4</unitdate>
+            <physdesc id="aspace_73453cbb7f192b5e5e55bd376863f8e3" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_ed1369b3432225ec60305e111f1b64f6" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="hy906py0979" xlink:show="new" xlink:title="Computer aids to writing" xlink:type="simple">
+              <daodesc>
+                <p>Computer aids to writing: 12/4/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+        <c id="aspace_ref87_h5s" level="file">
+          <did>
+            <unitid>174.29</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Dec 7</unitdate>
+            <physdesc id="aspace_acf22969db6e638cba2dab3f8c98f3bb" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_be99f03f2d9d0248f9976f13241db56b" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="cd985ys2315" xlink:show="new" xlink:title="Rosalie Stemer, guest lecturer, on Copy Editing" xlink:type="simple">
+              <daodesc>
+                <p>Rosalie Stemer, guest lecturer, on Copy Editing: 12/7/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+          <scopecontent id="aspace_c32d619f06740de6e6fbfd60c1757f57">
+            <head>Scope and Contents note</head>
+            <p>Rosalie Stemer, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref90_den" level="file">
+          <did>
+            <unitid>174.3</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Dec 9</unitdate>
+            <physdesc id="aspace_01a0c4676ac89b0429afa7ec463d44b7" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_1e2f4e4acb9799068a8923851d410baf" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="dq911sr5598" xlink:show="new" xlink:title="Paul Halmos, guest lecturer, on Mathematical Writing" xlink:type="simple">
+              <daodesc>
+                <p>Paul Halmos, guest lecturer, on Mathematical Writing: 12/9/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+          <scopecontent id="aspace_3db87fba1f68982f71d8e6ade9bf85df">
+            <head>Scope and Contents note</head>
+            <p>Paul Halmos, guest lecturer</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref93_smm" level="file">
+          <did>
+            <unitid>174.31</unitid>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1987 Dec 11</unitdate>
+            <physdesc id="aspace_bb7e6f873049f5fbf8c6838d8337d153" label="General Physical Description note">
+              <extent>videotape (VHS)</extent>
+            </physdesc>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_4af3a216f66bd5fd60068534953e36bc" label="Mixed Materials [aspace.536665.box.3]" type="Box">3</container>
+            <dao xlink:actuate="onRequest" xlink:href="xt754qk1584" xlink:show="new" xlink:title="Final truths" xlink:type="simple">
+              <daodesc>
+                <p>Final truths: 12/11/1987</p>
+              </daodesc>
+            </dao>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_49d1b931fd860e8fb738b47930170522" level="series">
+        <did>
+          <unittitle>Addenda, 1999-102</unittitle>
+          <unitid>Accession ARCH-1999-102</unitid>
+        </did>
+        <c id="aspace_ref9_2n7" level="file">
+          <did>
+            <unittitle>Burroughs Corporation. Lectures on Software Design by Donald E. Knuth (photocopy), along with a computer printout: Q &amp; D Version of Classroom Assembly Program</unittitle>
+            <unitdate calendar="gregorian" datechar="creation" era="ce">1964 Fall</unitdate>
+            <container id="aspace_a840a3927a940805320513cdc6b4f2a9" label="Mixed Materials [aspace.536064.box.1]" type="Box">1</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_ref531_7ep" level="series">
+        <did>
+          <unittitle>Addenda, 2001-078</unittitle>
+          <unitid>Accession ARCH-2001-078</unitid>
+        </did>
+        <scopecontent id="aspace_40034ae5543b3472247b67642e2a44b6">
+          <head>Scope and Contents note</head>
+          <p>Correspondence, drafts, galleys, and other materials pertaining to the following publications: Selected Papers in Computer Science, Digital Typography, Analysis of Algorithms, and MMIXware.</p>
+        </scopecontent>
+        <c id="aspace_ref533_5l8" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">Selected Papers in Computer Science</title>
+            </unittitle>
+          </did>
+          <c id="aspace_ref534_dh1" level="file">
+            <did>
+              <unittitle>Correspondence</unittitle>
+              <unitdate datechar="creation">1995-2000</unitdate>
+              <container id="aspace_b2ba6cb035d1026eea5ca1c02eb7d989" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_35de66c107b75519a12d79e9c7f680c1" parent="aspace_b2ba6cb035d1026eea5ca1c02eb7d989" type="folder">1 (CS1)</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref535_3eq" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">Digital Typography</title>
+            </unittitle>
+          </did>
+          <c id="aspace_ref536_gs8" level="file">
+            <did>
+              <unittitle>Correspondence, 1994-2000</unittitle>
+              <container id="aspace_a73886920594c53f97f01dce535008c0" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_393df93d9ef307bd949a1987f9cfe53f" parent="aspace_a73886920594c53f97f01dce535008c0" type="folder">2 (DT1)</container>
+            </did>
+          </c>
+          <c id="aspace_ref537_ewl" level="file">
+            <did>
+              <unittitle>Chapter 1: Digital Typography – drafts</unittitle>
+              <container id="aspace_3a4b079849402a47ef40449f4c75d4e8" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_b931e198a8dbb902184db2706a80a323" parent="aspace_3a4b079849402a47ef40449f4c75d4e8" type="folder">3 (DT2)</container>
+            </did>
+          </c>
+          <c id="aspace_ref538_eg5" level="file">
+            <did>
+              <unittitle>Chapter 2: Mathematical Typography – galleys and draft of addendum</unittitle>
+              <container id="aspace_4f3ff41629daeb0024ee004df2f67b06" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_292fc9c016947386072b401b04527bb3" parent="aspace_4f3ff41629daeb0024ee004df2f67b06" type="folder">4 (DT 3)</container>
+            </did>
+          </c>
+          <c id="aspace_ref539_a8x" level="file">
+            <did>
+              <unittitle>Chapter 3: Breaking Paragraphs into Lines – galleys</unittitle>
+              <container id="aspace_cec905c13e40d8cb8a090b0b0a474ebb" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_5ee43df17336f97c88a20459992d9879" parent="aspace_cec905c13e40d8cb8a090b0b0a474ebb" type="folder">5 (DT4)</container>
+            </did>
+          </c>
+          <c id="aspace_ref540_a80" level="file">
+            <did>
+              <unittitle>Chapter 4: Mixing Right-to-Left Texts with Left-To-Right Texts – galleys and proofs of illustrations</unittitle>
+              <container id="aspace_3cf2aceb4d8ef987ad43895f5cad012b" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_3a27daf9c7cd1eeb1ca7f2e8fe4d358f" parent="aspace_3cf2aceb4d8ef987ad43895f5cad012b" type="folder">6 (DT5)</container>
+            </did>
+          </c>
+          <c id="aspace_ref541_ej3" level="file">
+            <did>
+              <unittitle>Chapter 5: Recipes and Fractions – galleys and proofs of a "holly" font not used</unittitle>
+              <container id="aspace_273b73785fc84d9f568490ea84ed56e7" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_7b5d52e6cf3716edfb011f9f68b8cabc" parent="aspace_273b73785fc84d9f568490ea84ed56e7" type="folder">7 (DT6)</container>
+            </did>
+          </c>
+          <c id="aspace_ref542_dqo" level="file">
+            <did>
+              <unittitle>Chapter 6: The TeX Logo in Various Fonts – galleys</unittitle>
+              <container id="aspace_d819763bd883cb20318759aff1db7f6e" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_0c3eba94e138ae9b75103886521dbdd5" parent="aspace_d819763bd883cb20318759aff1db7f6e" type="folder">8 (DT7)</container>
+            </did>
+          </c>
+          <c id="aspace_ref543_0od" level="file">
+            <did>
+              <unittitle>Chapter 7: Printing Out Selected Pages – galleys and draft of addendum</unittitle>
+              <container id="aspace_59a4cffeef6802b5c777f64fdd62ecee" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ad2c797d22f960fd6ab996aba96347d8" parent="aspace_59a4cffeef6802b5c777f64fdd62ecee" type="folder">9 (DT8)</container>
+            </did>
+          </c>
+          <c id="aspace_ref544_jkl" level="file">
+            <did>
+              <unittitle>Chapter 8: Macros for Jill – galleys</unittitle>
+              <container id="aspace_fd1eff1bec5bf51a0965468fc00f9642" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_f195c5c24359df4e6f28c4f6256823f9" parent="aspace_fd1eff1bec5bf51a0965468fc00f9642" type="folder">10 (DT9)</container>
+            </did>
+          </c>
+          <c id="aspace_ref545_lux" level="file">
+            <did>
+              <unittitle>Chapter 9: Problem for a Saturday Morning – galleys</unittitle>
+              <container id="aspace_542b66143cd13f5a47d44d6132672a03" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_42771246a94cf6283206be1e640542bf" parent="aspace_542b66143cd13f5a47d44d6132672a03" type="folder">11 (DT10)</container>
+            </did>
+          </c>
+          <c id="aspace_ref546_i4p" level="file">
+            <did>
+              <unittitle>Chapter 10: Exercises for TeX: The program – galleys</unittitle>
+              <container id="aspace_40f2ae159b2aca6211e33d61ec0be4f7" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_b234096a94ce7c353aaf91027e873e03" parent="aspace_40f2ae159b2aca6211e33d61ec0be4f7" type="folder">12 (DT11)</container>
+            </did>
+          </c>
+          <c id="aspace_ref547_737" level="file">
+            <did>
+              <unittitle>Chapter 11: Mini-Indexes for Literate Programs – galleys</unittitle>
+              <container id="aspace_8e7be6789300a772fd35a9856aa01631" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_9f697495918bf35db34aad4397cb15cd" parent="aspace_8e7be6789300a772fd35a9856aa01631" type="folder">13 (DT12)</container>
+            </did>
+          </c>
+          <c id="aspace_ref548_ad4" level="file">
+            <did>
+              <unittitle>Chapter 12: Virtual Fonts – galleys</unittitle>
+              <container id="aspace_1b4755cdfd412ef02b6aacc1eea1c579" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_74ad4a640ccf57676ac7ae1cc9a7b7c0" parent="aspace_1b4755cdfd412ef02b6aacc1eea1c579" type="folder">14 (DT13)</container>
+            </did>
+          </c>
+          <c id="aspace_ref549_agq" level="file">
+            <did>
+              <unittitle>Chapter 13: The Letter S – galleys and draft of addendum</unittitle>
+              <container id="aspace_65c5fcdc9347d20990eb542041bef10a" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_6be17190662917628c47bca81365a37a" parent="aspace_65c5fcdc9347d20990eb542041bef10a" type="folder">15 (DT14)</container>
+            </did>
+          </c>
+          <c id="aspace_ref550_8tx" level="file">
+            <did>
+              <unittitle>Chapter 14: My First Experience with Indian Scripts – galleys and initial proof of Figure 1</unittitle>
+              <container id="aspace_bff7234ab73c505879930d5459e1ecf0" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ecfb682c9a918a4c789817af77e24a54" parent="aspace_bff7234ab73c505879930d5459e1ecf0" type="folder">16 (DT15)</container>
+            </did>
+          </c>
+          <c id="aspace_ref551_fkn" level="file">
+            <did>
+              <unittitle>Chapter 15: The Concept of a Meta-Font – galleys and initial proofs of two fonts</unittitle>
+              <container id="aspace_2c96c4620897767b8124ae2bf61632e1" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_d8a6f97e1b87db579aa74da522057044" parent="aspace_2c96c4620897767b8124ae2bf61632e1" type="folder">17 (DT16)</container>
+            </did>
+          </c>
+          <c id="aspace_ref552_c5t" level="file">
+            <did>
+              <unittitle>Chapter 16: Lessons Learned from METAFONT – galleys</unittitle>
+              <container id="aspace_f56cb6953f0dd99a4a3322c0e3d244ff" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_948a20bba2d0bda1bec8faeccd2c78b0" parent="aspace_f56cb6953f0dd99a4a3322c0e3d244ff" type="folder">18 (DT17)</container>
+            </did>
+          </c>
+          <c id="aspace_ref553_a0w" level="file">
+            <did>
+              <unittitle>Chapter 17: AMS Euler – A New Typeface for Mathematics – galleys, proofs of illustrations, and first proof of the typeface sample</unittitle>
+              <container id="aspace_848716a4fcf47655ed90f864f0c57333" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_70501fe26cc83585a76eecf032fe40f8" parent="aspace_848716a4fcf47655ed90f864f0c57333" type="folder">19 (DT18)</container>
+            </did>
+          </c>
+          <c id="aspace_ref554_chn" level="file">
+            <did>
+              <unittitle>Chapter 18: Typesetting Concrete Mathematics – galley proof</unittitle>
+              <container id="aspace_bdbf88a0feb646cb95861e802fcad4bf" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ba887bf584039bf0effb661fe4593c37" parent="aspace_bdbf88a0feb646cb95861e802fcad4bf" type="folder">20 (DT19)</container>
+            </did>
+          </c>
+          <c id="aspace_ref555_mau" level="file">
+            <did>
+              <unittitle>Chapter 19: A Course on METAFONT Programming – galleys and first proofs of illustrations</unittitle>
+              <container id="aspace_7ae45ba3a6e10a771265807c3259b161" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ea63ab2034c5e6ad544f76512667bc04" parent="aspace_7ae45ba3a6e10a771265807c3259b161" type="folder">21 (DT20)</container>
+            </did>
+          </c>
+          <c id="aspace_ref556_ti0" level="file">
+            <did>
+              <unittitle>Chapter 20: A Punk Meta-Font – galleys</unittitle>
+              <container id="aspace_b75b98bcd5f3b610a0cb67bfeb9e8dc9" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_a57784904e87acf411fb2ff609b8c728" parent="aspace_b75b98bcd5f3b610a0cb67bfeb9e8dc9" type="folder">22 (DT21)</container>
+            </did>
+          </c>
+          <c id="aspace_ref557_6rw" level="file">
+            <did>
+              <unittitle>Chapter 21: Fonts for Digital Halftones – galleys and some test pages supplied by the printer</unittitle>
+              <container id="aspace_7b62e9138ce89a7fcddc0f07c95ca29a" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_65bdb258cebb5e22a7fe4e168407b5f0" parent="aspace_7b62e9138ce89a7fcddc0f07c95ca29a" type="folder">23 (DT22)</container>
+            </did>
+          </c>
+          <c id="aspace_ref558_5em" level="file">
+            <did>
+              <unittitle>Chapter 22: Digital Halftones by Dot Diffusion – galleys</unittitle>
+              <container id="aspace_d2b29bdde78af071c470a5ef8ce73653" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_f5949411bc3965958e0e08817cd3cee7" parent="aspace_d2b29bdde78af071c470a5ef8ce73653" type="folder">24 (DT23)</container>
+            </did>
+          </c>
+          <c id="aspace_ref559_vz4" level="file">
+            <did>
+              <unittitle>Chapter 23: A Note on Digitized Angles – galleys</unittitle>
+              <container id="aspace_7e57d94a49bc29d41f06e90f73769edf" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_cf973fe11ba6833fbb4b289c1a8d08d8" parent="aspace_7e57d94a49bc29d41f06e90f73769edf" type="folder">25 (DT24)</container>
+            </did>
+          </c>
+          <c id="aspace_ref560_t20" level="file">
+            <did>
+              <unittitle>Chapter 24: TEXDR.AFT – Knuth's trial proof dated 14 June 1998</unittitle>
+              <container id="aspace_78612dd4d57e83c76f2a90806489d660" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ab15d5e5ac151f960d5d5c5c4a1c86a2" parent="aspace_78612dd4d57e83c76f2a90806489d660" type="folder">26 (DT25)</container>
+            </did>
+          </c>
+          <c id="aspace_ref561_d84" level="file">
+            <did>
+              <unittitle>Chapter 25: TEX.ONE – Knuth's trial proof dated 14 June 1998</unittitle>
+              <container id="aspace_2be9e5acb35efe383846db096d9a1e56" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_c3ffcdbab2a3616d481b0f32c052a3ce" parent="aspace_2be9e5acb35efe383846db096d9a1e56" type="folder">27 (DT26)</container>
+            </did>
+          </c>
+          <c id="aspace_ref562_xnp" level="file">
+            <did>
+              <unittitle>Chapter 26: TeX Incunabula – galleys</unittitle>
+              <container id="aspace_8eac67d79812f98a0bacf1b73348cf7c" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_b98ca69753a5c1908f1c05186520efcf" parent="aspace_8eac67d79812f98a0bacf1b73348cf7c" type="folder">28 (DT27)</container>
+            </did>
+          </c>
+          <c id="aspace_ref563_qe6" level="file">
+            <did>
+              <unittitle>Chapter 27: Icons for TeX and METAFONT – galleys</unittitle>
+              <container id="aspace_b8fc84e18066936ced787c9d738265a8" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_05cf77fb84ceb5f7fd7a5853fc9797b6" parent="aspace_b8fc84e18066936ced787c9d738265a8" type="folder">29 (DT28)</container>
+            </did>
+          </c>
+          <c id="aspace_ref564_dbt" level="file">
+            <did>
+              <unittitle>Chapter 28: Computers and Typesetting – galleys and draft of new material</unittitle>
+              <container id="aspace_c7fa42f556d11a20f9f80566ef80f071" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_5249b6820b62bb398773d0344fa07412" parent="aspace_c7fa42f556d11a20f9f80566ef80f071" type="folder">30 (DT29)</container>
+            </did>
+          </c>
+          <c id="aspace_ref565_nvd" level="file">
+            <did>
+              <unittitle>Chapter 29: The New Versions of TeX and METAFONT – galleys</unittitle>
+              <container id="aspace_2709744be1edd27383202891750c38fb" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_5e836be75d5a599b60465a13d6a50773" parent="aspace_2709744be1edd27383202891750c38fb" type="folder">31 (DT30)</container>
+            </did>
+          </c>
+          <c id="aspace_ref566_y8g" level="file">
+            <did>
+              <unittitle>Chapter 30: The Future of TeX and METAFONT – galleys</unittitle>
+              <container id="aspace_9b1986b73deb8e69a11cbf0f716fb8c3" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_e93eb77ccc635ce98a10c9ccdbdf31fb" parent="aspace_9b1986b73deb8e69a11cbf0f716fb8c3" type="folder">32 (DT31)</container>
+            </did>
+          </c>
+          <c id="aspace_ref567_jwo" level="file">
+            <did>
+              <unittitle>Chapter 31: Questions and Answers, I – galleys</unittitle>
+              <container id="aspace_5e80c420a4675d06745c963d6ed15162" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_c4bee293e5a41cb29538dae8ccb23468" parent="aspace_5e80c420a4675d06745c963d6ed15162" type="folder">33 (DT32)</container>
+            </did>
+          </c>
+          <c id="aspace_ref568_vr2" level="file">
+            <did>
+              <unittitle>Chapter 32: Questions and Answers, II – galleys</unittitle>
+              <container id="aspace_9b6f8dc1d858a4d7bc3d4de8f1272fbf" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_e20c0623a125604ea1967552551d9148" parent="aspace_9b6f8dc1d858a4d7bc3d4de8f1272fbf" type="folder">34 (DT33)</container>
+            </did>
+          </c>
+          <c id="aspace_ref569_cd5" level="file">
+            <did>
+              <unittitle>Chapter 33: Questions and Answers, III – galleys</unittitle>
+              <container id="aspace_1bdbb95b4c317f53e52fa2a15260aa38" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_8c03f905e0960d1a7589a4e50ff82f8b" parent="aspace_1bdbb95b4c317f53e52fa2a15260aa38" type="folder">35 (DT34)</container>
+            </did>
+          </c>
+          <c id="aspace_ref570_xvt" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. vii-65</unittitle>
+              <container id="aspace_a94e9e79ff9486cc056e456990625020" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_b9a792a6ed673eb7aff7badd06156819" parent="aspace_a94e9e79ff9486cc056e456990625020" type="folder">36 (DT35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref571_pln" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 67-155</unittitle>
+              <container id="aspace_2df7a234fa4cc66bd1d21cc8a7bc2ead" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_9bea2db4c250dc402ecf34df7c2c3786" parent="aspace_2df7a234fa4cc66bd1d21cc8a7bc2ead" type="folder">37 (DT35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref572_a2i" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 157-223</unittitle>
+              <container id="aspace_4467e6bfd98aa73d84a27ef4f1479cfb" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_33515b2a1fe9d95926f47d20eff78183" parent="aspace_4467e6bfd98aa73d84a27ef4f1479cfb" type="folder">38 (DT35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref573_xp4" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 225-313</unittitle>
+              <container id="aspace_19076494f0f97fa878be918261249077" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_99eb8b464ffe4f0904e7b915a1c14f6c" parent="aspace_19076494f0f97fa878be918261249077" type="folder">39 (DT35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref574_kri" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 315-414</unittitle>
+              <container id="aspace_4760df490745b9892272e79c845ce14a" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ffa072598712229a7de9c2d8ae376a4f" parent="aspace_4760df490745b9892272e79c845ce14a" type="folder">40 (DT35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref575_h0c" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 415-545</unittitle>
+              <container id="aspace_148006b86aa639a8b52df659e1ccc965" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_070cf8d7abdc1334dc7aa2f9c94cd575" parent="aspace_148006b86aa639a8b52df659e1ccc965" type="folder">41 (DT35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref576_0sg" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 547-end</unittitle>
+              <container id="aspace_71cf87b0eaaa01043e75c068eacc02ac" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_2162764279209ea8913477cc701567a5" parent="aspace_71cf87b0eaaa01043e75c068eacc02ac" type="folder">42 (DT35)</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref577_ghr" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">Analysis of Algorithms</title>
+            </unittitle>
+          </did>
+          <c id="aspace_ref578_jqd" level="file">
+            <did>
+              <unittitle>Correspondence, 1997-2000</unittitle>
+              <container id="aspace_bed5e4998f51c0aa3833aa084b30d636" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_4a9d43dbb914c297e1fca7aed40d077b" parent="aspace_bed5e4998f51c0aa3833aa084b30d636" type="folder">43 (AA1)</container>
+            </did>
+          </c>
+          <c id="aspace_ref579_8yx" level="file">
+            <did>
+              <unittitle>Preface</unittitle>
+              <container id="aspace_176f0a362903d4b6ff91d6185815c897" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_7c47798df05a7cb8aa75527c967cadb5" parent="aspace_176f0a362903d4b6ff91d6185815c897" type="folder">44 (AA2)</container>
+            </did>
+          </c>
+          <c id="aspace_ref580_mv2" level="file">
+            <did>
+              <unittitle>Chapter 1: Mathematical Analysis of Algorithms – copy of original article, galleys, copy of a bibliographic item</unittitle>
+              <container id="aspace_c050cb390cb51a598489a8f33ef8227a" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_92ff99338709b3cc3a12e25c941479c7" parent="aspace_c050cb390cb51a598489a8f33ef8227a" type="folder">45 (AA3)</container>
+            </did>
+          </c>
+          <c id="aspace_ref581_3ki" level="file">
+            <did>
+              <unittitle>Chapter 2: The Dangers of Computer Science Theory – copy of original article, galleys</unittitle>
+              <container id="aspace_d1c37a821786c40851ecfd829a7f8fe2" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_809635f97b4a5778d52d07f1b6553a75" parent="aspace_d1c37a821786c40851ecfd829a7f8fe2" type="folder">46 (AA4)</container>
+            </did>
+          </c>
+          <c id="aspace_ref582_9hv" level="file">
+            <did>
+              <unittitle>Chapter 3: The Analysis of Algorithms - copy of original article, galleys</unittitle>
+              <container id="aspace_b57bff800b7c4cd57361090bfebcc835" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_5231e8defb4a0b222924fe6bb9eed552" parent="aspace_b57bff800b7c4cd57361090bfebcc835" type="folder">47 (AA5)</container>
+            </did>
+          </c>
+          <c id="aspace_ref583_i08" level="file">
+            <did>
+              <unittitle>Chapter 4: Big Omicron and Big Omega and Big Theta - copy of original article, galleys</unittitle>
+              <container id="aspace_8e75e4ebc977c9bb166e82fd286acb8b" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_2486a00882c0594ce559e79068824b2b" parent="aspace_8e75e4ebc977c9bb166e82fd286acb8b" type="folder">48 (AA6)</container>
+            </did>
+          </c>
+          <c id="aspace_ref584_ym3" level="file">
+            <did>
+              <unittitle>Chapter 5: Optimal Measurement Points for Program Frequency Counts - copy of original article, galleys</unittitle>
+              <container id="aspace_c290a164bc4350dd50877625c88ed702" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_4afd71f4f32c38509d9458cdf28dacb1" parent="aspace_c290a164bc4350dd50877625c88ed702" type="folder">49 (AA7)</container>
+            </did>
+          </c>
+          <c id="aspace_ref585_4cm" level="file">
+            <did>
+              <unittitle>Chapter 6: Estimating the Efficiency of Backtrack Programs – copy of letter to I. J. Good, 1975, copy of original article, galleys, proofs of new illustrations</unittitle>
+              <container id="aspace_6ac964db2075e82e55a789583699677d" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_0d81115970f5751b71288fcd821a3f1a" parent="aspace_6ac964db2075e82e55a789583699677d" type="folder">50 (AA8)</container>
+            </did>
+          </c>
+          <c id="aspace_ref586_h0u" level="file">
+            <did>
+              <unittitle>Chapter 7: Ordered Hash Tables – notes, copy of original article, galleys</unittitle>
+              <container id="aspace_ae5747e8ae801dff99d06c8c492c72be" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_89f9aa8e8f72629a28cfa7736ca7648f" parent="aspace_ae5747e8ae801dff99d06c8c492c72be" type="folder">51 (AA9)</container>
+            </did>
+          </c>
+          <c id="aspace_ref587_l4x" level="file">
+            <did>
+              <unittitle>Chapter 8: Activity in an Interleaved Memory – copy of original article, galleys</unittitle>
+              <container id="aspace_c94381f6845d81c8cb9adcac7251771c" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_7d815f63779b0ad79b94de509e44cbc5" parent="aspace_c94381f6845d81c8cb9adcac7251771c" type="folder">52 (AA10)</container>
+            </did>
+          </c>
+          <c id="aspace_ref588_vkt" level="file">
+            <did>
+              <unittitle>Chapter 9: An Analysis of Alpha-Beta Pruning – copy of relevant correspondence, copy of original article, galleys, first proofs of illustrations, draft of addendum</unittitle>
+              <container id="aspace_ddd57f5d0d60355831f8778e5b6164be" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_3eab1954da718291f2500f3d1a076d57" parent="aspace_ddd57f5d0d60355831f8778e5b6164be" type="folder">53 (AA11)</container>
+            </did>
+          </c>
+          <c id="aspace_ref589_8l7" level="file">
+            <did>
+              <unittitle>Chapter 10: Notes on Generalized Dedekind Sums – notes, copy of original article, galleys</unittitle>
+              <container id="aspace_8804c6168dbd8a93e4664c7c777dea55" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_54815ac29722bdc88b0bacb01d7448aa" parent="aspace_8804c6168dbd8a93e4664c7c777dea55" type="folder">54 (AA12)</container>
+            </did>
+          </c>
+          <c id="aspace_ref590_9ol" level="file">
+            <did>
+              <unittitle>Chapter 11: The Distribution of Continued Fraction Approximations – copy of original article, galleys</unittitle>
+              <container id="aspace_99ecc8b3d9c69a611f414f36bc291105" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_7bca9a0d9b28b0e265cf1d8416c19b42" parent="aspace_99ecc8b3d9c69a611f414f36bc291105" type="folder">55 (AA13)</container>
+            </did>
+          </c>
+          <c id="aspace_ref591_jrs" level="file">
+            <did>
+              <unittitle>Chapter 12: Evaluation of Porter's Constant – copy of original article, correspondence from John Wrench, galleys, draft of addendum</unittitle>
+              <container id="aspace_77f0f8c876b0b36b2bedfc7b8de08af8" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_37d2911fb08ef72267ad8a1f2ae0b2c3" parent="aspace_77f0f8c876b0b36b2bedfc7b8de08af8" type="folder">56 (AA14)</container>
+            </did>
+          </c>
+          <c id="aspace_ref592_yz9" level="file">
+            <did>
+              <unittitle>Chapter 13: The Subtractive Algorithm for Greatest Common Divisors – copy of correspondence with co-author A. C. Yao, galleys, draft of addendum</unittitle>
+              <container id="aspace_a03efef93a049176ad67b602a491e42f" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_edabadeae7d067467ce90dd086414e59" parent="aspace_a03efef93a049176ad67b602a491e42f" type="folder">57 (AA15)</container>
+            </did>
+          </c>
+          <c id="aspace_ref593_7f7" level="file">
+            <did>
+              <unittitle>Chapter 14: Length of Strings for a Merge sort – copy of original article, galleys, draft of addendum</unittitle>
+              <container id="aspace_457df293e6a57b04edffa8336ff9dff5" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_30b3a2c0376d578abbc33b8349900b0f" parent="aspace_457df293e6a57b04edffa8336ff9dff5" type="folder">58 (AA16)</container>
+            </did>
+          </c>
+          <c id="aspace_ref594_7ha" level="file">
+            <did>
+              <unittitle>Chapter 15: The Average Height of Planted Plane Trees – corrections, copy of original article, galleys, proofs of illustrations</unittitle>
+              <container id="aspace_70b218557fbef9a536a655fa4031e969" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_c1a8af1dba5e156b61ca832ec06bafd6" parent="aspace_70b218557fbef9a536a655fa4031e969" type="folder">59 (AA17)</container>
+            </did>
+          </c>
+          <c id="aspace_ref595_nr2" level="file">
+            <did>
+              <unittitle>Chapter 16: The Toilet Paper Problem – copy of original article and one of its sequels, galleys, proofs of illustrations</unittitle>
+              <container id="aspace_68d223288805b42f6165e0e9958cc663" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_dc637922e323e4d0340101e3e6034742" parent="aspace_68d223288805b42f6165e0e9958cc663" type="folder">60 (AA18)</container>
+            </did>
+          </c>
+          <c id="aspace_ref596_ip7" level="file">
+            <did>
+              <unittitle>Chapter 17: An Analysis of Optimum Caching – letter from H. S. Wilf, copy of original and related articles, galleys</unittitle>
+              <container id="aspace_14b5f1d24906ea6cd91c7a25d4c333ac" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_9a7ec503833a6cb4529d19d78c2606a3" parent="aspace_14b5f1d24906ea6cd91c7a25d4c333ac" type="folder">61 (AA19)</container>
+            </did>
+          </c>
+          <c id="aspace_ref597_bdb" level="file">
+            <did>
+              <unittitle>Chapter 18: A Trivial Algorithm Whose Analysis Isn't – copies of related correspondence, copy of original article, galleys</unittitle>
+              <container id="aspace_3f210bda142d588fed80bc13c84e51db" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_670b7544e139e866edeffb3b236c49e8" parent="aspace_3f210bda142d588fed80bc13c84e51db" type="folder">62 (AA20)</container>
+            </did>
+          </c>
+          <c id="aspace_ref598_uwz" level="file">
+            <did>
+              <unittitle>Chapter 19: Deletions That Preserve Randomness – copy of original article, galleys, references used in preparing addendum</unittitle>
+              <container id="aspace_1bf5be3a2f73371d4e60df611cd30d4a" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_50d7931ef657aab72c859e5a4190399e" parent="aspace_1bf5be3a2f73371d4e60df611cd30d4a" type="folder">63 (AA21)</container>
+            </did>
+          </c>
+          <c id="aspace_ref599_85a" level="file">
+            <did>
+              <unittitle>Chapter 20: Analysis of a Simple Factorization Algorithm – notes, copy of original article, galleys</unittitle>
+              <container id="aspace_934a9f5d7109544bf653090f1001ee10" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_09ab06a92727ea14044badaec025a377" parent="aspace_934a9f5d7109544bf653090f1001ee10" type="folder">64 (AA22)</container>
+            </did>
+          </c>
+          <c id="aspace_ref600_217" level="file">
+            <did>
+              <unittitle>Chapter 21: The Expected Linearity of a Simple Equivalence Algorithm – notes, copy of original article, galleys, draft of addendum</unittitle>
+              <container id="aspace_ab42d6d46b28c6e03f607f452f189202" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ed4a4c3656b9233810845113927deda8" parent="aspace_ab42d6d46b28c6e03f607f452f189202" type="folder">65 (AA23)</container>
+            </did>
+          </c>
+          <c id="aspace_ref601_1vf" level="file">
+            <did>
+              <unittitle>Chapter 22: Textbook Examples of Recursion – copies of related correspondence 1990-96, galleys, correspondence 2000 regarding error and its correction</unittitle>
+              <container id="aspace_b401aea44c9dfc0ec59a7ab723da4f7f" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_24033c84446f34ef98853bd9e9272c12" parent="aspace_b401aea44c9dfc0ec59a7ab723da4f7f" type="folder">66 (AA24)</container>
+            </did>
+          </c>
+          <c id="aspace_ref602_bqf" level="file">
+            <did>
+              <unittitle>Chapter 23: An Exact Analysis of Stable Allocation – correspondence re the bibliography, galleys</unittitle>
+              <container id="aspace_2f00cc78226ea96d92c4b00ca46c0395" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_3d9a758bcb1bcad4f4af161277a984d7" parent="aspace_2f00cc78226ea96d92c4b00ca46c0395" type="folder">67 (AA25)</container>
+            </did>
+          </c>
+          <c id="aspace_ref603_0yw" level="file">
+            <did>
+              <unittitle>Chapter 24: Stable Husbands – galleys</unittitle>
+              <container id="aspace_5042bdf098c8681ec43e794fd052d635" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_e3731d3bca005f0dbe25ed00cfdb2a72" parent="aspace_5042bdf098c8681ec43e794fd052d635" type="folder">68 (AA26)</container>
+            </did>
+          </c>
+          <c id="aspace_ref604_bnq" level="file">
+            <did>
+              <unittitle>Chapter 25: Shellsort With Three Increments – copy of original article, galleys</unittitle>
+              <container id="aspace_d413148d37c344b95f46c3cd2123ef9b" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_a82fc0870795a2926e9f06246cd89ac7" parent="aspace_d413148d37c344b95f46c3cd2123ef9b" type="folder">69 (AA27)</container>
+            </did>
+          </c>
+          <c id="aspace_ref605_pu2" level="file">
+            <did>
+              <unittitle>Chapter 26: The Average Time for Carry Propagation – copy of original article, galleys</unittitle>
+              <container id="aspace_c7f0dcd492517361296fc101b834a954" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_1faad5d67d319b86fe0bba76ee5a718c" parent="aspace_c7f0dcd492517361296fc101b834a954" type="folder">70 (AA28)</container>
+            </did>
+          </c>
+          <c id="aspace_ref606_wz4" level="file">
+            <did>
+              <unittitle>Chapter 27: Linear Probing and Graphs – related correspondence, copy of original article, galleys</unittitle>
+              <container id="aspace_b709dbdcc4c3408abada9bef4db92354" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_f69007d6f1d58123b09ce2ca5d348206" parent="aspace_b709dbdcc4c3408abada9bef4db92354" type="folder">71 (AA29)</container>
+            </did>
+          </c>
+          <c id="aspace_ref607_zf5" level="file">
+            <did>
+              <unittitle>Chapter 28: A Terminological Proposal – copy of original article, galleys</unittitle>
+              <container id="aspace_baf22cb969ae0bf536a8a306f5556a5c" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_2d60391434b59e4135008b7e538fc58b" parent="aspace_baf22cb969ae0bf536a8a306f5556a5c" type="folder">72 (AA30)</container>
+            </did>
+          </c>
+          <c id="aspace_ref608_or6" level="file">
+            <did>
+              <unittitle>Chapter 29: Postscript about NP-Hard Problems – copy of original article, galleys</unittitle>
+              <container id="aspace_c04a166585cc955b9491c7ed63f8e64d" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_a51f670475b38f12bc713a98967b4900" parent="aspace_c04a166585cc955b9491c7ed63f8e64d" type="folder">73 (AA31)</container>
+            </did>
+          </c>
+          <c id="aspace_ref609_0cz" level="file">
+            <did>
+              <unittitle>Chapter 30: An Experiment in Optimal Sorting – copy of original article, galleys</unittitle>
+              <container id="aspace_386b833bdd0f754a7d1c0eed9a54c5e7" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_84eca1e5d17033e5cf23543bf4205a15" parent="aspace_386b833bdd0f754a7d1c0eed9a54c5e7" type="folder">74 (AA32)</container>
+            </did>
+          </c>
+          <c id="aspace_ref610_0s5" level="file">
+            <did>
+              <unittitle>Chapter 31: Duality in Addition Chains – copy of original article, galleys</unittitle>
+              <container id="aspace_01aded6a6febfcfa7bbeb05b39ad761f" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_cd6b79bf8942e422bf409c38ee30f04c" parent="aspace_01aded6a6febfcfa7bbeb05b39ad761f" type="folder">75 (AA33)</container>
+            </did>
+          </c>
+          <c id="aspace_ref611_s40" level="file">
+            <did>
+              <unittitle>Chapter 32: Complexity Results for Bandwidth Minimization – correspondence with co-author David Johnson, copy of original article, galleys, citations used in preparing the addendum</unittitle>
+              <container id="aspace_736ab2d1f13a3cebaeceb52fe27dadf5" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_ee2def1dbab1cd33e179ecb5b553cba1" parent="aspace_736ab2d1f13a3cebaeceb52fe27dadf5" type="folder">76 (AA34)</container>
+            </did>
+          </c>
+          <c id="aspace_ref612_ej3" level="file">
+            <did>
+              <unittitle>Chapter 33: The Problem of Compatible Representatives – copy of original article, galleys</unittitle>
+              <container id="aspace_7eba889827e87666ea2318258a39d776" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_233b9887ca9b07f96cd1af380026da28" parent="aspace_7eba889827e87666ea2318258a39d776" type="folder">77 (AA35)</container>
+            </did>
+          </c>
+          <c id="aspace_ref613_lur" level="file">
+            <did>
+              <unittitle>Chapter 34: The Complexity of Nonuniform Random Number Generation – copy of original article, galleys, proofs of illustrations</unittitle>
+              <container id="aspace_d2e54e4ac28c845bf2a1ab7c049a2ee4" label="Mixed Materials [aspace.536698.box.1]" type="Box">1</container>
+              <container id="aspace_30642ce8e702547a3814a1dc6b8c4806" parent="aspace_d2e54e4ac28c845bf2a1ab7c049a2ee4" type="folder">78 (AA36)</container>
+            </did>
+          </c>
+          <c id="aspace_ref614_m8e" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. vii-75</unittitle>
+              <container id="aspace_aad1d1569258fd26e081ae8b78c72011" label="Mixed Materials [aspace.536698.box.2]" type="Box">2</container>
+              <container id="aspace_a76ca9b2591c2df7310140c430380650" parent="aspace_aad1d1569258fd26e081ae8b78c72011" type="folder">1 (AA37)</container>
+            </did>
+          </c>
+          <c id="aspace_ref615_ox6" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 77-148</unittitle>
+              <container id="aspace_5fb62e339164ce7684e40ae533cbc987" label="Mixed Materials [aspace.536698.box.2]" type="Box">2</container>
+              <container id="aspace_a626adac774b06b15898b7f1ed940cbd" parent="aspace_5fb62e339164ce7684e40ae533cbc987" type="folder">2 (AA37)</container>
+            </did>
+          </c>
+          <c id="aspace_ref616_pwy" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 149-256</unittitle>
+              <container id="aspace_f19c63eabcd120503cad67fdbdf4ae26" label="Mixed Materials [aspace.536698.box.2]" type="Box">2</container>
+              <container id="aspace_1359df7c0d9a5a0c06d6ac107ee2847e" parent="aspace_f19c63eabcd120503cad67fdbdf4ae26" type="folder">3 (AA37)</container>
+            </did>
+          </c>
+          <c id="aspace_ref617_2ev" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 257-390</unittitle>
+              <container id="aspace_8538490744a03a155b0bd58e2b606c3f" label="Mixed Materials [aspace.536698.box.2]" type="Box">2</container>
+              <container id="aspace_9422233b6ad19282a4e4b2fb9df2d3d3" parent="aspace_8538490744a03a155b0bd58e2b606c3f" type="folder">4 (AA37)</container>
+            </did>
+          </c>
+          <c id="aspace_ref618_k14" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 391-492</unittitle>
+              <container id="aspace_4d066b499072ae9c1b4ea595c80e230e" label="Mixed Materials [aspace.536698.box.2]" type="Box">2</container>
+              <container id="aspace_4b16b07fbf092f96e4c6f7ff70ed967c" parent="aspace_4d066b499072ae9c1b4ea595c80e230e" type="folder">5 (AA37)</container>
+            </did>
+          </c>
+          <c id="aspace_ref619_rki" level="file">
+            <did>
+              <unittitle>Working copy of the entire book: pp. 493-end</unittitle>
+              <container id="aspace_c660b0d9dd7ffcf5b8e7bf793bbf6851" label="Mixed Materials [aspace.536698.box.2]" type="Box">2</container>
+              <container id="aspace_93de26a3f537de7e32faf193750b40ef" parent="aspace_c660b0d9dd7ffcf5b8e7bf793bbf6851" type="folder">6 (AA37)</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref620_6it" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">MMIXware</title>
+            </unittitle>
+          </did>
+          <c id="aspace_ref621_tme" level="file">
+            <did>
+              <unittitle>MMIX in 1991 and 1992 – first and second draft of the program, presentation letter to John Hennessy, and his comments</unittitle>
+              <container id="aspace_23f19421e4cadb7552c659fc17384592" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_1889e30a7135fd8b06dfbda4dc14a3e9" parent="aspace_23f19421e4cadb7552c659fc17384592" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref622_4ao" level="file">
+            <did>
+              <unittitle>MMIX-PIPE, 17 January 1999 – earliest printed draft with handwritten corrections</unittitle>
+              <container id="aspace_144c19343a0b0084165e0b1a2835d2cc" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_4dea6f6dcf070085e8d4ac61c1098f1a" parent="aspace_144c19343a0b0084165e0b1a2835d2cc" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref623_orh" level="file">
+            <did>
+              <unittitle>MMIX-PIPE, 5 February 1999 – draft</unittitle>
+              <container id="aspace_efc934d0ff12d7bf901f9bc8a8fad4b3" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_93ec2daac8e06b9eb74870b9940fe0d7" parent="aspace_efc934d0ff12d7bf901f9bc8a8fad4b3" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref624_o9r" level="file">
+            <did>
+              <unittitle>MMIX-PIPE, 16 February 1999 – draft with documentation of the MMIX hardware as it existed at the time</unittitle>
+              <container id="aspace_6eb654af374d3648b04ab139c12ba8be" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_2979d49e31ff3bb6d2c8e1cf7b50ed5f" parent="aspace_6eb654af374d3648b04ab139c12ba8be" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref625_o46" level="file">
+            <did>
+              <unittitle>MMIXware, 13 April 1999 – earliest surviving drafts of MMIX-ARITH and MMIX-SIM</unittitle>
+              <container id="aspace_dffe3bba2d4d4cce63b64f30ffd42ef3" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_2f5b258f1de8fb96ce425ad359e16e19" parent="aspace_dffe3bba2d4d4cce63b64f30ffd42ef3" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref626_tl5" level="file">
+            <did>
+              <unittitle>MMIXware, 19 April 199 – earliest surviving drafts of MMIX-IO and MNOtype with current versions of MMIX-SIM and the MMIX documentation</unittitle>
+              <container id="aspace_a1049b4daaf36f1017ed30e447879666" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_82165fdcbd7bfbcd5fabfca123622fae" parent="aspace_a1049b4daaf36f1017ed30e447879666" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref627_i9w" level="file">
+            <did>
+              <unittitle>Fascicle 1, 8 May 1999 – first galley proofs of new expository material for The Art of Computer Programming (section 1.3.1')</unittitle>
+              <container id="aspace_20767a509ddcc940efd82678a51a4df0" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_1b20a936074a0e66f6672d040f52af64" parent="aspace_20767a509ddcc940efd82678a51a4df0" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref628_p6n" level="file">
+            <did>
+              <unittitle>Fascicle 1, 26 May 1999 – galley proofs, including section 1.3.2'</unittitle>
+              <container id="aspace_e2a942aac9e5f210775af8e7d0f0afed" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_2e38dca6b2bdd2bde61d1fce264abd53" parent="aspace_e2a942aac9e5f210775af8e7d0f0afed" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref629_l15" level="file">
+            <did>
+              <unittitle>Fascicle 1, 8 June 1999 – galley proofs, now including section 1.4.1'</unittitle>
+              <container id="aspace_812a74ef5b01159bb06d124cd5ac21b1" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_ea08e00063374e67fefd69c21288b247" parent="aspace_812a74ef5b01159bb06d124cd5ac21b1" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref630_3hd" level="file">
+            <did>
+              <unittitle>Fascicle 1, 21 June 1999 – galley proofs, including sections 1.4.2' and 1.4.3', and first draft of index and glossary</unittitle>
+              <container id="aspace_a75977bd58f866c97011b5044bf6583e" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_fda291bf150bbdca681c737829ddc5d0" parent="aspace_a75977bd58f866c97011b5044bf6583e" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref631_dhb" level="file">
+            <did>
+              <unittitle>Fascicle 1, 27 June 1999 – galley proofs of first complete "clean" version</unittitle>
+              <container id="aspace_b0884dca7499d2cc7e5dd0f3c7fb87e4" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_ec322dc8dd1b1af62afec87be8448cfd" parent="aspace_b0884dca7499d2cc7e5dd0f3c7fb87e4" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref632_tmz" level="file">
+            <did>
+              <unittitle>Fascicle 1, 23 August 1999 – Knuth's working reference copy</unittitle>
+              <container id="aspace_44557d87c1f6b8c0fb187a1ae7667f43" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_825a95e8a6f037bccd6b29d7dbae2233" parent="aspace_44557d87c1f6b8c0fb187a1ae7667f43" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref633_vtu" level="file">
+            <did>
+              <unittitle>CTWILL – text for CTWILL program (version 3.43) and companion programs REFSORT and TWINX</unittitle>
+              <container id="aspace_2c02bedb16cd15f1e11e5a3dba89dd76" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_c218361a0c9fdded5e9ca2d575f7676b" parent="aspace_2c02bedb16cd15f1e11e5a3dba89dd76" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref634_a19" level="file">
+            <did>
+              <unittitle>MMIX-ARITH – proofmode output of program MMIX-ARITH dated 27 September 1999, with handwritten corrections, and book pages dated 2 October 1999</unittitle>
+              <container id="aspace_72065b0185b39a863d7fee2895c7e4d0" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_bcc12d49c1d337f07f8b679b3b180b92" parent="aspace_72065b0185b39a863d7fee2895c7e4d0" type="folder">14</container>
+            </did>
+          </c>
+          <c id="aspace_ref635_3zb" level="file">
+            <did>
+              <unittitle>MMIX-CONFIG – proofmode and book pages</unittitle>
+              <container id="aspace_5cb21776b6d55d0cadb31d2d077c9fb6" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_fbd516b9c06ec891e46c71b91d65a2f3" parent="aspace_5cb21776b6d55d0cadb31d2d077c9fb6" type="folder">15</container>
+            </did>
+          </c>
+          <c id="aspace_ref636_de5" level="file">
+            <did>
+              <unittitle>MMIX-PIPE – proofmode and book pages</unittitle>
+              <container id="aspace_8977abe0e2ed75e9f11decc9a245bf38" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_f648cffdd7074fc0da8fba7922bf21fb" parent="aspace_8977abe0e2ed75e9f11decc9a245bf38" type="folder">16</container>
+            </did>
+          </c>
+          <c id="aspace_ref637_u8x" level="file">
+            <did>
+              <unittitle>MMIX-SIM – proofmode and book pages</unittitle>
+              <container id="aspace_4aa7b991925096d18c8f8ac8ff74777b" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_b94654f483e2645c4b7106bb0f051ced" parent="aspace_4aa7b991925096d18c8f8ac8ff74777b" type="folder">17</container>
+            </did>
+          </c>
+          <c id="aspace_ref638_900" level="file">
+            <did>
+              <unittitle>MMIXAL – proofmode and book pages</unittitle>
+              <container id="aspace_608b1ac0d7211615143f862056ef0f9f" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_57ab746f99a7a3baf6b613b1eedf1093" parent="aspace_608b1ac0d7211615143f862056ef0f9f" type="folder">18</container>
+            </did>
+          </c>
+          <c id="aspace_ref639_k3g" level="file">
+            <did>
+              <unittitle>MMIX – proofmode and book pages</unittitle>
+              <container id="aspace_052a0f3f977b680fba9f6dcd493d4bee" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_c921a050be1d2e870112c42ead675a02" parent="aspace_052a0f3f977b680fba9f6dcd493d4bee" type="folder">19</container>
+            </did>
+          </c>
+          <c id="aspace_ref640_3vx" level="file">
+            <did>
+              <unittitle>MMIXware front matter and short chapters</unittitle>
+              <container id="aspace_99e6585d94754e327fb6e20963fa670f" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_dd2ee2ae3cfbae8cdd79d4b0b3851044" parent="aspace_99e6585d94754e327fb6e20963fa670f" type="folder">20</container>
+            </did>
+          </c>
+          <c id="aspace_ref641_xmk" level="file">
+            <did>
+              <unittitle>MMIXware correspondence with publisher Springer-Verlag, 1998-99</unittitle>
+              <container id="aspace_370af39d7e8756cbbe1c8b8bd2d57f9e" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+              <container id="aspace_bb75104ba51f99bab4c509725d0c40c8" parent="aspace_370af39d7e8756cbbe1c8b8bd2d57f9e" type="folder">21</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref642_zca" level="file">
+          <did>
+            <unittitle>The Joy of TeX, A Gourmet Guide to Typesetting Technical Text by Computer by Michael Spivak, Ph.D. [with annotations]</unittitle>
+            <unitdate datechar="creation">1980</unitdate>
+            <container id="aspace_9e659be402f1a20050fda696289c5008" label="Mixed Materials [aspace.536698.box.3]" type="Box">3</container>
+            <container id="aspace_986db5c09aecc8b2ae91430ed6ac1891" parent="aspace_9e659be402f1a20050fda696289c5008" type="folder">22</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_ref643_w1u" level="series">
+        <did>
+          <unittitle>Addenda, 2001-235</unittitle>
+          <unitid>Accession ARCH-2001-235</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <scopecontent id="aspace_d8447dcef35011ca5efe5133eb1288d1">
+          <head>Scope and Contents note</head>
+          <p>This accession pertains to the lecture series on the general topic of faith and science delivered at MIT in the fall of 1999, which resulted in the book <title render="italic">Things a Computer Scientist Rarely Talks About</title>. Included are correspondence, notes, transcripts of the taped lectures, drafts, and illustrations.</p>
+          <p>"Materials from a unique episode in my life, when I was asked to give a series of six public lectures at the Massachusetts Institute of Technology (MIT) on the general topic of faith and science. The lectures, delivered in the fall of 1999, were broadcast live on the Internet, and I'm told that tens of thousands of people watched them. Each 90-minute lecture consisted of a prepared talk followed by an impromptu question-and-answer session, with about 45 minutes devoted to each portion. Transcripts were made from the videotapes and I edited then during the summer of 2000, adding notes and references to the literature. They were published in 2001 by Stanford's Center for the Study of Linguistics and Information (CSLI), with the title "Things a Computer Scientist Rarely Talks About"--which was also the general title of the lectures when I gave them originally. A complete archive of that book appears here."</p>
+        </scopecontent>
+        <c id="aspace_ref645_3l8" level="file">
+          <did>
+            <unittitle>Correspondence regarding lectures, including email announcements of the lectures and some of the typical feedback</unittitle>
+            <unitdate datechar="creation">1998-1999</unitdate>
+            <container id="aspace_40e290e8cc11e7d6bec9b090a439d41b" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_e394bb3e83a65ed78bc29c7761133eb7" parent="aspace_40e290e8cc11e7d6bec9b090a439d41b" type="folder">1</container>
+          </did>
+          <scopecontent id="aspace_df24545e2225df1429d6504e9abfa34c">
+            <head>Scope and Contents note</head>
+            <p>Includes the original letters of invitation, letters about practical details of moving to Massachusetts, email announcenents of the lectures themselves, and some of the typical feedback received from the audience.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref647_rww" level="file">
+          <did>
+            <unittitle>Lecture 1: Introduction– notes and brochure</unittitle>
+            <unitdate datechar="creation">1999 Oct 6</unitdate>
+            <container id="aspace_6a9a045ee9f1dfd802ecf886de69c149" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_dd9437b2e586bc7a570b5323a419d30c" parent="aspace_6a9a045ee9f1dfd802ecf886de69c149" type="folder">2</container>
+          </did>
+          <scopecontent id="aspace_5f4f462beac8e6469a9f0b18434fb82d">
+            <head>Scope and Contents note</head>
+            <p>The page of handwritten notes I used while preparing the first lecture, fol1owed by the notes I used during the Lecture itself. Also the widely distributed brochure that had been used to announce the series.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref649_z5e" level="file">
+          <did>
+            <unittitle>Lecture 2: Randomization and Religion-notes</unittitle>
+            <unitdate datechar="creation">1999 Oct 13</unitdate>
+            <container id="aspace_451d4e1e7584c2ffaaa588c09c8a87b2" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_165cd3bd05acda179ef7637300af04ca" parent="aspace_451d4e1e7584c2ffaaa588c09c8a87b2" type="folder">3</container>
+          </did>
+          <scopecontent id="aspace_79bedf74790c39d9a840666282dfee7d">
+            <head>Scope and Contents note</head>
+            <p>The notes I used to prepare and deliver the second lecture.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref651_8e9" level="file">
+          <did>
+            <unittitle>Lecture 3: Language Translation– notes and overhead transparencies</unittitle>
+            <unitdate datechar="creation">1999 Oct 27</unitdate>
+            <container id="aspace_27d578cbf01036e231894c25ad4c6041" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_44fae30a9a2e95e2dcadf1d330074e6b" parent="aspace_27d578cbf01036e231894c25ad4c6041" type="folder">4</container>
+          </did>
+          <scopecontent id="aspace_3b841942438688332ffbed012452c48f">
+            <head>Scope and Contents note</head>
+            <p>The notes I used to prepare and deliver tbe third lecture, together with overhead transparencies used to illustrate it. (Included are several dozen additlonal transparencies that I had made just in case they night be needed when I was answering questions from the audience.)</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref653_j4a" level="file">
+          <did>
+            <unittitle>Lecture 4: Aesthetics– notes</unittitle>
+            <unitdate datechar="creation">1999 Nov 3</unitdate>
+            <container id="aspace_7783e14d3519d2546d7c2a229fe3b5a1" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_de0f333e2e56542e27dba928e5cea9a8" parent="aspace_7783e14d3519d2546d7c2a229fe3b5a1" type="folder">5</container>
+          </did>
+          <scopecontent id="aspace_8413b9c863b4bafb78e7fdf693079a02">
+            <head>Scope and Contents note</head>
+            <p>The notes I used to prepare and deliver the fourth lecture. This lecture was illustrated by 35mm slides, see Folder 17 below.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref655_jn4" level="file">
+          <did>
+            <unittitle>Lecture 5: Glimpses of God – notes and copy of Raymond Smullyan's story "Planet without Laughter," statistics about "key verses" of the Bible, and an email from Douglas Hofstadter re "laughter yoga"</unittitle>
+            <unitdate datechar="creation">1999 Dec 1</unitdate>
+            <container id="aspace_6dd76eb67840f6e70855c76933d41037" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_fae004b4872888318ffb2ba8b0ca19d9" parent="aspace_6dd76eb67840f6e70855c76933d41037" type="folder">6</container>
+          </did>
+          <scopecontent id="aspace_f919f8e56920ad645785c30d686a77b1">
+            <head>Scope and Contents note</head>
+            <p>The notes I used to prepare and deliver the fifth lecture. Also includes a xerox copy of Raymoud Smullyan's short story "Planet Without Laughter"; statistics about so-called "key verses" of the Bible and some materials collected subsequent to the lecture: an obituary of Raymond E. Brown; email from Douglas Hofstadter re "laughter yoga"; and an excerpt fron George Buttrick's lectures on Biblical Thougbt and the Secular University.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref657_dd2" level="file">
+          <did>
+            <unittitle>Lecture 6: God and Computer Science – notes and relevant sources</unittitle>
+            <unitdate datechar="creation">1999 Dec 8</unitdate>
+            <container id="aspace_016b51c38abd813c3a2cbe5952eadfb7" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_9c10f84c83135bddd352cd1b7c60092d" parent="aspace_016b51c38abd813c3a2cbe5952eadfb7" type="folder">7</container>
+          </did>
+          <scopecontent id="aspace_6ea553796ff668dbc94615ac37358890">
+            <head>Scope and Contents note</head>
+            <p>The notes I used to prepare ald deliver the sixth lecture, including several magazine articles and other relevant materials found on the Internet (e.g., Einstein's renarks on Science, Philosophy and Rellgion).</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref659_b6b" level="file">
+          <did>
+            <unittitle>Panel discussion: Creativity, Spirituality, and Computer Science, 17 – notes</unittitle>
+            <unitdate datechar="creation">1999 Nov</unitdate>
+            <container id="aspace_0b8d036d3fc0c6435dd6fe8bd8788eda" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_07af078a5a18686dd450f88566caa2e0" parent="aspace_0b8d036d3fc0c6435dd6fe8bd8788eda" type="folder">8</container>
+          </did>
+          <scopecontent id="aspace_ae0e1bf2549df10d0d5e7236ad9a80f8">
+            <head>Scope and Contents note</head>
+            <p>The single page of notes I used during that session.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref661_gio" level="file">
+          <did>
+            <unittitle>Raw transcripts (from videotapes of the lectures)</unittitle>
+            <container id="aspace_68c06367f45a0af344d042144d76949d" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_48093099ef23bf42824e18cfbb1b5771" parent="aspace_68c06367f45a0af344d042144d76949d" type="folder">9</container>
+          </did>
+          <scopecontent id="aspace_8b09702845bcd92dd8f78ac2e6bcf496">
+            <head>Scope and Contents note</head>
+            <p>The videotapes of all six lectures and the panel discussion were transcribed by staff members of Dr. Dobb's Journal, the company that did the webcasts. These transcriptions, though riddled with errors, provided a good basis fron which I could attempt to recreate the feeling of the original lectures (while watching the videotapes several times myself).</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref663_u0d" level="file">
+          <did>
+            <unittitle>Half-baked transcripts</unittitle>
+            <container id="aspace_8e21345d98d5dcb846188a297d904310" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_d02d70de25d6ba10552f091e3b4e49cf" parent="aspace_8e21345d98d5dcb846188a297d904310" type="folder">10</container>
+          </did>
+          <scopecontent id="aspace_1a73b16720e2932654df09666f08ea72">
+            <head>Scope and Contents note</head>
+            <p>This is how the transcripts looked after I had converted them to simple ASCII text format and inserted time coordinates to correlate them with the videotapes. My editing of the lectures essentially began here.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref665_en8" level="file">
+          <did>
+            <unittitle>Illustrations – includes original proofs of TV frames, poster illustration, and 35mm slides; and first proofs after conversion to black-and-white</unittitle>
+            <container id="aspace_d5e6e88b163aef80c73990718fae536d" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_48da03e6d963252241465856f585e1f9" parent="aspace_d5e6e88b163aef80c73990718fae536d" type="folder">11</container>
+          </did>
+          <scopecontent id="aspace_2d0afcd2e422b0c194dea481646c103a">
+            <head>Scope and Contents note</head>
+            <p>One of the interesting tasks I faced was to convert videotape frames to illustrations that could be used in the book. The quality of video data is insufficient for large pictures, so I decided to render each image at the largest size that would retain reasonably sharp details. This limited me to slightly nore than 1 inch in each dimension, so it strongly affected the design of the book. The original pictures shown here in black and white were actually in color when viewed by computer, but color did not add anything important. Indeed, when I edited the pictures later, converting then to black and white, the lack of color made it possible for me to enhance nany details that would have looked strange if I had distorted the colors in a similar fashion.</p>
+            <p>This folder contains: Original proofs of captured TV frames; An experinent with TV frames printed in color (fron the paael discussion); 0riginal proofs of the Poster illustration (scanned in parts); Original proofs of inages taken from 35mm slides; First proofs after conversion to black-and-white.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref667_cml" level="file">
+          <did>
+            <unittitle>First drafts for lectures 1-6</unittitle>
+            <container id="aspace_701dcfaa5f237753f15a9d24d131c4da" label="Mixed Materials [aspace.536809.box.1]" type="Box">1</container>
+            <container id="aspace_073ecbedf4c49589a492793604c334c6" parent="aspace_701dcfaa5f237753f15a9d24d131c4da" type="folder">12</container>
+          </did>
+          <scopecontent id="aspace_a25a20e877246cd1062e7ee7d7906875">
+            <head>Scope and Contents note</head>
+            <p>The result after initial editing of the "haIf-baked transcripts", showing many handwritten editorial changes and the places where illustrations are to be inserted. (These drafts cover Lectures 1-6 on1y. The first draft of the panel discussion was emailed to other panelists on 15 April 2000; see folder 16 below.)</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref669_f0g" level="file">
+          <did>
+            <unittitle>Second drafts, with illustrations</unittitle>
+            <container id="aspace_77f759dbed69ad9961927a53a74bff75" label="Mixed Materials [aspace.536809.box.2]" type="Box">2</container>
+            <container id="aspace_71fdd1745aceaf8067e25b050121bc51" parent="aspace_77f759dbed69ad9961927a53a74bff75" type="folder">1</container>
+          </did>
+          <scopecontent id="aspace_15b45f833d68882c931be97009592f67">
+            <head>Scope and Contents note</head>
+            <p>The result after inserting all illustrations (ear1y July 2000); this was shown to several readers asking for comments.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref671_rmg" level="file">
+          <did>
+            <unittitle>Comments from the copy editors</unittitle>
+            <container id="aspace_06856a81506ba5237fe257a9ac9da340" label="Mixed Materials [aspace.536809.box.2]" type="Box">2</container>
+            <container id="aspace_ef78135c894bcf148f56d56e932eb077" parent="aspace_06856a81506ba5237fe257a9ac9da340" type="folder">2</container>
+          </did>
+          <scopecontent id="aspace_63a431700b25ecc39942ad6134df6ad2">
+            <head>Scope and Contents note</head>
+            <p>After a few changes to the drafts in Box 2, Folder 1, the copy editors made numerous further suggestions.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref673_4p9" level="file">
+          <did>
+            <unittitle>Near-final copy</unittitle>
+            <container id="aspace_976913d0ce1fb843abdbe98c6009e8ed" label="Mixed Materials [aspace.536809.box.2]" type="Box">2</container>
+            <container id="aspace_67d6cf996fd8eee29611aa5c2ad04dcb" parent="aspace_976913d0ce1fb843abdbe98c6009e8ed" type="folder">3</container>
+          </did>
+          <scopecontent id="aspace_9b99e661600cd6cfefc0d09b9fa5cf2b">
+            <head>Scope and Contents note</head>
+            <p>Most of the copy editors, suggestions, and further corrections noticed on rereading, 1ed to these pages, which were used to prepare the index.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref675_q5f" level="file">
+          <did>
+            <unittitle>Correspondence re publication</unittitle>
+            <unitdate datechar="creation">2000-2001</unitdate>
+            <container id="aspace_e2dfe415338457dc8729e1ddcc34033f" label="Mixed Materials [aspace.536809.box.2]" type="Box">2</container>
+            <container id="aspace_4d6334d1c53091ae6c51cfc9489eb7ec" parent="aspace_e2dfe415338457dc8729e1ddcc34033f" type="folder">4</container>
+          </did>
+          <scopecontent id="aspace_dbe471f44e913df7a441b3c38a05b38f">
+            <head>Scope and Contents note</head>
+            <p>The bumpy road to publication of a complex book such as this is well documented by this sequence of more than 100 letters.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref677_njc" level="file">
+          <did>
+            <unittitle>slides used in lecture 4</unittitle>
+            <physdesc altrender="whole">
+              <extent altrender="materialtype spaceoccupied">48 computer file(s) (pcd)</extent>
+            </physdesc>
+          </did>
+          <scopecontent id="aspace_b4c9487df0c28630a3a94173babfb6b8">
+            <head>Scope and Contents note</head>
+            <p>The 35mm slides used in Lecture 4, converted to digital form, appear on this conpact disk in several sizes.</p>
+          </scopecontent>
+        </c>
+        <c id="aspace_ref680_alw" level="file">
+          <did>
+            <unittitle>Hand-bound proof [missing lecture 5, pages 138-166]</unittitle>
+            <unitdate datechar="creation">April 2001</unitdate>
+            <container id="aspace_d12a7f78962ac22d71ab9330231c917a" label="Mixed Materials [aspace.536809.box.2]" type="Box">2</container>
+            <container id="aspace_656678d2ee36ad2f4603179991fea576" parent="aspace_d12a7f78962ac22d71ab9330231c917a" type="folder">6</container>
+          </did>
+          <scopecontent id="aspace_ce727f958567fc9ff9d7820305610e75">
+            <head>Scope and Contents note</head>
+            <p>A xerox-copy mockup of the book, several copies of which were sent to potential reviewers. Also contains a few last-minute changes, especially to the index.</p>
+          </scopecontent>
+        </c>
+      </c>
+      <c id="aspace_ref682_s6n" level="series">
+        <did>
+          <unittitle>Addenda, 2004-044</unittitle>
+          <unitid>Accession ARCH-2004-044</unitid>
+        </did>
+        <c id="aspace_ref683_kr3" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">Selected Papers on Computer Languages</title>
+            </unittitle>
+            <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+          </did>
+          <c id="aspace_ref684_gfe" level="file">
+            <did>
+              <unittitle>CL1, Chapter 1: The Early Development of Programming Languages</unittitle>
+              <container id="aspace_34536ee95c720810c28715de893a31a5" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_1406fe34b1cbd29a55bb5ea8e7e2eecb" parent="aspace_34536ee95c720810c28715de893a31a5" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_3912d559ed0dd979065f959b737f2ed8">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence and additional references used to prepare the addendum; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref686_678" level="file">
+            <did>
+              <unittitle>CL 2, Chapter 2: Backus Normal Form versus Backus Naur Form</unittitle>
+              <container id="aspace_670310dfcae75b1cc2755b24c90f6c90" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_0a39cf426d8f3bb42af09f1aff3d1834" parent="aspace_670310dfcae75b1cc2755b24c90f6c90" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_02b4183faabbad8c1597cc5e781efbab">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref688_wt4" level="file">
+            <did>
+              <unittitle>CL3, Chapter 3: Teaching ALGOL 60</unittitle>
+              <container id="aspace_50c9568b499dd933b66c101e6e33c3be" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_285a124913ad1e18388475bbabd78c96" parent="aspace_50c9568b499dd933b66c101e6e33c3be" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_deff1ac1016b1147b8f92ae0a3d1f8fc">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref690_j11" level="file">
+            <did>
+              <unittitle>CL4, Chapter 4: ALGOL 60 confidential</unittitle>
+              <container id="aspace_574512d4023319ad0abc4db6a76623d8" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_68d92edfd9dbfe8d33e65a48084a74db" parent="aspace_574512d4023319ad0abc4db6a76623d8" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_b09a25b6f6821ac97b1c9c0d2d8b0d5a">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref692_ytq" level="file">
+            <did>
+              <unittitle>CL5, Chapter 5: SMALGOL-61</unittitle>
+              <container id="aspace_f0ef591cc13397faf9910593f7c2389e" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_07f980fb8406c863aec466a0df5c9b19" parent="aspace_f0ef591cc13397faf9910593f7c2389e" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_666ef384869d0ecc7a31e03939697039">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref694_ko9" level="file">
+            <did>
+              <unittitle>CL6, Chapter 6: Man or Boy?</unittitle>
+              <container id="aspace_a9b451ab8b8b1cc1126cfc09a9742488" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_6bd74b7527e2fad28b3ffcd1ef3af7be" parent="aspace_a9b451ab8b8b1cc1126cfc09a9742488" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_2a2efc53994b2fd1e981b9cf3bb6e0e1">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref696_4rq" level="file">
+            <did>
+              <unittitle>CL7, Chapter 7: A Proposal for Input-Output Conventions in ALGOL 60</unittitle>
+              <container id="aspace_eaa0ff030719a4e9fef5a7eb6e4302c7" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_74ded6a4017e2f303710f2c7440d738d" parent="aspace_eaa0ff030719a4e9fef5a7eb6e4302c7" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_e795fbaa8e0233db078070f1ac4cc3a6">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; subsequent correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref698_l5x" level="file">
+            <did>
+              <unittitle>CL8, Chapter 8: The Remaining Trouble Spots in ALGOL 60</unittitle>
+              <container id="aspace_06e15e7550cdc3099d707c30a65f69bd" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_3865b7c0bf1882004337d7259d333309" parent="aspace_06e15e7550cdc3099d707c30a65f69bd" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_47bc323309c38f6543b16d966e1dd290">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref700_deg" level="file">
+            <did>
+              <unittitle>CL 9, Chapter 9: SOL – A Symbolic Language for Systems Simulation</unittitle>
+              <container id="aspace_dd1514b3c919c5c3f8b741483cb721d9" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_a0fa0142a7c290b349bb678947c2510e" parent="aspace_dd1514b3c919c5c3f8b741483cb721d9" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_be99e68bf02ef79e999f6a4969444caa">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref702_enp" level="file">
+            <did>
+              <unittitle>CL10, Chapter 10: A Formal Definition of SOL</unittitle>
+              <container id="aspace_e26478eb15bd771e86578bb4d2d8394d" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_0ba7860cdea8f51b0fe49aad00305342" parent="aspace_e26478eb15bd771e86578bb4d2d8394d" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_1c9fb645ee5d8e8d92981d9bdf2661e3">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref704_loe" level="file">
+            <did>
+              <unittitle>CH11, Chapter 11: The Science of Programming Languages</unittitle>
+              <container id="aspace_6d6aa7c4b99fce359090faa5701c179c" label="Mixed Materials [aspace.536828.box.1]" type="Box">1</container>
+              <container id="aspace_1a496e418c661973d08710a2b226ecb9" parent="aspace_6d6aa7c4b99fce359090faa5701c179c" type="folder">11</container>
+            </did>
+            <scopecontent id="aspace_eadad7ab2e4d8581ca645ab0630fb637">
+              <head>Scope and Contents note</head>
+              <p>Copy of old manuscript notes; manuscripts for newly added material, including computer programs to check the examples; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref706_sy0" level="file">
+            <did>
+              <unittitle>CL12, Chapter 12: Programming Languages for Automata</unittitle>
+              <container id="aspace_8097a2b65eb689a28a729ac8b52240b8" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_b126c4d6149fe57fb97687a427bafec0" parent="aspace_8097a2b65eb689a28a729ac8b52240b8" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_20d484155f4fec2c7a60df7cc3c81bb7">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref708_9pt" level="file">
+            <did>
+              <unittitle>CL13, Chapter 13: A Characterization of Parenthesis Languages</unittitle>
+              <container id="aspace_378c19e78920542cf6a061569b11dde0" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_835d44d64cd5a2085108fb5b5926fdb6" parent="aspace_378c19e78920542cf6a061569b11dde0" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_4abda904bd00eca58a6d1148ffef36ca">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref710_xcl" level="file">
+            <did>
+              <unittitle>CL14, Chapter 14: Top-Down Syntax Analysis</unittitle>
+              <container id="aspace_c109776e5c9869aa4ec27a8589990a81" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_1f8488b5d8f1eb473557399b4ea715ed" parent="aspace_c109776e5c9869aa4ec27a8589990a81" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_dc3120ef4b5d073426e020b785d55eed">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref712_9i4" level="file">
+            <did>
+              <unittitle>CL15, Chapter 15: On the Translation of Languages from Left to Right</unittitle>
+              <container id="aspace_59dd23c546519f8665e31afb8299b406" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_821cc9f42851bc5a146e28b003e3423f" parent="aspace_59dd23c546519f8665e31afb8299b406" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_48306c2148d0f0c0e9f967acbfc285ae">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref714_wpt" level="file">
+            <did>
+              <unittitle>CL16, Chapter 16: Context-Free Multilanguages</unittitle>
+              <container id="aspace_aa2360ccef511e59d50fb11ea7e5a39c" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_312ab58174f5807cedb953c5e0f898e7" parent="aspace_aa2360ccef511e59d50fb11ea7e5a39c" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_a3701bf819ef5bf73fcf9562251d682c">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref716_e5o" level="file">
+            <did>
+              <unittitle>CL17, Chapter 17: Semantics of Context-Free Languages</unittitle>
+              <container id="aspace_034b8af882c86980a86fad0034bb6f74" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_9aedf09597b9df9ce2785155a5a6757d" parent="aspace_034b8af882c86980a86fad0034bb6f74" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_2045f0b6ebe199e2e1930bcae76e4456">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article and errata; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref718_s2t" level="file">
+            <did>
+              <unittitle>CL18, Chapter 18: Examples of Formal Semantics</unittitle>
+              <container id="aspace_d74c41ce077c9ac801db30c07525a62d" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_f8d5e06ca2cf647d3de17f49fbcafbd5" parent="aspace_d74c41ce077c9ac801db30c07525a62d" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_538d837f9ea85b30edcaac655da3efcf">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref720_gna" level="file">
+            <did>
+              <unittitle>CL19, Chapter 19: The Genesis of Attribute Grammars</unittitle>
+              <container id="aspace_73d419b4192d7c1d174f306a259a34f1" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_7e2e4e263ea0021985e973d01cc9c028" parent="aspace_73d419b4192d7c1d174f306a259a34f1" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_1db30d95efc55cf8c0cd130e976753a5">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref722_m2c" level="file">
+            <did>
+              <unittitle>CL20, Chapter 20: A History of Writing Compilers</unittitle>
+              <container id="aspace_2888295e9a18e0c421125337885b2cf9" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_6b8d938afc058a76c840a1e7973bf693" parent="aspace_2888295e9a18e0c421125337885b2cf9" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_8b30526be49d6c978ce3e5611bd56c0a">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; errata; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref724_12y" level="file">
+            <did>
+              <unittitle>CL21, Chapter 21: RUNCIBLE – Algebraic Translation on a Limited Computer</unittitle>
+              <container id="aspace_0d98fdbdfd1fdc9ceb4d79cfad6fd9d8" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_ee75ef59cd01371906acb480f7452e1b" parent="aspace_0d98fdbdfd1fdc9ceb4d79cfad6fd9d8" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_7c748051550b2c1e56b11bde27aa9ab5">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; worksheets to make the illustrations; marked galleys; manuscript for supplementary material; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref726_taf" level="file">
+            <did>
+              <unittitle>CL22, Chapter 22: Computer-Drawn Flowcharts</unittitle>
+              <container id="aspace_0ed5df04c7b53034c4c134597854003a" label="Mixed Materials [aspace.536828.box.2]" type="Box">2</container>
+              <container id="aspace_e0519e014f6613d137724fe6389bcc64" parent="aspace_0ed5df04c7b53034c4c134597854003a" type="folder">11</container>
+            </did>
+            <scopecontent id="aspace_47946a79b4efd1db384486188c5e8619">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref728_0tg" level="file">
+            <did>
+              <unittitle>CL23, Chapter 23: Notes on Avoiding 'go to' Statements</unittitle>
+              <container id="aspace_1b656ec2a65901627739c33a6e0d1ea6" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_6975d72d6884e8ab8fe71a900352e65c" parent="aspace_1b656ec2a65901627739c33a6e0d1ea6" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_3ac0564f255c4c8ea3d068c167f0ffcc">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; errata and correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref730_eaa" level="file">
+            <did>
+              <unittitle>CL24, Chapter 24: An Empirical Study of FORTRAN Programs</unittitle>
+              <container id="aspace_a8eb8262ddc48bd848d3bd15a68636d7" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_522b69c0d37d74174c45ac771f9cfc47" parent="aspace_a8eb8262ddc48bd848d3bd15a68636d7" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_26a6bc8026120ca0c12985ca4f6b75fe">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref732_3ju" level="file">
+            <did>
+              <unittitle>CL25, Chapter 25: Efficient Coroutine Generation</unittitle>
+              <container id="aspace_6f7409cc448308df3b216327236016ad" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_8d20bbbd449a99fe47c75f84cf18173c" parent="aspace_6f7409cc448308df3b216327236016ad" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_137a95bf587eabf9af34ea94189927fb">
+              <head>Scope and Contents note</head>
+              <p>Edited version (This article was composed for a festscrift publication that actually didn't appear until 2004.)</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref734_ua0" level="file">
+            <did>
+              <unittitle>CL26, Miscellaneous scraps:</unittitle>
+              <container id="aspace_2d68f3c16dd508263504eed0f1e7ab54" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_a12147d45ea3b16812dee91bce57211e" parent="aspace_2d68f3c16dd508263504eed0f1e7ab54" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_61e1e44b560f370bb2f522e4ca3021a1">
+              <head>Scope and Contents note</head>
+              <p>Proof of frontispiece; first draft of the index; correspondence re index</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref736_sb0" level="file">
+            <did>
+              <unittitle>CL27, First printout of entire book, chapters 1-8</unittitle>
+              <container id="aspace_2261425df86c948533f2264059667f9c" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_c75e6b4b37db3f9fe971af2853164642" parent="aspace_2261425df86c948533f2264059667f9c" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref737_gp1" level="file">
+            <did>
+              <unittitle>CL27, First printout of entire book, chapters 9-14</unittitle>
+              <container id="aspace_dc372b54fe497af0eb45ddf22512fb29" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_b34b9bab6982ffbbc64746043951e410" parent="aspace_dc372b54fe497af0eb45ddf22512fb29" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref738_rwv" level="file">
+            <did>
+              <unittitle>CL27, First printout of entire book, chapters 15-21</unittitle>
+              <container id="aspace_1653368ed6a056fc2e0d3537706c3102" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_00153423e8fa136a5ffc3f58d77d3aa9" parent="aspace_1653368ed6a056fc2e0d3537706c3102" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref739_sr2" level="file">
+            <did>
+              <unittitle>CL27, First printout of entire book, chapters 22-end</unittitle>
+              <container id="aspace_a58ce4b3f895d829ce4a9681183036d3" label="Mixed Materials [aspace.536828.box.3]" type="Box">3</container>
+              <container id="aspace_41d5096bcb8b16b5f1c099bd5bd4f065" parent="aspace_a58ce4b3f895d829ce4a9681183036d3" type="folder">8</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref740_y44" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">Selected Papers on Discrete Mathematics</title>
+            </unittitle>
+          </did>
+          <c id="aspace_ref741_v9u" level="file">
+            <did>
+              <unittitle>DM01, Chapter 1: Combinatorial Analysis and Computer</unittitle>
+              <container id="aspace_3e7d04daf584c28e94671aa6fd7d07c4" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_0182cd5d2290597282283aa3d0434a8f" parent="aspace_3e7d04daf584c28e94671aa6fd7d07c4" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_f4a3c7b58caef9d64a77996f79c3b629">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref743_vnl" level="file">
+            <did>
+              <unittitle>DM02, Chapter 2: Two Notes on Notation</unittitle>
+              <container id="aspace_d649eb76c7bcfb6989b1d3d8ef5381ef" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_8464c2491019d289ff22027fc72521da" parent="aspace_d649eb76c7bcfb6989b1d3d8ef5381ef" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_a35323a418a96fbfb108cac8598ec510">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref745_4is" level="file">
+            <did>
+              <unittitle>DM03, Chapter 3: Bracket Notation for the 'Coefficient of' Operator</unittitle>
+              <container id="aspace_429d12174263c857ad8617d2bc0dec1a" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_5087743295fd531d4d14ef471fe6ad24" parent="aspace_429d12174263c857ad8617d2bc0dec1a" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_74ca64996440eda2d7d212631faf405a">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref747_agw" level="file">
+            <did>
+              <unittitle>DM04, Chapter 4: Johann Faulhaber and Sums of Powers</unittitle>
+              <container id="aspace_fdf77624390d2ddf554ac73cb80d2de2" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_a3f5505cf07c2e644d15282455073cad" parent="aspace_fdf77624390d2ddf554ac73cb80d2de2" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_351d375bc3cd258f60e49b09effd03c3">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref749_rel" level="file">
+            <did>
+              <unittitle>DM05, Chapter 5: Notes on Thomas Harriot</unittitle>
+              <container id="aspace_c24efa237c62f0014b14f12086545b06" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_33d0c281fcd4595b7066fabe74aad5b6" parent="aspace_c24efa237c62f0014b14f12086545b06" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_d46c7cb1c4189dfe46c34d453a86ba4b">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref751_vug" level="file">
+            <did>
+              <unittitle>DM06, Chapter 6: A Permanent Inequality</unittitle>
+              <container id="aspace_2a91da3a0210db8e389e1cdde42999ef" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_2d06b1738eb85312e1cd784a031e1b9f" parent="aspace_2a91da3a0210db8e389e1cdde42999ef" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_6f57db209c1580ec8d836e401cb00c9f">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref753_06r" level="file">
+            <did>
+              <unittitle>DM07, Chapter 7: Overlapping Pfaffians</unittitle>
+              <container id="aspace_4e73da06a8fe52e96ad5a0bb9c897f53" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_8fc3ab2767da4701128552ea01956dee" parent="aspace_4e73da06a8fe52e96ad5a0bb9c897f53" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_7f8d77fcb72df3f362b1b5129c7313eb">
+              <head>Scope and Contents note</head>
+              <p>Copy of original electronic publication; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref755_4nn" level="file">
+            <did>
+              <unittitle>DM08, Chapter 8: The Sandwich Theorem</unittitle>
+              <container id="aspace_28d7d4d52733bdf142b8b29fa781d71f" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_f31267aaf9dd23fdda7ba44c881ddc80" parent="aspace_28d7d4d52733bdf142b8b29fa781d71f" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_99e9ad1645fa9f9f88ffad199d1231da">
+              <head>Scope and Contents note</head>
+              <p>Copy of original electronic publication; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref757_yls" level="file">
+            <did>
+              <unittitle>DM09, Chapter 9: Combinatorial Matrices</unittitle>
+              <container id="aspace_2ef2658662ea90e93065f808d84bf8c7" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_99a7c22bb489bce9e685a38398bce60a" parent="aspace_2ef2658662ea90e93065f808d84bf8c7" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_51de7c26124977c3dab4eb61750d85ac">
+              <head>Scope and Contents note</head>
+              <p>Copy of original electronic preprint; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref759_moo" level="file">
+            <did>
+              <unittitle>DM10, Chapter: Aztec Diamonds, Checkerboard Graphs, Spanning Trees</unittitle>
+              <container id="aspace_61919b1c5c97694caeb3731c835d3dc3" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_10a9e09376072faec7d3080449546900" parent="aspace_61919b1c5c97694caeb3731c835d3dc3" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_844e4116fc4471d2b5527319dfd5f112">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref761_t04" level="file">
+            <did>
+              <unittitle>DM11, Chapter: Partitioned Tensor Products and Their Spectra</unittitle>
+              <container id="aspace_287a5a2fca71bbc60d9ab495650b0cd8" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_f5d028dbc167e7e0ded2cb86582e2db7" parent="aspace_287a5a2fca71bbc60d9ab495650b0cd8" type="folder">11</container>
+            </did>
+            <scopecontent id="aspace_ef55da55622872c1303e199fe2948c54">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref763_mji" level="file">
+            <did>
+              <unittitle>DM12, Chapter: Oriented Subtrees of an Arc Digraph</unittitle>
+              <container id="aspace_b39e37adeece4d26c869fbfc71da16a4" label="Mixed Materials [aspace.536828.box.4]" type="Box">4</container>
+              <container id="aspace_66b2ae815d379ee43dd00313bcd02e93" parent="aspace_b39e37adeece4d26c869fbfc71da16a4" type="folder">12</container>
+            </did>
+            <scopecontent id="aspace_c4fd5ce47fcc81f03c09dcd133ee94e8">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref765_zhx" level="file">
+            <did>
+              <unittitle>DM13, Chapter 13: Another Enumeration of Trees</unittitle>
+              <container id="aspace_c6d601749e80b1ea72f67e5c20e5909c" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_a9989604af7347d7ef706b16c2c3b975" parent="aspace_c6d601749e80b1ea72f67e5c20e5909c" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_ad1480d92b5327753de797d2ebf592cb">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref767_ae5" level="file">
+            <did>
+              <unittitle>DM14, Chapter 14: Abel Identities and Inverse Relations</unittitle>
+              <container id="aspace_5859c6e913069079e21fa1a54ee881cf" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_ff937b6fd93c04345d3f172ead5bc0fa" parent="aspace_5859c6e913069079e21fa1a54ee881cf" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_d679c2b1edd1a90c78c4c0430b8bd190">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref769_bt3" level="file">
+            <did>
+              <unittitle>DM15, Chapter 15: Convolution Polynomials</unittitle>
+              <container id="aspace_8f552cdef7f52d2bb7ad8c57bd0afd47" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_d2a5e916764f2ad9daefce4381bd742f" parent="aspace_8f552cdef7f52d2bb7ad8c57bd0afd47" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_d2c0f70b372e77b47acdaf0d21203990">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref771_jgc" level="file">
+            <did>
+              <unittitle>DM16, Chapter 16: Polynomials Involving the Floor Function</unittitle>
+              <container id="aspace_cb86e696e0498fe0b1eec86bda5a83ce" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_3a4225c63ec5d051cbc9d8073737c2c5" parent="aspace_cb86e696e0498fe0b1eec86bda5a83ce" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_e1bed37045eb35d027a8faf1bf02079c">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref773_2wa" level="file">
+            <did>
+              <unittitle>DM17, Chapter 17: Construction of a Random Sequence</unittitle>
+              <container id="aspace_ad568a191a6a878e04f19319eaca3c65" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_513df65070a13da4382036c198dbb50a" parent="aspace_ad568a191a6a878e04f19319eaca3c65" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_a820496b5488bde2cc53ffb111d7e4ec">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref775_orz" level="file">
+            <did>
+              <unittitle>DM18, Chapter 18: An Imaginary Number System</unittitle>
+              <container id="aspace_7a041cb7fc2547d6e5f21962f39269ee" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_4a85874a8a757e6040cffbd6cba9888c" parent="aspace_7a041cb7fc2547d6e5f21962f39269ee" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_84ea7a1becac8fad3a5aa21a56755b1f">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article and errata; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref777_90u" level="file">
+            <did>
+              <unittitle>DM19, Chapter 19: Tables of Finite Fields</unittitle>
+              <container id="aspace_f2ca9ebbaebd4288d6955f4a8416275d" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_111db7ce90482476a15819ae510679fb" parent="aspace_f2ca9ebbaebd4288d6955f4a8416275d" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_3af376c2b59cfa061ed2f33e813eca77">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref779_8vt" level="file">
+            <did>
+              <unittitle>DM20, Chapter 20: Finite Semifields and Projective Planes</unittitle>
+              <container id="aspace_4e18eeff671fe24efd20fa8b30134550" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_131d0b93cbe3cad52626d5586583b44c" parent="aspace_4e18eeff671fe24efd20fa8b30134550" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_ccd47dce26ad86f2a8762b8b09743ae3">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref781_b4n" level="file">
+            <did>
+              <unittitle>DM21, Chapter 21: A Class of Projective Planes</unittitle>
+              <container id="aspace_750f37a1e0702ed10ad51dbed6074b97" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_2103aa1bef35607943f4036c28fa96f4" parent="aspace_750f37a1e0702ed10ad51dbed6074b97" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_b87a62ce7089a781e3d086ac2526af43">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref783_m0m" level="file">
+            <did>
+              <unittitle>DM22, Chapter 22: Notes on Central Groupoids</unittitle>
+              <container id="aspace_e5dca700299d9cb8228000a45f269ba3" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_f58dfbe7aae12e24ac12a5b4f31b54e7" parent="aspace_e5dca700299d9cb8228000a45f269ba3" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_d416609dfdc74bb418c0e49845a03193">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; computer programs and articles used for supplementary material; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref785_krw" level="file">
+            <did>
+              <unittitle>DM23, Chapter 23: Huffman's Algorithm via Algebra</unittitle>
+              <container id="aspace_deefac0e97b62fd17b61fa95c4e43176" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_d12b32794a1d312228419a578d622fff" parent="aspace_deefac0e97b62fd17b61fa95c4e43176" type="folder">11</container>
+            </did>
+            <scopecontent id="aspace_9ce15b8aa96e355467393f9948c88707">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref787_519" level="file">
+            <did>
+              <unittitle>DM24, Chapter 24: Wheels Within Wheels</unittitle>
+              <container id="aspace_74ae8ae14477ae4c045cbfc16dffead5" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_79be23ec387883794a129efe652abcb5" parent="aspace_74ae8ae14477ae4c045cbfc16dffead5" type="folder">12</container>
+            </did>
+            <scopecontent id="aspace_d6c0fc35872f9e7591b995b4ee4a400b">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref789_xhv" level="file">
+            <did>
+              <unittitle>DM25, Chapter 25: Complements and Transitive Closures</unittitle>
+              <container id="aspace_6df8168506d0ff9fdd1cbac2f8e4ee48" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_5fe6853f34a55d52f070b3ee1b7470cd" parent="aspace_6df8168506d0ff9fdd1cbac2f8e4ee48" type="folder">13</container>
+            </did>
+            <scopecontent id="aspace_c49fde9a06fa1eff7e34ccf25076cb80">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref791_4ug" level="file">
+            <did>
+              <unittitle>DM26, Chapter 26: Random Matroids</unittitle>
+              <container id="aspace_d66fef87e2a559da779b850c7621f842" label="Mixed Materials [aspace.536828.box.5]" type="Box">5</container>
+              <container id="aspace_b74754437d2bd0f197efd64f9d9a6ca8" parent="aspace_d66fef87e2a559da779b850c7621f842" type="folder">14</container>
+            </did>
+            <scopecontent id="aspace_ba753d40e40a94c11c801eaf0c28aa9e">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; computer programs used to check examples; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref793_zb4" level="file">
+            <did>
+              <unittitle>DM27, Chapter 27: The Asymptotic Number of Geometries</unittitle>
+              <container id="aspace_59cc8cde3f212680061e4b6d2b7183ea" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_18024d8669d863b033e67f8e5ffbb0f0" parent="aspace_59cc8cde3f212680061e4b6d2b7183ea" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_9655140388a47582199c9310445920cf">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref795_lmd" level="file">
+            <did>
+              <unittitle>DM28, Chapter 28: Permutations with Nonnegative Partial Sums</unittitle>
+              <container id="aspace_5617f9c34c231fa8ce5235c4823dffb1" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_57e3ec7ac43de2ef423e3c581ff9e254" parent="aspace_5617f9c34c231fa8ce5235c4823dffb1" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_2127086b3fa58afe8f694c1c68d087d8">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref797_zvz" level="file">
+            <did>
+              <unittitle>DM29, Chapter 29: Efficient Balanced Codes</unittitle>
+              <container id="aspace_3b0be5e7d1fa9bec8a071d03ad88baad" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_99a97e846bcd13c6676aafe58fa69d2c" parent="aspace_3b0be5e7d1fa9bec8a071d03ad88baad" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_42a27d1859e58a1415418363bdbde879">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; reprint of paper used to prepare addendum; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref799_l1g" level="file">
+            <did>
+              <unittitle>DM30, Chapter 30: The Knowlton\with Graham Partition Problem</unittitle>
+              <container id="aspace_81e45a83e9d5386c1391e705159e486e" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_58af5641e0d7e7ac47fd42317884ad41" parent="aspace_81e45a83e9d5386c1391e705159e486e" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_c015ae7489bfae0236f1231ec138c5e1">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref801_5tf" level="file">
+            <did>
+              <unittitle>DM31, Chapter 31: Permutations, Matrices, Generalized Young Tableaux</unittitle>
+              <container id="aspace_1fca02da9522a27c5ea4d8876d56585b" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_44a36814732764e5121a3af481f9b776" parent="aspace_1fca02da9522a27c5ea4d8876d56585b" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_85ca48723359694ae8dc8f8206f66cc2">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref803_r6t" level="file">
+            <did>
+              <unittitle>DM32, Chapter 32: Enumeration of Plane Partitions</unittitle>
+              <container id="aspace_ecdfd72c1747e56fddff2fd917ff55ed" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_bb005679d7aaf8cf0d49660c20347bf9" parent="aspace_ecdfd72c1747e56fddff2fd917ff55ed" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_6a2bbaee923a1dc3bef9130040a9a413">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref805_gog" level="file">
+            <did>
+              <unittitle>DM33, Chapter 33: A Note on Solid Partitions</unittitle>
+              <container id="aspace_b13f8252dde693d72f5c622919ca52f9" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_7a75ce04d90ceec19c2563be7bf90f66" parent="aspace_b13f8252dde693d72f5c622919ca52f9" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_efeb74b3a762efa0f3fe6fac47d40aba">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; computer program used to check the algorithm; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref807_2vz" level="file">
+            <did>
+              <unittitle>DM34, Chapter 34: Identities from Partition Involutions</unittitle>
+              <container id="aspace_a40d5c6a2c44bfb620926915540be172" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_34f173b610d506c898c20d23b38f4df9" parent="aspace_a40d5c6a2c44bfb620926915540be172" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_33d153d8353a78cbf8d0a701e0c8c404">
+              <head>Scope and Contents note</head>
+              <p>Correspondence; computer program; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref809_3ud" level="file">
+            <did>
+              <unittitle>DM35, Chapter 35: Subspaces, Subsets, and Partitions</unittitle>
+              <container id="aspace_3a5cb5440027bf3cb9dddda9c5585c42" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_4332d1803f27a41b7200774d248c7c94" parent="aspace_3a5cb5440027bf3cb9dddda9c5585c42" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_8f6f8354c3b6f677c47ee736d54b4973">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref811_r4e" level="file">
+            <did>
+              <unittitle>DM36, Chapter 36: The Power of a Prime...</unittitle>
+              <container id="aspace_b58242c22dab0f1e1ccf963b1756311b" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_e42ccad0b39839c9c49f82d8b3d331fa" parent="aspace_b58242c22dab0f1e1ccf963b1756311b" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_99ff1fc75f027f8562a3a954b3a222db">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref813_s5g" level="file">
+            <did>
+              <unittitle>DM37, Chapter 37: An Almost Linear Recurrence</unittitle>
+              <container id="aspace_a26d90a221a4ac48f2a440ce69f43977" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_2dc067dbc7801494939c3cbb881e92c2" parent="aspace_a26d90a221a4ac48f2a440ce69f43977" type="folder">11</container>
+            </did>
+            <scopecontent id="aspace_c370b0aaec668b8df9d3e0f2cfa33fbf">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref815_7nu" level="file">
+            <did>
+              <unittitle>DM38, Chapter 38: Recurrence Relations Based on Minimization</unittitle>
+              <container id="aspace_b50041b712d2f037db3868ecd45dc8b7" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_513bbcf35f9e18d2c94153477b721da4" parent="aspace_b50041b712d2f037db3868ecd45dc8b7" type="folder">12</container>
+            </did>
+            <scopecontent id="aspace_dd47959d5f6f6136fd2c28c75f450e17">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; reprint of related article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref817_0fv" level="file">
+            <did>
+              <unittitle>DM39, Chapter 39: A Recurrence Related to Trees</unittitle>
+              <container id="aspace_8d520ed42ca8256b9f6b169c78db1a24" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_1a66c3f93399cb48f1df1436586d4ddc" parent="aspace_8d520ed42ca8256b9f6b169c78db1a24" type="folder">13</container>
+            </did>
+            <scopecontent id="aspace_86b930818f751ece7012bce1e330c7e3">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref819_p6b" level="file">
+            <did>
+              <unittitle>DM4, Chapter 40: The First Cycles in an Evolving Graph</unittitle>
+              <container id="aspace_61a9c209510866659dbe1fe935f5c3a5" label="Mixed Materials [aspace.536828.box.6]" type="Box">6</container>
+              <container id="aspace_595cb28dd446622772eb5aa741bf4afb" parent="aspace_61a9c209510866659dbe1fe935f5c3a5" type="folder">14</container>
+            </did>
+            <scopecontent id="aspace_a149df10dd2982c3c5115b7570aae564">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref821_7iy" level="file">
+            <did>
+              <unittitle>DM41, Chapter 41: The Birth of the Giant Component</unittitle>
+              <container id="aspace_5550adbd26d46660db5f2b590d57d7cd" label="Mixed Materials [aspace.536828.box.7]" type="Box">7</container>
+              <container id="aspace_8cb65739d289a394ad61bc646560cb9b" parent="aspace_5550adbd26d46660db5f2b590d57d7cd" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_383e98d8e9b4f3f5cc4d979b5c85b16a">
+              <head>Scope and Contents note</head>
+              <p>Copy of original article; correspondence;; computer programs and results used to correct the originally reported data; marked galleys; edited version</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref823_i07" level="file">
+            <did>
+              <unittitle>DM42, Miscellaneous scraps</unittitle>
+              <container id="aspace_4196ca07598392c66d162aef6d827e95" label="Mixed Materials [aspace.536828.box.7]" type="Box">7</container>
+              <container id="aspace_ab9265b4e011334611e80240f44dc794" parent="aspace_4196ca07598392c66d162aef6d827e95" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_f09fffcedb08efba79f47f3f3fd08f65">
+              <head>Scope and Contents note</head>
+              <p>List of chapters and number of errors caught by spell-checker; proofs of some illustrations; list of names to complete for the index; first draft of the index</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref825_vlj" level="file">
+            <did>
+              <unittitle>DM43, First Printout of Entire Book</unittitle>
+              <container id="aspace_d64582dc136263888f6e5c2d589f1d09" label="Mixed Materials [aspace.536828.box.8]" type="Box">8</container>
+            </did>
+          </c>
+        </c>
+      </c>
+      <c id="aspace_ref1027_u13" level="series">
+        <did>
+          <unittitle>Addenda, 2011-200</unittitle>
+          <unitid>Accession ARCH 2011-200</unitid>
+        </did>
+        <c id="aspace_ref1028_phn" level="subseries">
+          <did>
+            <unittitle>Selected papers</unittitle>
+          </did>
+          <scopecontent id="aspace_0ce68da9295ba523325d0f68dcf07da8">
+            <head>Scope and Contents note</head>
+            <p>Materials accumulated while preparing the final three volumes of the series of Knuth's technical papers, namely <title render="italic">Selected Papers on Design of Algorithms</title> (published in 2009) <title render="italic">Selected Papers on Fun and Games</title> (published in 2010) <title render="italic">Companion to the Papers of Donald Knuth</title> (to be published in January 2011)</p>
+            <p>Also included are relevant letters written back and forth since 2003, relating not only to the creation of the final three volumes but also to reprints of the first six, and translations into other languages. </p>
+          </scopecontent>
+          <c id="aspace_ref1030_xqi" level="file">
+            <did>
+              <unittitle>DA02: The Bose--Nelson Sorting Problem P55</unittitle>
+              <container id="aspace_60256d9d2f58d323138aebbb431b6de7" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_ba866f40f89914a718aef0577671aa1b" parent="aspace_60256d9d2f58d323138aebbb431b6de7" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_16d1aa0ba2599ffc6b9465812c351581">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs; test of illustrations</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1032_1up" level="file">
+            <did>
+              <unittitle>DA03: A One-Way, Stackless Quicksort Algorithm P115</unittitle>
+              <container id="aspace_17d29d1651aaed19138ccd1e3285e5bc" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_ff87684e5133753d132eed57bf33a578" parent="aspace_17d29d1651aaed19138ccd1e3285e5bc" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_ba73fdf6795ab50e9c412f95d39495c4">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1034_9at" level="file">
+            <did>
+              <unittitle>DA04: Optimum Binary Search Trees P41</unittitle>
+              <container id="aspace_02c5918ccd4eb6905c35f5c66c585001" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_63703a3e964e9c8cfe847f7a9b805489" parent="aspace_02c5918ccd4eb6905c35f5c66c585001" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_b19554db6b926e6828eac2619638297b">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1036_74o" level="file">
+            <did>
+              <unittitle>DA05: Dynamic Huffman Coding P103</unittitle>
+              <container id="aspace_24fdc75733610385f1d7c9f7248657b3" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_30e4dccb77ca496afdee7118c0da395e" parent="aspace_24fdc75733610385f1d7c9f7248657b3" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_4e02b4f67c9125088c0ae04170927f84">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1038_wvj" level="file">
+            <did>
+              <unittitle>DA06: Inhomogeneous Sorting P92</unittitle>
+              <container id="aspace_aac2e6a5a0d7312046720908838d787a" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_1598f14e32dec9772d664e5ab4d7d2a8" parent="aspace_aac2e6a5a0d7312046720908838d787a" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_5751e27f31c875642e26c72a3a0107d8">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1040_t9r" level="file">
+            <did>
+              <unittitle>DA07: Lexicographic Permutations with Restrictions P93</unittitle>
+              <container id="aspace_0605581120ec78270f4e5ca597150339" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_c22d174fc6c3dc1a9a3a19f87fab6218" parent="aspace_0605581120ec78270f4e5ca597150339" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_0625a67b354a1cd389fff68aadc8b544">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1042_ed7" level="file">
+            <did>
+              <unittitle>DA08: Nested Satisfiability P134</unittitle>
+              <container id="aspace_46df7cfecbf513bc01088b62477d9b45" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_f1861ad2c663257f28d398ad49aa9035" parent="aspace_46df7cfecbf513bc01088b62477d9b45" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_2a0d3ba4a36bc1e40be280e04d8350c8">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1044_216" level="file">
+            <did>
+              <unittitle>DA09: Fast Pattern Matching in Strings P71</unittitle>
+              <container id="aspace_877c33f2cb9b29dede7b925367585b38" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_de83c157799235219f725e49a1004ba3" parent="aspace_877c33f2cb9b29dede7b925367585b38" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_3f3d5c4131fba9d73b198281fad90f3a">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1046_2qt" level="file">
+            <did>
+              <unittitle>DA10: Addition Machines P126</unittitle>
+              <container id="aspace_161a3b7b075d4a0d5ddc7da1cf39f100" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_673930de86d06bc47dc0e78fe40d86f6" parent="aspace_161a3b7b075d4a0d5ddc7da1cf39f100" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_bef48098c05d46b55980b55dac165dbc">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1048_ltk" level="file">
+            <did>
+              <unittitle>DA11: A Simple Program Whose Proof Isn't P133</unittitle>
+              <container id="aspace_6ad9ebadb93899b80805c878bb253229" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_82ad022513f6aeedbdfdc57e5e3e4b50" parent="aspace_6ad9ebadb93899b80805c878bb253229" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_cfec06facae4fb548fea0de1e8a9a4b0">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1050_li2" level="file">
+            <did>
+              <unittitle>DA12: Verification of Link-Level Protocols P99</unittitle>
+              <container id="aspace_9bdd1ca9b30fb8fa597599e51c50c4fa" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_3e8b3f89538989eabde06a1872905018" parent="aspace_9bdd1ca9b30fb8fa597599e51c50c4fa" type="folder">11</container>
+            </did>
+            <scopecontent id="aspace_98835ee0215b901448b217f44b6cd072">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1052_bgs" level="file">
+            <did>
+              <unittitle>DA13: A Problem in Concurrent Programming Control Q17</unittitle>
+              <container id="aspace_60ae689497e5b0c8edf0d830d67beee4" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_37fd250a6e0bd519ddff211e1272f8d1" parent="aspace_60ae689497e5b0c8edf0d830d67beee4" type="folder">12</container>
+            </did>
+            <scopecontent id="aspace_4647fc953bf392b3b389141ea33e2ac8">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1054_m5i" level="file">
+            <did>
+              <unittitle>DA14: Optimal Prepaging and Font Caching P105</unittitle>
+              <container id="aspace_850d8c9ee4c8ab3063724ad9223906f3" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_fe707353a17f610799c1b59f28af063d" parent="aspace_850d8c9ee4c8ab3063724ad9223906f3" type="folder">13</container>
+            </did>
+            <scopecontent id="aspace_e9ec0537dc05e8f510bf60cbda818731">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1056_qay" level="file">
+            <did>
+              <unittitle>DA15: A Generalization of Dijkstra's Algorithm P85</unittitle>
+              <container id="aspace_baf0cfff8bc93aac75b062c9f5129276" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_6ea3bead1dc1adbccc7a87c679c86092" parent="aspace_baf0cfff8bc93aac75b062c9f5129276" type="folder">14</container>
+            </did>
+            <scopecontent id="aspace_84c9ebb8f69de1c2530726c6a98d5d78">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1058_aas" level="file">
+            <did>
+              <unittitle>DA16: Two-Way Rounding P145</unittitle>
+              <container id="aspace_1d09cf0bc1d94de4c5885f9645034e53" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_a03a50c270a27ed0a79f7f674bed5595" parent="aspace_1d09cf0bc1d94de4c5885f9645034e53" type="folder">15</container>
+            </did>
+            <scopecontent id="aspace_10e0ec8d55aae2c9a89d223732c2ea3e">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1060_7rt" level="file">
+            <did>
+              <unittitle>DA17: Matroid Partitioning R28</unittitle>
+              <container id="aspace_31fa6d32b217e608b57c1504870ce173" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_cb2e02e0504c35ece3111a96c355c406" parent="aspace_31fa6d32b217e608b57c1504870ce173" type="folder">16</container>
+            </did>
+            <scopecontent id="aspace_b2c830e64ea02b96cdec1fad5c86d030">
+              <head>Scope and Contents note</head>
+              <p> copy of original tech report; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1062_7yr" level="file">
+            <did>
+              <unittitle>DA18: Irredundant Intervals P151</unittitle>
+              <container id="aspace_5ab56b8fc024ce41020bd750cfe7aa90" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_56044aa172e65e0ae65d9b0a3720e24c" parent="aspace_5ab56b8fc024ce41020bd750cfe7aa90" type="folder">17</container>
+            </did>
+            <scopecontent id="aspace_f72fb4fe4d4d8ce1595255681d547077">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; copies of correspondence; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1064_ce2" level="file">
+            <did>
+              <unittitle>DA19: Simple Word Problems in Universal Algebras P34</unittitle>
+              <container id="aspace_63fe61ecd0b56c74f385991be176c353" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_42413e96871e1883d3881054d7fbe23d" parent="aspace_63fe61ecd0b56c74f385991be176c353" type="folder">18</container>
+            </did>
+            <scopecontent id="aspace_8334908c97b231d5e8b85735ac05b150">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1066_tu9" level="file">
+            <did>
+              <unittitle>DA20: Efficient Representation of Perm Groups P123</unittitle>
+              <container id="aspace_d83ca36de1fddf9d128a6e1e153dcd19" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_403a04cafea5041c5d59d12fdc694f91" parent="aspace_d83ca36de1fddf9d128a6e1e153dcd19" type="folder">19</container>
+            </did>
+            <scopecontent id="aspace_e938b17a0c1de4de443217165a78e4ad">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1068_l3q" level="file">
+            <did>
+              <unittitle>DA21: An Algorithm for Brownian Zeros P107</unittitle>
+              <container id="aspace_2db5a2be0d2a107f97b4b99650ec4930" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_3ed258c0a13e56ee8ce7a22878c3b372" parent="aspace_2db5a2be0d2a107f97b4b99650ec4930" type="folder">20</container>
+            </did>
+            <scopecontent id="aspace_6eb2418412699e4b31a3dab0d1bd7685">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1070_l28" level="file">
+            <did>
+              <unittitle>DA22: Semi-Optimal Bases for Linear Dependencies P113</unittitle>
+              <container id="aspace_d568c579824012528383ceb304ee9780" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_89eb317f33dd4a366e67dca590c82140" parent="aspace_d568c579824012528383ceb304ee9780" type="folder">21</container>
+            </did>
+            <scopecontent id="aspace_0ed9104ceda6520eb34528ddfa333bc5">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1072_76o" level="file">
+            <did>
+              <unittitle>DA23: Evading the Drift in Floating-Point Addition P73</unittitle>
+              <container id="aspace_b64ee9ef9e44461506a4cddce5c92abb" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_4287456361654969309290346bfc4e3f" parent="aspace_b64ee9ef9e44461506a4cddce5c92abb" type="folder">22</container>
+            </did>
+            <scopecontent id="aspace_b1113c5f8251c469467bab549564e109">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1074_dzo" level="file">
+            <did>
+              <unittitle>DA24: Deciphering a Linear Congruential Encryption P97</unittitle>
+              <container id="aspace_860762e0e3ef77ec11e69c24b3e9f5a9" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_3c3f16be0c109e41889091567ec278c9" parent="aspace_860762e0e3ef77ec11e69c24b3e9f5a9" type="folder">23</container>
+            </did>
+            <scopecontent id="aspace_38377e43953a1ebe069db334bc655a51">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1076_dfm" level="file">
+            <did>
+              <unittitle>DA25: Computation of Tangent, Euler, and Bernoulli Numbers P27</unittitle>
+              <container id="aspace_115659a381749be0aa2fedd5b5bddb91" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_bedd3d94fb4081f48ccba86448f8f6b8" parent="aspace_115659a381749be0aa2fedd5b5bddb91" type="folder">24</container>
+            </did>
+            <scopecontent id="aspace_359547ab0fa8d011d3ed0f902158fb2f">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1078_r65" level="file">
+            <did>
+              <unittitle>DA26: Euler's Constant to 1271 Places P8</unittitle>
+              <container id="aspace_56e16427df6e93053ad7df650f7d79d0" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_85011ef2df2e4a495cfd8482e58ffc75" parent="aspace_56e16427df6e93053ad7df650f7d79d0" type="folder">25</container>
+            </did>
+            <scopecontent id="aspace_75124d7a652255bd889b4b46c2151673">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1080_21k" level="file">
+            <did>
+              <unittitle>DA27: Evaluation of Polynomials by Computer P9</unittitle>
+              <container id="aspace_534a1ecfb75a7c80fede50c1442e0273" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_be8d9ffd27352eba822a6f743ae9a961" parent="aspace_534a1ecfb75a7c80fede50c1442e0273" type="folder">26</container>
+            </did>
+            <scopecontent id="aspace_6ae76aa30e246b08f0c163c9a0000b39">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1082_b5d" level="file">
+            <did>
+              <unittitle>DA28: Minimizing Drum Latency Time P5</unittitle>
+              <container id="aspace_4783a0d4b36121ac9b57231d2a6dcb2d" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_7f00f0fca59d079ba9251711947ed8b8" parent="aspace_4783a0d4b36121ac9b57231d2a6dcb2d" type="folder">27</container>
+            </did>
+            <scopecontent id="aspace_6537c0065120266b0c9e64536812c3d8">
+              <head>Scope and Contents note</head>
+              <p> copy of original article; marked proofs; appendix on modern solution</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1084_g6p" level="file">
+            <did>
+              <unittitle>DA29: first draft of entire book, used to make the index</unittitle>
+              <container id="aspace_45c68eeddee22d61a25cf25ee5987481" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_a746b2ec723dbd57ab492a5566ce799f" parent="aspace_45c68eeddee22d61a25cf25ee5987481" type="folder">28</container>
+            </did>
+          </c>
+          <c id="aspace_ref1085_tec" level="file">
+            <did>
+              <unittitle>DA30: results of proofreading</unittitle>
+              <container id="aspace_a80569fb99353adaabf9b86465ef0195" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_7597b149932bc049f986196de22a6143" parent="aspace_a80569fb99353adaabf9b86465ef0195" type="folder">29</container>
+            </did>
+          </c>
+          <c id="aspace_ref1086_3lj" level="file">
+            <did>
+              <unittitle>FG00: Front matter</unittitle>
+              <container id="aspace_9968046a1696bcb00b43c02272f9c9bd" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_8591fc0ed18f1b0e7e0f0e68b244de29" parent="aspace_9968046a1696bcb00b43c02272f9c9bd" type="folder">30</container>
+            </did>
+            <scopecontent id="aspace_7a57bfa1ef4487f43220dce67d13d22a">
+              <head>Scope and Contents note</head>
+              <p> early outline and notes; early drafts</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1088_8ar" level="file">
+            <did>
+              <unittitle>FG01: The Potrzebie System of Weights and Measures P1</unittitle>
+              <container id="aspace_265266f3c2981a649150638cbd1c9da4" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e49111996b625e09de424e9f6b93241b" parent="aspace_265266f3c2981a649150638cbd1c9da4" type="folder">31</container>
+            </did>
+            <scopecontent id="aspace_949d7f809044ac6ec03bf07712c781e6">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1090_67n" level="file">
+            <did>
+              <unittitle>FG02: Official Tables of the Potrzebie System 10p</unittitle>
+              <container id="aspace_b7cf528cf90c9ab12907c10e5363a05b" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_56eea1575745de1d6bacee62cbe76e58" parent="aspace_b7cf528cf90c9ab12907c10e5363a05b" type="folder">32</container>
+            </did>
+          </c>
+          <c id="aspace_ref1091_wv6" level="file">
+            <did>
+              <unittitle>FG03: The Revolutionary Potrzebie R4a</unittitle>
+              <container id="aspace_2727c93b4cbf4b3e9f9d427e1df588f9" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_aaca037f5fd7c5164887101b19af7939" parent="aspace_2727c93b4cbf4b3e9f9d427e1df588f9" type="folder">33</container>
+            </did>
+            <scopecontent id="aspace_eabcbc3f339c0ae1e2f12eb55ee50ec6">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1093_o5w" level="file">
+            <did>
+              <unittitle>FG04: A {\mc MAD} Crossword 4p</unittitle>
+              <container id="aspace_14c3d8dd1279ead80d2c8ae2eee22d57" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_4e4f032f180b350c32375ce9d690e09f" parent="aspace_14c3d8dd1279ead80d2c8ae2eee22d57" type="folder">34</container>
+            </did>
+            <scopecontent id="aspace_dce80f609d6522a52073738ca2008c98">
+              <head>Scope and Contents note</head>
+              <p> copy of original editorial correspondence from 1960; marked proofs and trials</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1095_s27" level="file">
+            <did>
+              <unittitle>FG06: The Complexity of Songs Q48</unittitle>
+              <container id="aspace_88f3fff94c6c88fb96ed87887c3ff2dc" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_1d25461403f26738974539eac2c72dcd" parent="aspace_88f3fff94c6c88fb96ed87887c3ff2dc" type="folder">35</container>
+            </did>
+            <scopecontent id="aspace_70a0377c88e3fb2c28bb240471441081">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1097_8wk" level="file">
+            <did>
+              <unittitle>FG07: TPK in {\mc INTERCAL} 18p</unittitle>
+              <container id="aspace_569c352db0ad299d46871e10e7f02467" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_bd48ac54e03a4959bf6d0247e2f677c1" parent="aspace_569c352db0ad299d46871e10e7f02467" type="folder">36</container>
+            </did>
+            <scopecontent id="aspace_4cfed76402afc64965ccea916dfa3f6c">
+              <head>Scope and Contents note</head>
+              <p> early draft notes; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1099_xg9" level="file">
+            <did>
+              <unittitle>FG08: Math Ace: The Plot Thickens R4cd</unittitle>
+              <container id="aspace_eaf05da9a478cca3b327c4793ff9e916" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e2ea2540e61716a24bd1d297b24a3274" parent="aspace_eaf05da9a478cca3b327c4793ff9e916" type="folder">37</container>
+            </did>
+            <scopecontent id="aspace_2ac6a3861b3e9922fdcb8327e902dc39">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1101_1sg" level="file">
+            <did>
+              <unittitle>FG09: Billiard Balls in an Equilateral Triangle P14</unittitle>
+              <container id="aspace_0b40d8066d6e667a6f7ff14e56ea885d" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_d385dd808d99ecbeb86be383963c3e10" parent="aspace_0b40d8066d6e667a6f7ff14e56ea885d" type="folder">38</container>
+            </did>
+            <scopecontent id="aspace_4b414ba0a39288e0d9d29db4c46bb07c">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1103_aq5" level="file">
+            <did>
+              <unittitle>FG10: Representing Numbers Using Only One 4 P18</unittitle>
+              <container id="aspace_60b512dbd75716ca8cdc5631a9bde3e9" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_758c8d814d9fb5416754453ff567efa5" parent="aspace_60b512dbd75716ca8cdc5631a9bde3e9" type="folder">39</container>
+            </did>
+            <scopecontent id="aspace_7b0817f3e0fbe96bd4db7a0e67b57d34">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1105_o4p" level="file">
+            <did>
+              <unittitle>FG11: Very Magic Squares P31</unittitle>
+              <container id="aspace_95e4655c23ba488476277d470d65729e" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_b6f2a82be8e7cc5a3f4c5037845916ba" parent="aspace_95e4655c23ba488476277d470d65729e" type="folder">40</container>
+            </did>
+            <scopecontent id="aspace_13078c49efd345fe3675db74b4c9dfe4">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1107_il7" level="file">
+            <did>
+              <unittitle>FG12: The Gamow--Stern Elevator Problem P35</unittitle>
+              <container id="aspace_30f0c85cdb9cb24108b33f76ffb55e16" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_741181027932e49b8128fdac4745b6f9" parent="aspace_30f0c85cdb9cb24108b33f76ffb55e16" type="folder">41</container>
+            </did>
+            <scopecontent id="aspace_94499c3d97a9c8f9ed841cb2ca9cfec0">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1109_qb4" level="file">
+            <did>
+              <unittitle>FG13: Fibonacci Multiplication P117</unittitle>
+              <container id="aspace_8abb256e0d9a97062b3fc7697bfbd986" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_c65b980b4b04aa68ea7df960fd7178b5" parent="aspace_8abb256e0d9a97062b3fc7697bfbd986" type="folder">42</container>
+            </did>
+            <scopecontent id="aspace_6be0486fdd49ced1452dfc2519537a1e">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1111_wpc" level="file">
+            <did>
+              <unittitle>FG14: A Fibonacci-Like Sequence of Composite Numbers P119</unittitle>
+              <container id="aspace_cbfdc7f30a4096afc092d59977c07e52" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_6a1e754f21d33fc294056b0438147622" parent="aspace_cbfdc7f30a4096afc092d59977c07e52" type="folder">43</container>
+            </did>
+            <scopecontent id="aspace_eed928902361101bb996ed8305f77e5f">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1113_2qp" level="file">
+            <did>
+              <unittitle>FG15: Transcendental Numbers Based on the Fibonacci Sequence P13</unittitle>
+              <container id="aspace_3c21c64dd3b94f65fb0270bfba9156f3" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_929ee2fd63be3023836f5fcdb29d96dd" parent="aspace_3c21c64dd3b94f65fb0270bfba9156f3" type="folder">44</container>
+            </did>
+            <scopecontent id="aspace_fa767210718d4f6d7096291d50c3218f">
+              <head>Scope and Contents note</head>
+              <p> marked proofs; copy of recent research cited in addendum</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1115_5e5" level="file">
+            <did>
+              <unittitle>FG16: Supernatural Numbers P95</unittitle>
+              <container id="aspace_34970a78656bae7d85ce9063cc82ce60" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e6b43c3ce2a49520372b65f6e66432ee" parent="aspace_34970a78656bae7d85ce9063cc82ce60" type="folder">45</container>
+            </did>
+            <scopecontent id="aspace_cd2aa7c51d13e0b1cded37b877a67626">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1117_cvn" level="file">
+            <did>
+              <unittitle>FG17: Mathematical Vanity Plates Q210</unittitle>
+              <container id="aspace_ca131305c10a3fbba90ec39ac3433246" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_430bda754ef3c75958c07590d6dfdb11" parent="aspace_ca131305c10a3fbba90ec39ac3433246" type="folder">46</container>
+            </did>
+            <scopecontent id="aspace_52d04a0ca543836054f3ebc0b59060d8">
+              <head>Scope and Contents note</head>
+              <p> proofs of illustrations; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1119_g3d" level="file">
+            <did>
+              <unittitle>FG18: Diamond Signs 18p</unittitle>
+              <container id="aspace_4145c05a2b10d8c1b62ed2ea71868acd" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_8553c48c99335b84e922646ab7baca34" parent="aspace_4145c05a2b10d8c1b62ed2ea71868acd" type="folder">47</container>
+            </did>
+            <scopecontent id="aspace_fd669f682cba358a6dee10640bbf5309">
+              <head>Scope and Contents note</head>
+              <p> proofs of illustrations; handwritten drafts; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1121_pn6" level="file">
+            <did>
+              <unittitle>FG19: The Orchestra Song 6p</unittitle>
+              <container id="aspace_9603f62461d2ecfa82c3422e20feef1a" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e84a938ad85a28f984de4f7832920bcc" parent="aspace_9603f62461d2ecfa82c3422e20feef1a" type="folder">48</container>
+            </did>
+            <scopecontent id="aspace_35e506d68411c55d000a00ace5356886">
+              <head>Scope and Contents note</head>
+              <p> first proofs of music setting with METAPOST; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1123_6rk" level="file">
+            <did>
+              <unittitle>FG20: Gnebbishland 4p</unittitle>
+              <container id="aspace_8d705d2253a6f833bb78745b76a25417" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_688a01932c43c873fd730fa0b7f14486" parent="aspace_8d705d2253a6f833bb78745b76a25417" type="folder">49</container>
+            </did>
+            <scopecontent id="aspace_d1af9fcf40277c48df5e8cae56ab73eb">
+              <head>Scope and Contents note</head>
+              <p> handwritten MS; web research on nebbishes; correspondence; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1125_55n" level="file">
+            <did>
+              <unittitle>FG21: A Carol for Advent 3p</unittitle>
+              <container id="aspace_1e7497d2d6504d20f2b841f274a8422a" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_377618a87f70bb9e1102f816582b0324" parent="aspace_1e7497d2d6504d20f2b841f274a8422a" type="folder">50</container>
+            </did>
+            <scopecontent id="aspace_28f5c3088c0c7b8c9b6a013f49904798">
+              <head>Scope and Contents note</head>
+              <p> original music and lyrics sent out Christmas 2001; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1127_rxx" level="file">
+            <did>
+              <unittitle>FG22: Randomness in Music 6p</unittitle>
+              <container id="aspace_b32e9b408b1f4a4dea3133be4fc43eb4" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_b8ff9b79acb1e04f5fcfe56d1dae8dc9" parent="aspace_b32e9b408b1f4a4dea3133be4fc43eb4" type="folder">51</container>
+            </did>
+            <scopecontent id="aspace_be534749ba0f159c11ecee7990155925">
+              <head>Scope and Contents note</head>
+              <p> proofs of illustrations; library search re Strindberg; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1129_rhm" level="file">
+            <did>
+              <unittitle>FG23: Basketball's Electronic Coach 10p</unittitle>
+              <container id="aspace_ceb617ec9ef7a9cf12388f6e118570ba" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_b1685e93f04441d5fe43cea4fb5629fe" parent="aspace_ceb617ec9ef7a9cf12388f6e118570ba" type="folder">52</container>
+            </did>
+            <scopecontent id="aspace_34f354300bf234931da8de952e6283dc">
+              <head>Scope and Contents note</head>
+              <p> original notes; marked proofs; correspondence about players' names</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1131_0hl" level="file">
+            <did>
+              <unittitle>FG24: The Triel: A New Solution P58</unittitle>
+              <container id="aspace_8bc8dfdd9c85e46b9a9336fea145d2bd" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_2c7a6697b2718497da20820d0fed219e" parent="aspace_8bc8dfdd9c85e46b9a9336fea145d2bd" type="folder">53</container>
+            </did>
+            <scopecontent id="aspace_a8dbf999ddb262475169770dbcae6f7d">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1133_yvi" level="file">
+            <did>
+              <unittitle>FG25: The Computer as Master Mind P81</unittitle>
+              <container id="aspace_fdc9c51f009d97f00fcf3c390b2477d6" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_a1476987cb1aed5a2df96d689767f259" parent="aspace_fdc9c51f009d97f00fcf3c390b2477d6" type="folder">54</container>
+            </did>
+            <scopecontent id="aspace_aee71cec2aa1d0eb7f74d559c9074436">
+              <head>Scope and Contents note</head>
+              <p> marked proofs; correspondence re early sets and new results</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1135_mnf" level="file">
+            <did>
+              <unittitle>FG26: Move It Or Lose It Q223</unittitle>
+              <container id="aspace_50bf9a97e2e44e3d501c81194bc8209e" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_4dba9f5714f47520fb65dcb0becc8fb2" parent="aspace_50bf9a97e2e44e3d501c81194bc8209e" type="folder">55</container>
+            </did>
+            <scopecontent id="aspace_5ac28b4c57d0559ae5ddc8191ee1dbb8">
+              <head>Scope and Contents note</head>
+              <p> copy of original letter to Martin Gardner; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1137_jq7" level="file">
+            <did>
+              <unittitle>FG27.1: Adventure 160p</unittitle>
+              <container id="aspace_9c195d09b25d1a934fffc6d1a3a9d8ef" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e47fdf09e4607e5fd9c19987fd251e54" parent="aspace_9c195d09b25d1a934fffc6d1a3a9d8ef" type="folder">56</container>
+            </did>
+            <scopecontent id="aspace_1c30d052a4e4748633b98c9057c67e72">
+              <head>Scope and Contents note</head>
+              <p> original CTWILLed program before converting to book pages</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1139_m41" level="file">
+            <did>
+              <unittitle>FG27.2: Adventure 160p</unittitle>
+              <container id="aspace_638148089cb28fbe6a184f36751b236e" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_20c991eaef7a59b1ebd3fef2ff824483" parent="aspace_638148089cb28fbe6a184f36751b236e" type="folder">57</container>
+            </did>
+            <scopecontent id="aspace_a36a261782fd136e9d970702e03977ba">
+              <head>Scope and Contents note</head>
+              <p> early proofs of cave map; first version of the program in book-page format</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1141_5d2" level="file">
+            <did>
+              <unittitle>FG27.3: Adventure 160p</unittitle>
+              <container id="aspace_d8d4294a1b6ebc10e6cda6f3ade7bcc2" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e11bab3013c54670a2941bf3697b9931" parent="aspace_d8d4294a1b6ebc10e6cda6f3ade7bcc2" type="folder">58</container>
+            </did>
+            <scopecontent id="aspace_a53b46bdd15428fb47dcd46739808dc9">
+              <head>Scope and Contents note</head>
+              <p> marked proofs of May 2010</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1143_fzm" level="file">
+            <did>
+              <unittitle>FG28: Ziegler's Giant Bar 6p</unittitle>
+              <container id="aspace_2f903cebb83158baee7a5ba132419d55" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_478d9e0fca0c462ba81b7fdd1dcacd68" parent="aspace_2f903cebb83158baee7a5ba132419d55" type="folder">59</container>
+            </did>
+            <scopecontent id="aspace_248520de4024994babe7261b9707911a">
+              <head>Scope and Contents note</head>
+              <p> tests of illustrations; marked proofs; correspondence re Milwaukee TV etc; material from the dictionary I used in 1952; copies of news clippings</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1145_p7v" level="file">
+            <did>
+              <unittitle>FG29: The Chemical Caper R4b</unittitle>
+              <container id="aspace_62c869750ddbf1bbdf4989d07c03d1fa" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_e84cc1b7ebd9b670c2d6869b6366b13b" parent="aspace_62c869750ddbf1bbdf4989d07c03d1fa" type="folder">60</container>
+            </did>
+            <scopecontent id="aspace_3b684154181fabbe6a4a2f936bdaa5e6">
+              <head>Scope and Contents note</head>
+              <p> marked proofs; info about original names of newly discovered elements</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1147_3bv" level="file">
+            <did>
+              <unittitle>FG31: Disappearances Q54</unittitle>
+              <container id="aspace_282c84b71c9e42cbbbe8004d41f77e92" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_527e24a1c76aec183ce3c89020b14de7" parent="aspace_282c84b71c9e42cbbbe8004d41f77e92" type="folder">61</container>
+            </did>
+            <scopecontent id="aspace_a0e74bbdaa43618148c70bcb565be4ce">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1149_3ts" level="file">
+            <did>
+              <unittitle>FG32: Lewis~Carroll's word--ward--ware--dare--dame--game Q51</unittitle>
+              <container id="aspace_18e06eb41265064ee594ab50975aca3a" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_2fdcf2b53457ab40dfd3e80ec331b05f" parent="aspace_18e06eb41265064ee594ab50975aca3a" type="folder">62</container>
+            </did>
+            <scopecontent id="aspace_46484e12d44263b804204795cb4e7234">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1151_ty0" level="file">
+            <did>
+              <unittitle>FG34: Biblical Ladders Q172</unittitle>
+              <container id="aspace_25fa2e0e5fe4ddbc7edee97905e3d28d" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_4172892c50cace1fa013a71fbe90588c" parent="aspace_25fa2e0e5fe4ddbc7edee97905e3d28d" type="folder">63</container>
+            </did>
+            <scopecontent id="aspace_2bc80e8e70ec2d20ac00750226036f86">
+              <head>Scope and Contents note</head>
+              <p> marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1153_f1h" level="file">
+            <did>
+              <unittitle>FG36: {\it Quadrata Obscura\/} (Hidden Latin Squares) Q224</unittitle>
+              <container id="aspace_da3e47b61d63e4dae2398e1acbdf55cb" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_c9873988985e0068628990bd6b539794" parent="aspace_da3e47b61d63e4dae2398e1acbdf55cb" type="folder">64</container>
+            </did>
+            <scopecontent id="aspace_4a2faa6eb0a0b1482865c8aaa69bb0af">
+              <head>Scope and Contents note</head>
+              <p> words tests done while composing this puzzle</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1155_3y6" level="file">
+            <did>
+              <unittitle>FG38: Dancing Links P159</unittitle>
+              <container id="aspace_f0cc7386f6b483bbc65f35f27958f84e" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_80c47b53aa46f4cd45d2a5ece26558e9" parent="aspace_f0cc7386f6b483bbc65f35f27958f84e" type="folder">65</container>
+            </did>
+            <scopecontent id="aspace_71b3c41281dda718cc6da54cb7b6eb7a">
+              <head>Scope and Contents note</head>
+              <p> marked proofs, before and after major changes</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1157_e5v" level="file">
+            <did>
+              <unittitle>FG40: Uncrossed Knight's Tours Q23</unittitle>
+              <container id="aspace_fdfa64ee4baa84e5c43ff96284438f49" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_59e3d76858c977f3c2196b1aac4a1ca3" parent="aspace_fdfa64ee4baa84e5c43ff96284438f49" type="folder">66</container>
+            </did>
+            <scopecontent id="aspace_48e2a035684c6c657457d03d040ba8a7">
+              <head>Scope and Contents note</head>
+              <p> samples of marked proofs and illustration tests as I was writing this chapter</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1159_zw7" level="file">
+            <did>
+              <unittitle>FG41: Celtic Knight's Tours 21p</unittitle>
+              <container id="aspace_62c4a60de9e9c0350b8b6f02985efb75" label="Mixed Materials [aspace.536904.box.1]" type="Box">1</container>
+              <container id="aspace_18a345b0a9564aaf6987dd71c4d4f8e6" parent="aspace_62c4a60de9e9c0350b8b6f02985efb75" type="folder">67</container>
+            </did>
+            <scopecontent id="aspace_ad7544f0618b0de5fed746b42e3c7c03">
+              <head>Scope and Contents note</head>
+              <p> samples of marked proofs and illustration tests as I was writing this chapter</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1161_jq0" level="file">
+            <did>
+              <unittitle>FG42: Long and Skinny Knight's Tours 29p</unittitle>
+              <container id="aspace_7ae7a1660ebeb01de2eb36793d7f1dd9" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_89fdc66ddc9a9c5c6007288e90f31f38" parent="aspace_7ae7a1660ebeb01de2eb36793d7f1dd9" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_632e0952842069de90e75895fef9d81f">
+              <head>Scope and Contents note</head>
+              <p> handwritten MS; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1163_xrb" level="file">
+            <did>
+              <unittitle>FG43: Leaper Graphs P147</unittitle>
+              <container id="aspace_243dd5430a255c7b57a0b631b1a1917d" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_94ee08a2aeb5e7f8df7011dbdc9edcb0" parent="aspace_243dd5430a255c7b57a0b631b1a1917d" type="folder">2</container>
+            </did>
+            <scopecontent id="aspace_b9e9740f1805da051699c6a06650fd14">
+              <head>Scope and Contents note</head>
+              <p> marked proofs, before and after major changes</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1165_9l9" level="file">
+            <did>
+              <unittitle>FG44: Number Representations and Dragon Curves P37</unittitle>
+              <container id="aspace_1a4e675b11969c81981bf7a99571443c" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_d15633e433aa1c257cc69499d26a4c5d" parent="aspace_1a4e675b11969c81981bf7a99571443c" type="folder">3</container>
+            </did>
+            <scopecontent id="aspace_3ed3df18b6fa57afcae12fef365bef87">
+              <head>Scope and Contents note</head>
+              <p>index to files re dragon curves; tests of illustrations;  marked proofs, before and after major changes</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1167_sop" level="file">
+            <did>
+              <unittitle>FG45: Mathematics and Art: The Dragon Curve in Ceramic Tile P59</unittitle>
+              <container id="aspace_e6960c1b7402e394a1a41466aac382e6" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_60685a4bb1f2bc1f7a0c324b0a939cf0" parent="aspace_e6960c1b7402e394a1a41466aac382e6" type="folder">4</container>
+            </did>
+            <scopecontent id="aspace_bcb51b2604357024b25d09dfd9e9c9db">
+              <head>Scope and Contents note</head>
+              <p> tests of illustrations; marked proofs</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1169_ouy" level="file">
+            <did>
+              <unittitle>FG46: Christmas Cards 34p</unittitle>
+              <container id="aspace_70a9e5b5f84f9ddea3e86c96a884005b" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_a26f63ca1b1dedd12412f76855d89c6c" parent="aspace_70a9e5b5f84f9ddea3e86c96a884005b" type="folder">5</container>
+            </did>
+            <scopecontent id="aspace_65f5c7180a5172bf5c776bb873fd6e7b">
+              <head>Scope and Contents note</head>
+              <p> samples of proof pages and other tests as I was writing this chapter</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1171_m5o" level="file">
+            <did>
+              <unittitle>FG47: Geek Art 48p</unittitle>
+              <container id="aspace_e7f455bc2b91939f12239343f5da5459" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_a884f00eda5b4fd81ed69bd849921761" parent="aspace_e7f455bc2b91939f12239343f5da5459" type="folder">6</container>
+            </did>
+            <scopecontent id="aspace_bde08d33886aea5ea28961afdfd14617">
+              <head>Scope and Contents note</head>
+              <p> samples of proof pages and other tests as I was writing this chapter</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1173_ap0" level="file">
+            <did>
+              <unittitle>FG49: An Earthshaking Announcement Q227</unittitle>
+              <container id="aspace_b6df4f01a912669f8af389a9bb3c4e5d" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_fbfab930f4f5c832c559e54089638490" parent="aspace_b6df4f01a912669f8af389a9bb3c4e5d" type="folder">7</container>
+            </did>
+            <scopecontent id="aspace_87b38c7b477caabf03beb88336473da4">
+              <head>Scope and Contents note</head>
+              <p> handwritten MS, test illustrations, marked proofs, correspondence</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1175_rab" level="file">
+            <did>
+              <unittitle>FG50: index</unittitle>
+              <container id="aspace_b4f80c59dbad0046d6d030aaf4039493" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_e069fd918d7eae49e5479e52b3390ed7" parent="aspace_b4f80c59dbad0046d6d030aaf4039493" type="folder">8</container>
+            </did>
+            <scopecontent id="aspace_ffbb7e262f4ece1b5db0d4e4c06fbf16">
+              <head>Scope and Contents note</head>
+              <p> ideas for the index (noted while writing the material); first draft pages</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1177_jli" level="file">
+            <did>
+              <unittitle>FG51: early copy of many chapters, used to index them</unittitle>
+              <container id="aspace_62abc68d1c93d9a71d3eeea41345170f" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_576d8567144deb914390b16b342f0f54" parent="aspace_62abc68d1c93d9a71d3eeea41345170f" type="folder">9</container>
+            </did>
+            <scopecontent id="aspace_9cb2332e7a808ca11e4b70336c17215a">
+              <head>Scope and Contents note</head>
+              <p>(before the final order of chapters was decided, and before many of the chapters were written) [I brought these with me to work on in odd moments, during a long trip East]</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1179_1uk" level="file">
+            <did>
+              <unittitle>FG52: first copy of the entire book, sent to proofreading team</unittitle>
+              <container id="aspace_8bc71737047f737eea9c678287b7a1fd" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_a77b56ddb676af6b34b54de40d1aaafa" parent="aspace_8bc71737047f737eea9c678287b7a1fd" type="folder">10</container>
+            </did>
+            <scopecontent id="aspace_0f506894b522135e9e500f3d60586050">
+              <head>Scope and Contents note</head>
+              <p> (and also used to index several chapters)</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1181_hdf" level="file">
+            <did>
+              <unittitle>FG53: feedback from the proofreaders</unittitle>
+              <container id="aspace_4fb4f04b229b052314855340462a6e3a" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_84f494f6747d432f7a5d8d38e2fe410e" parent="aspace_4fb4f04b229b052314855340462a6e3a" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref1182_jeo" level="file">
+            <did>
+              <unittitle>CP00: miscellaneous notes and trial pages saved while making the CPbook</unittitle>
+              <container id="aspace_e567e7b563b76f0330186f620465cc2d" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_8d4427a8f81b73b19301cad9913e15bb" parent="aspace_e567e7b563b76f0330186f620465cc2d" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref1183_8d7" level="file">
+            <did>
+              <unittitle>CP01: rough transcriptions of the taped luncheon conversations between Dikran Karagueuzian and Don Knuth in 1996 (these became Chapters 7--17)</unittitle>
+              <container id="aspace_6acb7bd0b53a9b9c4be8a97673153afd" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_d57d1a9d7fc83ae184236d3a063c12ec" parent="aspace_6acb7bd0b53a9b9c4be8a97673153afd" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref1184_hs2" level="file">
+            <did>
+              <unittitle>CP02: first working copy of the entire CPbook as sent to proofreaders</unittitle>
+              <container id="aspace_d21c84185f929b633d126862767eb5fc" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_d4e026e23ea303111323615692e1848e" parent="aspace_d21c84185f929b633d126862767eb5fc" type="folder">14</container>
+            </did>
+          </c>
+          <c id="aspace_ref1185_88n" level="file">
+            <did>
+              <unittitle>CP03: extensive files of correspondence relating to all nine volumes of the series</unittitle>
+              <container id="aspace_b623b898ffe27bd84ba45032bf01a67b" label="Mixed Materials [aspace.536904.box.2]" type="Box">2</container>
+              <container id="aspace_1eabe012b6a4fa9e5c680e235da220e7" parent="aspace_b623b898ffe27bd84ba45032bf01a67b" type="folder">15</container>
+            </did>
+            <scopecontent id="aspace_f7daae962d2307b3fa98f7d60bf062f6">
+              <head>Scope and Contents note</head>
+              <p>a few of these are from the 1990s, but the vast majority are from the period 2004--2011</p>
+            </scopecontent>
+          </c>
+        </c>
+        <c id="aspace_ref1187_uuk" level="subseries">
+          <did>
+            <unittitle>
+              <title render="italic">The Art of Computer Programming</title>
+            </unittitle>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+          </did>
+          <scopecontent id="aspace_b3f5f70401c23bfa5f1864af2ae5401d">
+            <head>Scope and Contents note</head>
+            <p>Volume 4A of <title render="italic">The Art of Computer Programming</title>was published in January 2011; it represents the culmination of a project that Knuth had begun to write in 1973, when the first edition of Volume 3 was completed. More precisely, Volume 4A represents the "first part of the culmination" of this project, because it's only the first part of a "Volume 4", Combinatorial Algorithms.</p>
+            <p>Table of contents of Volume 4A: <list><item>7. Introduction to combinatorial searching</item><item>7.1. Zeros and ones</item><item>7.1.1. Boolean basics</item><item>7.1.2. Boolean evaluation</item><item>7.1.3. Bitwise tricks and techniques</item><item>7.1.4. Binary decision diagrams</item><item>7.2. Generating all possibilities</item><item>7.2.1. Generating basic combinatorial patterns</item><item>7.2.1.1. Generating all $n$-tuples</item><item>7.2.1.2. Generating all permutations</item><item>7.2.1.3. Generating all combinations</item><item>7.2.1.4. Generating all partitions</item><item>7.2.1.5. Generating all set partitions</item><item>7.2.1.6. Generating all treesv</item><item>7.2.1.7. History and further references</item></list> </p>
+          </scopecontent>
+          <bioghist id="aspace_a593e4fa42cd3169be7dfff18474657b">
+            <head>Biographical/Historical note</head>
+            <p>Background notes from Knuth:</p>
+            <p>I began to collect material already in 1962, but began to work on Volume 4 in earnest in 1973, while visiting the University of Oslo on leave of absence from Stanford. For many years I made scribbled notes and continued to follow the literature as new techniques were discovered. However, I also took time out for other projects (notably typography) and other books (notably Concrete Mathematics and 3:16); then I spent a few years bringing Volumes 1--3 up to date in the 1990s. During 1999 I prepared "Volume 1 Fascicle 1", a paperback booklet about the MMIX computer; MMIX is a new computer intended for use in Volume 4 as well as in future editions of Volumes 1, 2, and 3. (All archives for that fascicle are included in the "MMIX archives" that were donated to Stanford in 2001, except that I recently found a few additional page proofs that I've included here.)</p>
+            <p>I began to write the final copy of Volume 4A in the spring of 2001, in longhand as usual. My diary shows that I began to enter it into the computer on 22 July 2001: "happiness as I resume typing Volume 4 for the first time since 1977". (I had spent four months at the beginning of 1977 preparing what I thought would be Section 7.1; it was an 83-page typewritten manuscript, plus 22 pages of answers to exercises. About 100 copies were made and circulated at that time to interested computer scientists in various universities. The original of that MS is included below. Fate was, however, to intervene, because 1977 was the year that I realized I should drop everything else and work "temporarily" on typography. The TeX project began in the spring of that year and ran for roughly ten years.)</p>
+            <p>In 2001 I actually began to work on Section 7.2.1.1, because I wasn't ready yet to write the opening parts of Chapter 7 (and Volume 4). I needed to flesh out the "middle" of the volume first, so that I'd have a better idea of what tone ought to be set in the opening pages. I continued with the next subsections, 7.2.1.2 through 7.2.1.7, which took several years because they cover a substantial amount of material. These drafts were first made available online as "prefascicles", beginning with prefascicle 2A --- which first went on the Web at 1am on 17 September 2001 [a few days after a somewhat more memorable event in the history of the USA]. Prefascicle 2B went online just before midnight on 31 December of that year.</p>
+            <p>In 2002 I posted prefascicle 2C at noon on 13 June, and began to work on prefascicle 2d. Those two were however subsequently renamed 3A and 3B; prefascicle 3B went online on 14 February 2004. The prefascicles became true "fascicles", printed in paperback by Addison-Wesley, in 2005 when Volume 4 Fascicle 2 and (later) Volume 4 Fascicle 3 were ready.</p>
+            <p>The same pattern was repeated as I continued to write: Prefascicles 4A and 4B went online in 2005, then Volume 4 Fascicle 4 was published in 2006. After finishing Section 7.2.1.7 I was ready to turn to the opening pages of the book; well, not quite: I began now with Section 7.1, still postponing the actual introductory pages. On 27 May 2005 I reread my draft of 7.1 from 1977 and made vague plans for reorganizing it substantially. By 30 May I had typed seven pages into the computer, and had accumulated a long list of things to look up in the library. (This was incidentally before Volume 4 Fascicle 3 was sent to the publisher in June of 2005.) I finished the first draft of Section 7.1.1 on 7 September 2005, and put it online as prefascicle 1B.</p>
+            <p>However, I was soon to learn that Section 7.1.1 should be followed by hundreds of pages of new material, because Sections 7.1.2 and 7.1.3 were growing like crazy. Fascicle 2 had already been published, but at least two fascicles' worth of copy would be needed to precede it! So I decided to create a Fascicle 0, to precede Fascicle 1; and prefascicle 1B was renamed prefascicle 0B. I finished Section 7.1.2 (prefascicle 0C) on 17 March 2006. [Incidentally I had undergone surgery for prostate cancer at the end of 2005, and had radiation therapy during the spring of 2006.] By the end of 2006 I was ready to release Section 7.1.3, aka prefascicle 1A.</p>
+            <p>I turned to the introductory material, prefascicle 0A, at the beginning of 2007, trying to be careful to make it "match" the end of Volume 3 without too much of a change in style even though the end of Volume 3 had been written some 35 years earlier. That prefascicle went public on 28 April 2007; Volume 4 Fascicle 0 was printed in paperback at the beginning of 2008.</p>
+            <p>The remaining piece of the puzzle was Section 7.1.4, which turned out to be extremely interesting material for which I needed to do extensive research. I had typed two sample exercises destined for prefascicle 1B into my home computer on 30 June 2007, and had finished the first three pages by 2 July, thinking that the whole section would amount to roughly 30 pages max. In fact, Section 7.1.4 wound up 80 pages long, with 267 exercises(!), plus almost 60 pages more for answers to those exercises; and I didn't finish prefascicle 1B until 8 September 2008. Addison-Wesley published Volume 4 Fascicle 1 in 2009.</p>
+            <p>The paperback fascicles went through several reprintings, and hundreds of readers sent comments. Much of this material had never before been published in book form, and in fact about a hundred of the exercises are original material that had never appeared before in any form. Therefore it was important to get extensive feedback from readers, and in this I was extremely fortunate. Finally at the end of 2010 I combined all the material from Fascicles 0, 1, 2, 3, and 4 of Volume 4, added some appendices, and sent the completed manuscript to Addison-Wesley's production department (in the form of PostScript files) on 3 December 2010 --- curiously on the very same day that I submitted the final PostScript files for another just-completed book, Selected Papers on Fun and Games, to CSLI's production department at Stanford.</p>
+          </bioghist>
+          <c id="aspace_ref1190_ehu" level="file">
+            <did>
+              <unittitle>Original typewritten manuscript of the opening pages of Volume 4</unittitle>
+              <container id="aspace_d63fb34d369efaa48ebff0e49b245536" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_513e5315f2bfc75df1eda252d19e1945" parent="aspace_d63fb34d369efaa48ebff0e49b245536" type="folder">1</container>
+            </did>
+            <scopecontent id="aspace_74c4105c98f85ceb5eb7d345167b861b">
+              <head>Scope and Contents note</head>
+              <p>[This MS was incidentally typed on a "historic" early IBM Selectric Typewriter, which is now in the collection of the Computer History Museum.]</p>
+            </scopecontent>
+          </c>
+          <c id="aspace_ref1192_gj9" level="file">
+            <did>
+              <unittitle>Changes to my working copy of Volume 1 Fascicle 1 (MMIX)</unittitle>
+              <unitdate datechar="creation">Apr 2000- Jun 2002</unitdate>
+              <container id="aspace_8614c709d9ae4db95d662a0eba15fbf3" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_e7cf1f009725a51a9c6d25b78d166966" parent="aspace_8614c709d9ae4db95d662a0eba15fbf3" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1193_qcd" level="file">
+            <did>
+              <unittitle>Section 7.2.1.1, the first hardcopy proofs of all pages, </unittitle>
+              <unitdate datechar="creation">1-Aug-2001</unitdate>
+              <container id="aspace_0051112df4fd040ed972da06a526fe7a" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_1aafa13e4c8f92a8a04b5c5fb9661327" parent="aspace_0051112df4fd040ed972da06a526fe7a" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref1194_zr0" level="file">
+            <did>
+              <unittitle>Section 7.2.1.1, page proofs to make the index of prefascicle 2A, </unittitle>
+              <unitdate datechar="creation">4-Aug-2001</unitdate>
+              <container id="aspace_a3f5aed9c4b564001c9f3a68a9b80f24" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_747a225e742ed655dc311d62ea517c75" parent="aspace_a3f5aed9c4b564001c9f3a68a9b80f24" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref1195_glm" level="file">
+            <did>
+              <unittitle>Section 7.2.1.2, the first complete page proofs</unittitle>
+              <unitdate datechar="creation">8-Dec-2001</unitdate>
+              <container id="aspace_9f357a004752c66a9e8b0a2ebac95eee" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_a8ddf4c82825cadfb9263424fdfe428c" parent="aspace_9f357a004752c66a9e8b0a2ebac95eee" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref1196_hld" level="file">
+            <did>
+              <unittitle>Changes to my working copies of prefascicles 2A&amp;2B</unittitle>
+              <unitdate datechar="creation">summer 2001 - summer 2002</unitdate>
+              <container id="aspace_8fa3da713b2909088a06df41b07a77c6" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_f46681710d23a5fcbb62a22a06e2d72d" parent="aspace_8fa3da713b2909088a06df41b07a77c6" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref1197_dsi" level="file">
+            <did>
+              <unittitle>Sections 7.2.1.1 and 7.2.1.2, drafts</unittitle>
+              <unitdate datechar="creation">after November 2002</unitdate>
+              <container id="aspace_0a41df4aebec8685ff9d1c17875b9685" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_0cd9e7feac8d3d9acd79a0a731c71620" parent="aspace_0a41df4aebec8685ff9d1c17875b9685" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1198_89t" level="file">
+            <did>
+              <unittitle>Section 7.2.1.3, proof copy used to make index</unittitle>
+              <unitdate datechar="creation">11-Jun-2002</unitdate>
+              <container id="aspace_2fdf47e7e70ae63f8e75ebd5a7c915d7" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_c1be1bc8c64f9a74250e44d18c66a59e" parent="aspace_2fdf47e7e70ae63f8e75ebd5a7c915d7" type="folder">8</container>
+            </did>
+          </c>
+          <c id="aspace_ref1199_t67" level="file">
+            <did>
+              <unittitle>Section 7.2.1.3, first copy (with subsequent corrections)</unittitle>
+              <unitdate datechar="creation">13-Jun-2002</unitdate>
+              <container id="aspace_50dab62df60415b04f4461edd05d747e" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_b81d259df772555ded4bce0e0372b1c3" parent="aspace_50dab62df60415b04f4461edd05d747e" type="folder">9</container>
+            </did>
+          </c>
+          <c id="aspace_ref1200_8m5" level="file">
+            <did>
+              <unittitle>Section 7.2.1.3, version (with subsequent corrections)</unittitle>
+              <unitdate datechar="creation">29-Aug-2003</unitdate>
+              <container id="aspace_4955ad62a04397d9e6b878a4d98c495e" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_e55067d8a590de97c91d882985a5c835" parent="aspace_4955ad62a04397d9e6b878a4d98c495e" type="folder">10</container>
+            </did>
+          </c>
+          <c id="aspace_ref1201_gou" level="file">
+            <did>
+              <unittitle>Section 7.2.1.4, drafts</unittitle>
+              <unitdate datechar="creation">2001 Nov-2003 Nov</unitdate>
+              <container id="aspace_878726de0d320b359ac1bbb3bf0258d4" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_de6d9aef6cf86090837997bfb237de68" parent="aspace_878726de0d320b359ac1bbb3bf0258d4" type="folder">11</container>
+            </did>
+          </c>
+          <c id="aspace_ref1202_h2c" level="file">
+            <did>
+              <unittitle>Sections 7.2.1.4 and 7.2.1.5</unittitle>
+              <unitdate datechar="creation">10-Jan-2004</unitdate>
+              <container id="aspace_11b974eb06fcabeb42f38c32a5ce1d6d" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_4199d00ecc13277f846a15f3bc16fcce" parent="aspace_11b974eb06fcabeb42f38c32a5ce1d6d" type="folder">12</container>
+            </did>
+          </c>
+          <c id="aspace_ref1203_s6c" level="file">
+            <did>
+              <unittitle>Sections 7.2.1.4 and 7.2.1.5 (now called prefascicle 3B)</unittitle>
+              <unitdate datechar="creation">12-Jun-2004</unitdate>
+              <container id="aspace_5f6e4871cfb590d0d9984d78ff00a14f" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_716d5d5cdfcfeeacafd052e44fcdc00f" parent="aspace_5f6e4871cfb590d0d9984d78ff00a14f" type="folder">13</container>
+            </did>
+          </c>
+          <c id="aspace_ref1204_one" level="file">
+            <did>
+              <unittitle>Section 7.2.1.6, early drafts</unittitle>
+              <unitdate datechar="creation">Apr 2004 -- Jul 2004</unitdate>
+              <container id="aspace_d3d1564304f2c5542758dad2d43c534a" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_48e9bf6ed527918cae74064df163a038" parent="aspace_d3d1564304f2c5542758dad2d43c534a" type="folder">14</container>
+            </did>
+          </c>
+          <c id="aspace_ref1205_dla" level="file">
+            <did>
+              <unittitle>Section 7.2.1.7, my first printed copy</unittitle>
+              <unitdate datechar="creation">12-Oct-2004</unitdate>
+              <container id="aspace_8ec40e21f2aaee96a7a60dfc93cd2d7d" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_777f5fb5fb50faa91cbbb7aa80efc905" parent="aspace_8ec40e21f2aaee96a7a60dfc93cd2d7d" type="folder">15</container>
+            </did>
+          </c>
+          <c id="aspace_ref1206_u69" level="file">
+            <did>
+              <unittitle>Section 7.2.1.7 as marked by Robin Wilson, given to me</unittitle>
+              <unitdate datechar="creation">early 2005</unitdate>
+              <container id="aspace_788b1640f11761635ebffa8aee50ceb1" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_eb7d8804680f018d2622a440cf17895f" parent="aspace_788b1640f11761635ebffa8aee50ceb1" type="folder">16</container>
+            </did>
+          </c>
+          <c id="aspace_ref1207_d86" level="file">
+            <did>
+              <unittitle>First draft of special copy for the paperback Fascicle 3</unittitle>
+              <unitdate datechar="creation">13-Jun-2005</unitdate>
+              <container id="aspace_dc2deab56b27b97d458bac151a36cec9" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_7e8112b531702230e138608b8d79b1b9" parent="aspace_dc2deab56b27b97d458bac151a36cec9" type="folder">17</container>
+            </did>
+          </c>
+          <c id="aspace_ref1208_zjf" level="file">
+            <did>
+              <unittitle>Sections 7.1.1 and 7.1.2, early drafts</unittitle>
+              <unitdate datechar="creation">May 2005 -- Mar 2006</unitdate>
+              <container id="aspace_9d06d066614a294ad3e817aa2634346b" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_e41212b7ca6ee1da7bc400aab66a5679" parent="aspace_9d06d066614a294ad3e817aa2634346b" type="folder">18</container>
+            </did>
+          </c>
+          <c id="aspace_ref1209_s52" level="file">
+            <did>
+              <unittitle>Section 7.1.3, early drafts</unittitle>
+              <unitdate datechar="creation">Dec 2006-Oct 2008</unitdate>
+              <container id="aspace_ff91f975c47a31d10ec0c2b127fcce9a" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_964b696661e1aa3a202e271b20fb6c45" parent="aspace_ff91f975c47a31d10ec0c2b127fcce9a" type="folder">19</container>
+            </did>
+          </c>
+          <c id="aspace_ref1210_ntp" level="file">
+            <did>
+              <unittitle>Section 7 (introduction to whole chapter, early draft)</unittitle>
+              <unitdate datechar="creation">2007 Apr</unitdate>
+              <container id="aspace_7d0cdc34f71ec1d8068672d513747594" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_16909c2ad7622df39244fff396b51109" parent="aspace_7d0cdc34f71ec1d8068672d513747594" type="folder">20</container>
+            </did>
+          </c>
+          <c id="aspace_ref1211_j9v" level="file">
+            <did>
+              <unittitle>Robin Wilson's comments on Section 7</unittitle>
+              <unitdate datechar="creation">26-Jul-2007</unitdate>
+              <container id="aspace_c6000335a34e26e63ce69abfb4eead45" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_23cc74df654072cba0495f5ebfe905fe" parent="aspace_c6000335a34e26e63ce69abfb4eead45" type="folder">21</container>
+            </did>
+          </c>
+          <c id="aspace_ref1212_p6b" level="file">
+            <did>
+              <unittitle>Section 7.1.4, early drafts</unittitle>
+              <unitdate datechar="creation">Oct 2007-Nov 2008</unitdate>
+              <container id="aspace_db09066e3126c25d01212e815586a4d3" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_f32b2a1420f9dce3c7d8ebd1d8c1095f" parent="aspace_db09066e3126c25d01212e815586a4d3" type="folder">22</container>
+            </did>
+          </c>
+          <c id="aspace_ref1213_pf7" level="file">
+            <did>
+              <unittitle>Miscellaneous notes and pages saved while writing Volume 4A;</unittitle>
+              <unitdate datechar="creation">2001-2010</unitdate>
+              <container id="aspace_c027c0ec4bdb6acfb000aff4fd4ba17d" label="Mixed Materials [aspace.536904.box.3]" type="Box">3</container>
+              <container id="aspace_a6d250348d1ebcd5226110fc7411998e" parent="aspace_c027c0ec4bdb6acfb000aff4fd4ba17d" type="folder">23</container>
+            </did>
+            <scopecontent id="aspace_fb7a3a295ceb0740e64186553cf055ce">
+              <head>Scope and Contents note</head>
+              <p>often shows tests of illustrations, or samples of computer program output, or sketches of ideas that didn't go into the main manuscript</p>
+            </scopecontent>
+          </c>
+        </c>
+      </c>
+      <c id="aspace_ref1220_psx" level="series">
+        <did>
+          <unittitle>Addenda, 2014-128 (Teaching material)</unittitle>
+          <unitid>Accession ARCH-2014-128</unitid>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="1969/1989" type="inclusive">1969-1989</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <c id="aspace_ref1221_ufw" level="subseries">
+          <did>
+            <unittitle>Course materials</unittitle>
+          </did>
+          <c id="aspace_ref1222_a7j" level="file">
+            <did>
+              <unittitle>Computer Science 144 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1969</unitdate>
+              <container id="aspace_bc03a292ac2eb124f98439478c28242c" label="Mixed Materials [aspace.537012.box.1]" type="Box">1</container>
+              <container id="aspace_d1112351bad9f368386c24fc2202ec31" parent="aspace_bc03a292ac2eb124f98439478c28242c" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref1223_hse" level="file">
+            <did>
+              <unittitle>Computer Science 144A Course Materials Winter 1977</unittitle>
+              <unitdate datechar="creation">1977</unitdate>
+              <container id="aspace_b7c201096e0aa66a0d1d9e226ae25feb" label="Mixed Materials [aspace.537012.box.1]" type="Box">1</container>
+              <container id="aspace_0efc8aabde5057dc1360019ddfd3e1f0" parent="aspace_b7c201096e0aa66a0d1d9e226ae25feb" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1224_3lh" level="file">
+            <did>
+              <unittitle>Computer Sciecne 144B Course Materials Spring 1975</unittitle>
+              <unitdate datechar="creation">1975</unitdate>
+              <container id="aspace_1b9f4a84a9bc71e9d143f8e3781a27d4" label="Mixed Materials [aspace.537012.box.1]" type="Box">1</container>
+              <container id="aspace_7e4b9158444a0b14e8672af82cff6a92" parent="aspace_1b9f4a84a9bc71e9d143f8e3781a27d4" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref1225_5cb" level="file">
+            <did>
+              <unittitle>Computer Science 150 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1970-1971</unitdate>
+              <container id="aspace_5ef5e58e18999834a74a1ae55e70c649" label="Mixed Materials [aspace.537012.box.1]" type="Box">1</container>
+              <container id="aspace_f5f77e0f9f8f7c5d5f307b5dec87d24e" parent="aspace_5ef5e58e18999834a74a1ae55e70c649" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref1226_9wa" level="file">
+            <did>
+              <unittitle>Computer Sicence 155 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1971-1975</unitdate>
+              <container id="aspace_53bdfd7eca9e88a892d2345c5500fd86" label="Mixed Materials [aspace.537012.box.2]" type="Box">2</container>
+              <container id="aspace_17cd352faeca2433a240c78392fee486" parent="aspace_53bdfd7eca9e88a892d2345c5500fd86" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref1227_h6d" level="file">
+            <did>
+              <unittitle>Computer Science 155 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1976-1979</unitdate>
+              <container id="aspace_5e022044ac2ad5fcd60b388224907342" label="Mixed Materials [aspace.537012.box.2]" type="Box">2</container>
+              <container id="aspace_ca001e36baf16534ac1a83164856b994" parent="aspace_5e022044ac2ad5fcd60b388224907342" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1228_kzj" level="file">
+            <did>
+              <unittitle>Computer Science 255 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1974-1978</unitdate>
+              <container id="aspace_5afe07093b835de76a473367c6cb9090" label="Mixed Materials [aspace.537012.box.2]" type="Box">2</container>
+              <container id="aspace_1058e83741eafdcafe0ea005e1ca578a" parent="aspace_5afe07093b835de76a473367c6cb9090" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref1229_icp" level="file">
+            <did>
+              <unittitle>Computer Science 155 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1980-1981</unitdate>
+              <container id="aspace_6dd01e5b3436e556b7162e563b1d1045" label="Mixed Materials [aspace.537012.box.3]" type="Box">3</container>
+              <container id="aspace_97aab19e2f0c612df32075542e5f552b" parent="aspace_6dd01e5b3436e556b7162e563b1d1045" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref1230_3wo" level="file">
+            <did>
+              <unittitle>Computer Science 155 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1982-1984</unitdate>
+              <container id="aspace_19f80fd462013ed583ab9f4825354dc0" label="Mixed Materials [aspace.537012.box.3]" type="Box">3</container>
+              <container id="aspace_364445323603cd1f187493d408219b26" parent="aspace_19f80fd462013ed583ab9f4825354dc0" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1231_7u2" level="file">
+            <did>
+              <unittitle>Computer Science 204 Course Materials Master Compilation</unittitle>
+              <unitdate datechar="creation">1975-1979</unitdate>
+              <container id="aspace_b4346fab6161e7832e11676d38e69621" label="Mixed Materials [aspace.537012.box.3]" type="Box">3</container>
+              <container id="aspace_7c6e3a434e11523906d6bf5a11e5a219" parent="aspace_b4346fab6161e7832e11676d38e69621" type="folder">3</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref1232_o8x" level="subseries">
+          <did>
+            <unittitle>Handouts</unittitle>
+          </did>
+          <c id="aspace_ref1233_jgg" level="file">
+            <did>
+              <unittitle>Computer Sicence 279 Spring '84 Profs. Chuck Bigelow, Donald Knuth &amp; Richard Southall Handouts</unittitle>
+              <unitdate datechar="creation">1984</unitdate>
+              <container id="aspace_50b0d3c17c09422ad2a80f10fa4edbdb" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_9ec169d6108d7f6c5d04364f9d29c6ae" parent="aspace_50b0d3c17c09422ad2a80f10fa4edbdb" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref1234_fx7" level="file">
+            <did>
+              <unittitle>Computer Sicence 204 Winter 85' Handouts</unittitle>
+              <unitdate datechar="creation">1985</unitdate>
+              <container id="aspace_8386aa748a3b6c65db425e5a3d3382a1" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_846e04bb8cc1328de108e2c073f9dd20" parent="aspace_8386aa748a3b6c65db425e5a3d3382a1" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1235_aov" level="file">
+            <did>
+              <unittitle>Computer Science 260 Autumn '86 Handouts</unittitle>
+              <unitdate datechar="creation">1986</unitdate>
+              <container id="aspace_85c4371d3c746ee7648fc27b7b40eafa" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_0cafb38f0c579771fe8a0ef85ea02fc9" parent="aspace_85c4371d3c746ee7648fc27b7b40eafa" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref1236_efm" level="file">
+            <did>
+              <unittitle>Computer Science 204 Autumn 82' Handouts</unittitle>
+              <unitdate datechar="creation">1982</unitdate>
+              <container id="aspace_5df9703fd13b9858ab953ae2d4c1f14a" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_607478684d56929523972a0a0f43e3f1" parent="aspace_5df9703fd13b9858ab953ae2d4c1f14a" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref1237_62x" level="file">
+            <did>
+              <unittitle>Computer Science 304 Winter '87 Handouts</unittitle>
+              <unitdate datechar="creation">1987</unitdate>
+              <container id="aspace_920506516544ccebf57648386b931674" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_da8cf561e1e43206c67af6fac4aab7a0" parent="aspace_920506516544ccebf57648386b931674" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref1238_os5" level="file">
+            <did>
+              <unittitle>Computer Science 349 Spring 87' Handouts</unittitle>
+              <unitdate datechar="creation">1987</unitdate>
+              <container id="aspace_2bddfa82b745ac468a65a34df25eef3c" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_45fc753bb721d031415b2506cf3eb735" parent="aspace_2bddfa82b745ac468a65a34df25eef3c" type="folder">6</container>
+            </did>
+          </c>
+          <c id="aspace_ref1239_lj9" level="file">
+            <did>
+              <unittitle>Computer Science 209 Autumn 87' Handouts</unittitle>
+              <unitdate datechar="creation">1987</unitdate>
+              <container id="aspace_e396941972e0f8316271a9697d2e61b4" label="Mixed Materials [aspace.537012.box.4]" type="Box">4</container>
+              <container id="aspace_ad2d7143766eb0711dbdd18351414815" parent="aspace_e396941972e0f8316271a9697d2e61b4" type="folder">7</container>
+            </did>
+          </c>
+          <c id="aspace_ref1240_c4h" level="file">
+            <did>
+              <unittitle>Computer Science 260 Autumn 88' Handouts</unittitle>
+              <unitdate datechar="creation">1988</unitdate>
+              <container id="aspace_2ca1030ed470928e7297e76f11db0833" label="Mixed Materials [aspace.537012.box.5]" type="Box">5</container>
+              <container id="aspace_9170e081f04e1ee662ab4704eec58e2d" parent="aspace_2ca1030ed470928e7297e76f11db0833" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref1241_bm4" level="file">
+            <did>
+              <unittitle>Computer Science 304</unittitle>
+              <unitdate datechar="creation">1989</unitdate>
+              <container id="aspace_134cfd8fd44708376413a5113f41fcb8" label="Mixed Materials [aspace.537012.box.5]" type="Box">5</container>
+              <container id="aspace_cf21f84899ac7d1a5f94ed711969decf" parent="aspace_134cfd8fd44708376413a5113f41fcb8" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1242_cyl" level="file">
+            <did>
+              <unittitle>Computer Science 260 Autumn 89' Handouts</unittitle>
+              <unitdate datechar="creation">1989</unitdate>
+              <container id="aspace_56f5aa482710a4d3abf18a1be58f8484" label="Mixed Materials [aspace.537012.box.5]" type="Box">5</container>
+              <container id="aspace_a4348c26ff4eb870cdf3f67bcec35ae2" parent="aspace_56f5aa482710a4d3abf18a1be58f8484" type="folder">3</container>
+            </did>
+          </c>
+        </c>
+        <c id="aspace_ref1243_c7e" level="subseries">
+          <did>
+            <unittitle>Examinations</unittitle>
+          </did>
+          <c id="aspace_ref1244_deg" level="file">
+            <did>
+              <unittitle>Computer Science 144 Examinations Master Compilation</unittitle>
+              <unitdate datechar="creation">1969-1977</unitdate>
+              <container id="aspace_9d081ac819246e247cc7abb437a9cfb7" label="Mixed Materials [aspace.537012.box.6]" type="Box">6</container>
+              <container id="aspace_569ac3a6b78143aff21e2f886c87785e" parent="aspace_9d081ac819246e247cc7abb437a9cfb7" type="folder">1</container>
+            </did>
+          </c>
+          <c id="aspace_ref1245_y71" level="file">
+            <did>
+              <unittitle>Computer Science 155 Examinations Master Compilation</unittitle>
+              <unitdate datechar="creation">1971-1980</unitdate>
+              <container id="aspace_13d3dd67f392aa10497d0c3cac6a3424" label="Mixed Materials [aspace.537012.box.6]" type="Box">6</container>
+              <container id="aspace_416f3c581dd3972e203841523be687c3" parent="aspace_13d3dd67f392aa10497d0c3cac6a3424" type="folder">2</container>
+            </did>
+          </c>
+          <c id="aspace_ref1246_i59" level="file">
+            <did>
+              <unittitle>Computer Science 255 Examinations Master Compilation</unittitle>
+              <unitdate datechar="creation">1974-1976</unitdate>
+              <container id="aspace_b92fffab83f29bb1d945a76e30272255" label="Mixed Materials [aspace.537012.box.6]" type="Box">6</container>
+              <container id="aspace_4d0ef5e21fe8209607d596dbb2236316" parent="aspace_b92fffab83f29bb1d945a76e30272255" type="folder">3</container>
+            </did>
+          </c>
+          <c id="aspace_ref1247_vn6" level="file">
+            <did>
+              <unittitle>Computer Science 150 Examinations Master Compilation</unittitle>
+              <unitdate datechar="creation">1974-1978</unitdate>
+              <container id="aspace_cd3eee98c99ffe6a954fce6f8b46c83d" label="Mixed Materials [aspace.537012.box.6]" type="Box">6</container>
+              <container id="aspace_053d445cad1ddd0385c079cd3072dfdb" parent="aspace_cd3eee98c99ffe6a954fce6f8b46c83d" type="folder">4</container>
+            </did>
+          </c>
+          <c id="aspace_ref1248_grr" level="file">
+            <did>
+              <unittitle>Computer Science 144A Examinations Winter 1977</unittitle>
+              <unitdate datechar="creation">1977</unitdate>
+              <container id="aspace_ae1268f719c83720c0cafd0f1de7c732" label="Mixed Materials [aspace.537012.box.6]" type="Box">6</container>
+              <container id="aspace_a317d73a154bb7d8d26f380ddc3eb8ba" parent="aspace_ae1268f719c83720c0cafd0f1de7c732" type="folder">5</container>
+            </did>
+          </c>
+          <c id="aspace_ref1249_s7g" level="file">
+            <did>
+              <unittitle>Computer Science 360 Examinnations Winter 1988</unittitle>
+              <unitdate datechar="creation">1988</unitdate>
+              <container id="aspace_37a92dae127de57d4d7210e4d5abc521" label="Mixed Materials [aspace.537012.box.6]" type="Box">6</container>
+              <container id="aspace_e6aecdd723b68436ea0562da25932d0a" parent="aspace_37a92dae127de57d4d7210e4d5abc521" type="folder">6</container>
+            </did>
+          </c>
+        </c>
+      </c>
+      <c id="aspace_6d59f51029d173c4cdb1507549534d2b" level="series">
+        <did>
+          <unittitle>Addenda, 2016-104 (The Art of Computer Programming)</unittitle>
+          <unitid>Accession ARCH-2016-104</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <c id="aspace_ae477941828a47bb65a971b8c9a4760a" level="file">
+          <did>
+            <unittitle>Volume 1 MSS</unittitle>
+            <unitdate datechar="other">undated</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_abe5dc209bff92ef105ded7850b7d4bc" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_7f45dcd18729dcafcb782417f5cd7884" parent="aspace_abe5dc209bff92ef105ded7850b7d4bc" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_d05eb17b788b84a91318d90cea0ef319" level="file">
+          <did>
+            <unittitle>Volume 2 MSS</unittitle>
+            <unitdate datechar="other">undated</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_97690957db8a428f9df812467d44dec5" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_729021c4a38d7c5f6c372b6420a93011" parent="aspace_97690957db8a428f9df812467d44dec5" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_935c5658752e92ecc6f162ef4fe1b6cc" level="file">
+          <did>
+            <unittitle>Volume 3 MSS</unittitle>
+            <unitdate datechar="other">undated</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_e9902d50647bf5cbd41c6b4d8987bce7" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_cc8a2731e527acce0ce6bd74ff864f45" parent="aspace_e9902d50647bf5cbd41c6b4d8987bce7" type="folder">3</container>
+          </did>
+        </c>
+        <c id="aspace_e8cdfc835b98a679b840e613f810c84d" level="file">
+          <did>
+            <unittitle>Misc. notes (references, first analysis of algorithm, list of "complete names")</unittitle>
+            <unitdate datechar="other">1963-1972</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_6562164ce0eab0567129a7312c5d2815" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_b3f30cd63fdec3529143e6f174c740cc" parent="aspace_6562164ce0eab0567129a7312c5d2815" type="folder">4</container>
+          </did>
+        </c>
+        <c id="aspace_8f99baf30de0113d93337398db67c9f6" level="file">
+          <did>
+            <unittitle>Errata and addenda for publisher</unittitle>
+            <unitdate datechar="other">undated</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_692e61bd60a9b1fc2d3a6de5c6b700bb" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_7b74585d8071f1828d61231d5d37fce2" parent="aspace_692e61bd60a9b1fc2d3a6de5c6b700bb" type="folder">5</container>
+          </did>
+        </c>
+        <c id="aspace_2defde1ebd70b6a29e88293cb54e7b04" level="file">
+          <did>
+            <unittitle>Computer programs written while preparing the manuscripts (mostly volume 2)</unittitle>
+            <unitdate datechar="other">undated</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_47ee7b9a2478faff9ccfd1bc7cac0be6" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_7a1a153122c4d00efc590d0e119d3f45" parent="aspace_47ee7b9a2478faff9ccfd1bc7cac0be6" type="folder">6</container>
+          </did>
+        </c>
+        <c id="aspace_14eee1d7ed2ea7f9876f7c7877dfa7c1" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2012 Feb 2</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_5c0caa30c24e4b37fff7785d449a76d9" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_f85f435d3a489bd0def10d2209bdb3cf" parent="aspace_5c0caa30c24e4b37fff7785d449a76d9" type="folder">7</container>
+          </did>
+        </c>
+        <c id="aspace_6eb00f09b5f1fa1998db10c3b2208afb" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2012 Apr 21</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_1cb5bd790b72a13d95dcb729dcaa4b53" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_80713552d68322a419f5a547338191fc" parent="aspace_1cb5bd790b72a13d95dcb729dcaa4b53" type="folder">8</container>
+          </did>
+        </c>
+        <c id="aspace_d4cdb3230a1a081b57ab6006ab458f05" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2012 May 16</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_2883427c04c055d7199b44b6f32f58de" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_b28e4baad00d80fec49124c9b28fb00a" parent="aspace_2883427c04c055d7199b44b6f32f58de" type="folder">9</container>
+          </did>
+        </c>
+        <c id="aspace_ac282378283366fd55db914a60bc91e9" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2013 Jan 10</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_89c85350887d0ec60ee4ca7200b02817" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_41eb001cf3a98c7e85596ffb17d58d30" parent="aspace_89c85350887d0ec60ee4ca7200b02817" type="folder">10</container>
+          </did>
+        </c>
+        <c id="aspace_52555f1489e820d771b77db21608ba94" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2014 Feb 10</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_3e75978e18d54122a8e1424f76e6cfe8" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_b980efe364ab18023ab80ffaadf8aa56" parent="aspace_3e75978e18d54122a8e1424f76e6cfe8" type="folder">11</container>
+          </did>
+        </c>
+        <c id="aspace_acf45d785c48ba69aab86aba9da4cacc" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2014 Dec 18</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_64f8ab47ee406409fd2d6989ce48cf48" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_03f1af48472f25833591007487a3497e" parent="aspace_64f8ab47ee406409fd2d6989ce48cf48" type="folder">12</container>
+          </did>
+        </c>
+        <c id="aspace_e5dad77a21a97293e91edf98f77a69ee" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts</unittitle>
+            <unitdate datechar="other">2015 Apr 7</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_f0bc0ceb117e13323451a7bcb430aca5" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_c30c052b945a799b2629901ee72caeaf" parent="aspace_f0bc0ceb117e13323451a7bcb430aca5" type="folder">13</container>
+          </did>
+        </c>
+        <c id="aspace_202e6ae8eb7a8c84da6a5c6001a7660e" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts (first draft of index)</unittitle>
+            <unitdate datechar="other">2015 Apr 15</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_a4c967c1e7e13363d240a4f9e071b193" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_49f468af305b0bc053773b2e6e2418b9" parent="aspace_a4c967c1e7e13363d240a4f9e071b193" type="folder">14</container>
+          </did>
+        </c>
+        <c id="aspace_8fc9b8e5c669d6cf47be4b94caa56de3" level="file">
+          <did>
+            <unittitle>Volume 4A MSS drafts (first draft of index)</unittitle>
+            <unitdate datechar="other">2015 Apr 22</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_081e1d6f4675c9ae66c31025bc356da4" label="Mixed Materials [aspace.908145.box.1]" type="Box">1</container>
+            <container id="aspace_91346e1dea967e43748ac1f7b4375963" parent="aspace_081e1d6f4675c9ae66c31025bc356da4" type="folder">15</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_d3a6752c682373f0d19e2f3c1f3efe68" level="series">
+        <did>
+          <unittitle>Addenda, 2017-128</unittitle>
+          <unitid>Accession ARCH-2017-128</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <c id="aspace_665011c41139aded1787f6d56db00f71" level="file">
+          <did>
+            <unittitle>Japan by Jill Carter Knuth</unittitle>
+            <unitdate calendar="gregorian" datechar="creation" era="ce" type="inclusive">1996</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_9cd6e080ab0306fbc747def6505511a9" label="Mixed Materials [aspace.1026129.box.1]" type="Box">1</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_26fdc79aaafc011a573386ac06b88f72" level="series">
+        <did>
+          <unittitle>Websites</unittitle>
+          <unitid>Series 4</unitid>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2017/2018" type="inclusive">2017-2018</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+      </c>
+      <c id="aspace_7fce141ccefe89885ed5db018b98300c" level="series">
+        <did>
+          <unittitle>Addenda, 2018-123</unittitle>
+          <unitid>Accession ARCH-2018-123</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <c id="aspace_d964e21eec96b76d92e78fb4733b36dc" level="file">
+          <did>
+            <unittitle> Fantasia Apocalyptica Program</unittitle>
+            <unitdate calendar="gregorian" datechar="creation" era="ce" normal="2018/2018">2018</unitdate>
+            <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_18dab79b05c98be59b353d42695cac61" level="series">
+        <did>
+          <unittitle>Email</unittitle>
+          <unitid>Accession ARCH-2019-070</unitid>
+          <unitdate calendar="gregorian" datechar="creation" era="ce" type="inclusive">1999-2019</unitdate>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <scopecontent id="aspace_4f84fe0e43e3fdfb08b6be982a565ba4">
+          <head>Scope and Contents</head>
+          <p>Email in accession 2019-070 were captured from Knuth's Gmail and  rmail accounts with ePADD software, resulting in over 32,000 messages. This series is comprised of: 11,834 incoming messages and 20,184 outgoing; 2,630 attachments (1,288 images, 865 documents, and 477 other); 7,394 correspondents; and several thousand extracted entities, including 5,348 names and 717 places.</p>
+        </scopecontent>
+        <processinfo id="aspace_3aeea12e7f5342e82cacd8705f3df2ef">
+          <head>Processing Information</head>
+          <p>Messages were processed with ePADD software (https://library.stanford.edu/projects/epadd). It was screened for messages containing personal identifying information (PII) and sensitive content and correspondents were edited. The correspondents and extracted entities (personal and corporate names and locations) have been published in Stanford's online discovery module: http://epadd.stanford.edu/epadd/collections.</p>
+          <p>This email collection was processed in two parts due to significant technical differences between the email formats Knuth used. Researchers will encounter duplicate messages across both parts. Note that email in RMAIL format (dating from January 1999 through December 2018) consists only of sent messages, while email in MBOX format (November 2010 through January 2019) consists of both sent and received messages.</p>
+        </processinfo>
+        <accessrestrict id="aspace_8833282c4b420c8b66a65ef7015c5e03">
+          <head>Conditions Governing Access</head>
+          <p>Access condition: Access to digital content is restricted to the Special Collections Reading Room. In order to access this content, please contact specialcollections@stanford.edu.</p>
+          <p>The Donald Knuth papers include some messages identified by the donor, or Stanford Libraries, as sensitive. Access to these messages has been restricted according to federal and state guidelines, and Stanford Libraries policy, for up to 80 years from the date of message creation. These email messages are not included in this release of the collection; they will be made available between January 2045 through January 2099.</p>
+        </accessrestrict>
+      </c>
+      <c id="aspace_b341ff85960f0c0806094c2093fb1aea" level="series">
+        <did>
+          <unittitle>Addenda, 2022-026</unittitle>
+          <unitid>Accession ARCH-2022-026</unitid>
+          <langmaterial><language langcode="eng" scriptcode="Latn">English</language>.</langmaterial>
+        </did>
+        <c id="aspace_959cc7619a38deaf542247e378c4d474" level="file">
+          <did>
+            <unittitle>Journal from Djursholm by Jill Knuth</unittitle>
+            <unitdate calendar="gregorian" datechar="creation" era="ce" type="inclusive">1991</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_d3bfc9bc3aeaf6887ce56cfc2c01a539" label="Mixed Materials" type="Box">1</container>
+            <container id="aspace_d626f578ae83f43316dcf61aa72fb4a5" parent="aspace_d3bfc9bc3aeaf6887ce56cfc2c01a539" type="folder">1</container>
+          </did>
+        </c>
+        <c id="aspace_a1bfbd0f42583d6e724800019f8d6b46" level="file">
+          <did>
+            <unittitle>Northern Spring paste-ups </unittitle>
+            <unitdate calendar="gregorian" datechar="creation" era="ce" type="inclusive">1994</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_b2d78e82d450487850083652c3de30c2" label="Mixed Materials" type="Box">1</container>
+            <container id="aspace_d217966e71f527dd75c454da4fcdccd0" parent="aspace_b2d78e82d450487850083652c3de30c2" type="folder">2</container>
+          </did>
+        </c>
+        <c id="aspace_0590a8890169d9281109ce98dc8c3583" level="file">
+          <did>
+            <unittitle><emph>Hooray, We're Going to America!: The Migration of the H.H. Bohning Family from Barkhausen, Hanover, to Cleveland, Ohio, in 1843</emph> Edited and published by Jill Knuth</unittitle>
+            <unitdate calendar="gregorian" datechar="creation" era="ce" type="inclusive">1987</unitdate>
+            <langmaterial><language langcode="eng">English</language>.</langmaterial>
+            <container id="aspace_b552c6d96d033943028d66ff7d28c0c5" label="Mixed Materials" type="Box">1</container>
+            <container id="aspace_2c81990e2c34aa605fa2845d97b71380" parent="aspace_b552c6d96d033943028d66ff7d28c0c5" type="folder">3</container>
+          </did>
+        </c>
+      </c>
+      <c id="aspace_539ea810ae9aa777cf8e82082387d63d" level="series">
+        <did>
+          <unittitle>Addenda, 2022-104</unittitle>
+        </did>
+        <c id="aspace_s2022-104b1fo1" level="file">
+          <did>
+            <unittitle>CS Tex Knuth</unittitle>
+            <unitid>1</unitid>
+            <unitdate datechar="creation">29647</unitdate>
+            <physdesc id="aspace_4765670ec0c8a3b00b9369b88d4f5d63">videotape(s) (vhs)</physdesc>
+            <container id="aspace_4e9ccd32f9f4d89e63821047ae122cde" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo2" level="file">
+          <did>
+            <unittitle>CS Tex Knuth</unittitle>
+            <unitid>2</unitid>
+            <unitdate datechar="creation">29640</unitdate>
+            <physdesc id="aspace_a31c1d766258e913bde3ee91e1121083">videotape(s) (vhs)</physdesc>
+            <container id="aspace_8cf83f32180ff171865ed9c1fc0cced3" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo3" level="file">
+          <did>
+            <unittitle>Sonderkolloquium, All Questions Answered, Pr. Donald E. Knuth Stanford</unittitle>
+            <unitid>3</unitid>
+            <unitdate datechar="creation">37021</unitdate>
+            <physdesc id="aspace_5ec1b742d2066d73e4d30345b49ea924">videotape(s) (vhs)</physdesc>
+            <container id="aspace_9041eb50915580069993f0f73833c1b5" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo4" level="file">
+          <did>
+            <unittitle>CNN "Future Watch" ind puzzler interviews</unittitle>
+            <unitid>4</unitid>
+            <unitdate datechar="creation">33984</unitdate>
+            <physdesc id="aspace_803bd017ec116d4ecc3016495aa0c3e4">videotape(s) (vhs)</physdesc>
+            <container id="aspace_1db230db097215028dcb3797315454c0" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo5" level="file">
+          <did>
+            <unittitle>UoM, Nomination as Honorary Doctors: Don Knuth, Christos Papadimitriou (in a European video format)</unittitle>
+            <unitid>5</unitid>
+            <unitdate datechar="creation">37804</unitdate>
+            <physdesc id="aspace_b4f8eb8c174b7f574355becbecdd89d8">videotape(s) (vhs)</physdesc>
+            <container id="aspace_9f54ca5e1fae82f95ba0e1bd981a7bcd" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo6" level="file">
+          <did>
+            <unittitle>ITiCSE2003-invited Speakers. Christos Papadimitrious. Don Knuth. (European video format)</unittitle>
+            <unitid>6</unitid>
+            <unitdate datechar="creation">2003 July 1-2</unitdate>
+            <physdesc id="aspace_7faf590d025b9aee44f2a5f4a871b0cb">videotape(s) (vhs)</physdesc>
+            <container id="aspace_aa0b9e2d9a5985793889b728a6cda2a9" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo7" level="file">
+          <did>
+            <unittitle>"Watch Your Language" by Scott Kim</unittitle>
+            <unitid>7</unitid>
+            <physdesc id="aspace_d451e1c9e86c14526be41457123e86d9">videotape(s) (vhs)</physdesc>
+            <container id="aspace_b94126a729d03b2f9cc610ab59b8f990" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo8" level="file">
+          <did>
+            <unittitle>"Experiments with Digital Halftones" (unedited) Don Knuth, Speaker. College of Engineering-Michigan Engineering Television Network.</unittitle>
+            <unitid>8</unitid>
+            <unitdate datechar="creation">31923</unitdate>
+            <physdesc id="aspace_16ddd43cba281ad93859846e48287dad">videotape(s) (vhs)</physdesc>
+            <container id="aspace_14d70fa458fd8dc195dd4886413ebb3a" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo9" level="file">
+          <did>
+            <unittitle>TCSE (illegible) 200 Tape I 4:15 Comp Science</unittitle>
+            <unitid>9</unitid>
+            <unitdate datechar="creation">37593</unitdate>
+            <physdesc id="aspace_0ce00f1847ddfa53a21d60b402a46bfb">videotape(s) (vhs)</physdesc>
+            <container id="aspace_3ae0104318758d5c3050bc26d54780c4" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo10" level="file">
+          <did>
+            <unittitle>Untitled</unittitle>
+            <unitid>10</unitid>
+            <physdesc id="aspace_2102aacd5fe8c3f29a57dd386d5cf199">videotape(s) (vhs)</physdesc>
+            <container id="aspace_c55aff822a7be2804a859d2b5cf44ee7" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo11" level="file">
+          <did>
+            <unittitle>Corporate Technical Colloquium, R. R. Donnelley and Sons Co. Inc. "Can Computers Help Produce Beautiful Books?" Dr. Donald E. Knuth</unittitle>
+            <unitid>11</unitid>
+            <unitdate datechar="creation">32286</unitdate>
+            <physdesc id="aspace_d4b020ef82756d105ca75a216ba40343">videotape(s) (vhs)</physdesc>
+            <container id="aspace_9ed08ac4b7ecb059e2bbc737f101b9fa" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo12" level="file">
+          <did>
+            <unittitle>Donald E. Knuth "Computer Musings: The Associative Law, or The Anatomy of Roatations in Binary Trees"</unittitle>
+            <unitid>12</unitid>
+            <unitdate datechar="creation">34303</unitdate>
+            <physdesc id="aspace_c52569f08279c028f5384b656ab0964e">videotape(s) (vhs)</physdesc>
+            <container id="aspace_593e038a8d646efb1fed8a807651cef2" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo13" level="file">
+          <did>
+            <unittitle>"An Anthology of Algorithm Animations using Zeus" by Marc H. Brown</unittitle>
+            <unitid>13</unitid>
+            <unitdate datechar="creation">33480</unitdate>
+            <physdesc id="aspace_e26a050d2ec9bc94f9576bca5366c6dd">videotape(s) (vhs)</physdesc>
+            <container id="aspace_16ebd0dd8d10aa95863d08e24e8e79e9" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo14" level="file">
+          <did>
+            <unittitle>TEX 82 Knuth Session 11 Dub of Master</unittitle>
+            <unitid>14</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_e8fddc07e83cda7215c6f31c829389bb">videotape(s) (vhs)</physdesc>
+            <container id="aspace_b02fd7a788b3ce1829534ed8e4752267" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo15" level="file">
+          <did>
+            <unittitle>TEX 82 Knuth Session 1 Dub of Master</unittitle>
+            <unitid>15</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_7483332dfcb87e2e0b375b7d29f4457d">videotape(s) (vhs)</physdesc>
+            <container id="aspace_ab9dd2f57f6baf1349e4062a4ea94082" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo16" level="file">
+          <did>
+            <unittitle>CS TEX Knuth</unittitle>
+            <unitid>16</unitid>
+            <unitdate datechar="creation">29649</unitdate>
+            <physdesc id="aspace_9861cd95d348824db816b13e2a17a29c">videotape(s) (vhs)</physdesc>
+            <container id="aspace_5b278c2781b410d63582e83d8d2c8bd7" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo17" level="file">
+          <did>
+            <unittitle>Presedential Ceremony</unittitle>
+            <unitid>17</unitid>
+            <unitdate datechar="creation">29234</unitdate>
+            <physdesc id="aspace_25ea97f90d1d3a2989b3827240b51292">videotape(s) (vhs)</physdesc>
+            <container id="aspace_5c65736476feaa45e150ffc399af8c13" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo18" level="file">
+          <did>
+            <unittitle>CS TEX Knuth Done KR Sess. #213</unittitle>
+            <unitid>18</unitid>
+            <unitdate datechar="creation">29648</unitdate>
+            <physdesc id="aspace_bedaaafe06a8ea459457b3901e8a72d1">videotape(s) (vhs)</physdesc>
+            <container id="aspace_916f28299d6025084afc449ab247055f" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo19" level="file">
+          <did>
+            <unittitle>CS TEX Knuth #413</unittitle>
+            <unitid>19</unitid>
+            <unitdate datechar="creation">29650</unitdate>
+            <physdesc id="aspace_ec448cafad031654c4ec4d6f117ded38">videotape(s) (vhs)</physdesc>
+            <container id="aspace_aa699bcde67aab6a853df136c4f6844d" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo20" level="file">
+          <did>
+            <unittitle>TEX 82 Knuth Session 10 Dub of master</unittitle>
+            <unitid>20</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_1ca47e86bdc3a3939f4924adaaf982d1">videotape(s) (vhs)</physdesc>
+            <container id="aspace_24489b8511308e2440b68d5cc23dc0b9" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b1fo21" level="file">
+          <did>
+            <unittitle>TEX 82 Knuth Session 12 Dub of master</unittitle>
+            <unitid>21</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_a5960bf0bdc343828a8c8468464d8efa">videotape(s) (vhs)</physdesc>
+            <container id="aspace_8270c818b44a404d719916ead872b30c" label="Mixed Materials" type="Box">1</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo22" level="file">
+          <did>
+            <unittitle>MICRO TEX Technical Processing System: Includes a spiral bound textbook, two booklets, and a case of software floppydisks.</unittitle>
+            <unitid>1</unitid>
+            <unitdate datechar="creation">1985</unitdate>
+            <physdesc id="aspace_cad52a475c3f4d0ca3bd69b53b91c37f">floppy disk(s) (5.25 inch)</physdesc>
+            <container id="aspace_09bf4f5e80e57f951fd72a6d121581c2" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo23" level="file">
+          <did>
+            <unittitle>Presedential Ceremony Honooring the 1979 Medal of Science Awardees, White House Ceremony</unittitle>
+            <unitid>2</unitid>
+            <unitdate datechar="creation">29234</unitdate>
+            <physdesc id="aspace_3c253ce9f7e00e3536bf0ed1c7a2ea3d">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_7246a68e2c82e305965dba49b6e18cc2" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo24" level="file">
+          <did>
+            <unittitle>God and Computers, Introduction: Donald E. Knuth</unittitle>
+            <unitid>3</unitid>
+            <unitdate datechar="creation">36439</unitdate>
+            <physdesc id="aspace_9ed40204c088b06056c5e3de147ebfeb">videotape(s) (vhs)</physdesc>
+            <container id="aspace_30f4b96535a7b8f532a8311df18298ee" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo25" level="file">
+          <did>
+            <unittitle>God and Computers "Randomization and Religion" Donald E. Knuth</unittitle>
+            <unitid>4</unitid>
+            <unitdate datechar="creation">36446</unitdate>
+            <physdesc id="aspace_cc36f1d30e42300c0df883fb9e462185">videotape(s) (vhs)</physdesc>
+            <container id="aspace_252e37dd53fea43cc26419b679906106" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo26" level="file">
+          <did>
+            <unittitle>God and Computers "Language and Translation" Donald E. Knuth</unittitle>
+            <unitid>5</unitid>
+            <unitdate datechar="creation">36460</unitdate>
+            <physdesc id="aspace_5a2e7fe4d56c92a8c632b9bf054b2722">videotape(s) (vhs)</physdesc>
+            <container id="aspace_93de4c08f8b0927e0f133681958fcef3" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo27" level="file">
+          <did>
+            <unittitle>God and Computers "Aesthetics" Donald E. Knuth</unittitle>
+            <unitid>6</unitid>
+            <unitdate datechar="creation">36467</unitdate>
+            <physdesc id="aspace_ebd23bfa8528e23626dbb6b2e26bd0a7">videotape(s) (vhs)</physdesc>
+            <container id="aspace_947ddccc7b41d124885b35fe23b3de4f" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo28" level="file">
+          <did>
+            <unittitle>God and Computers</unittitle>
+            <unitid>7</unitid>
+            <unitdate datechar="creation">36481</unitdate>
+            <physdesc id="aspace_86dad9335a82ce41503ca19e122e002b">videotape(s) (vhs)</physdesc>
+            <container id="aspace_0e12240e43981ffa31e6ac3c1a0d39ff" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo29" level="file">
+          <did>
+            <unittitle>God and Computers "Glimpses of God" Donald E. Knuth</unittitle>
+            <unitid>8</unitid>
+            <unitdate datechar="creation">36495</unitdate>
+            <physdesc id="aspace_6bff878b2b177ce9d7877cff77731f49">videotape(s) (vhs)</physdesc>
+            <container id="aspace_8519f7450ede0cde4c17ca20268569b5" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo30" level="file">
+          <did>
+            <unittitle>God and Computers "God and Computer Science" Donald E. Knuth</unittitle>
+            <unitid>9</unitid>
+            <unitdate datechar="creation">36502</unitdate>
+            <physdesc id="aspace_bb9d369e543ca7dd7b5fe11d16e969e4">videotape(s) (vhs)</physdesc>
+            <container id="aspace_9e235f6969d819036ac891b7bf3af540" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo31" level="file">
+          <did>
+            <unittitle>Don Knuth Computer Musings, 35yrs of Linear Probing</unittitle>
+            <unitid>10</unitid>
+            <unitdate datechar="creation">35732</unitdate>
+            <physdesc id="aspace_e881613f0935cffbe9769db5d97b13ef">videotape(s) (vhs)</physdesc>
+            <container id="aspace_4291f543b66e509bb630e4ea0813d307" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo32" level="file">
+          <did>
+            <unittitle>Don Knuth Computer Musings, 35yrs of Linear Probing</unittitle>
+            <unitid>11</unitid>
+            <unitdate datechar="creation">35732</unitdate>
+            <physdesc id="aspace_7c39917a35568b7e3810975dfa3e5cb8">videotape(s) (vhs)</physdesc>
+            <container id="aspace_d3aa83c853c2429baeb87a85e00991ba" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo33" level="file">
+          <did>
+            <unittitle>Don Knuth Computer Musings</unittitle>
+            <unitid>12</unitid>
+            <unitdate datechar="creation">36095</unitdate>
+            <physdesc id="aspace_21c822cb59859ed08628f873449596fe">videotape(s) (vhs)</physdesc>
+            <container id="aspace_48837263e892f0f2bff1ff000050b615" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo34" level="file">
+          <did>
+            <unittitle>Don Knuth Computer Musings, The MMIX architecture simulation</unittitle>
+            <unitid>13</unitid>
+            <unitdate datechar="creation">36222</unitdate>
+            <physdesc id="aspace_bf78b938b4b197b6500fee0a33b7effb">videotape(s) (vhs)</physdesc>
+            <container id="aspace_4f26d3c671384bcc00c3d14cc687cf44" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo36" level="file">
+          <did>
+            <unittitle>Don Knuth Computer Musings Fast input/output with multiple disks</unittitle>
+            <unitid>15</unitid>
+            <unitdate datechar="creation">35815</unitdate>
+            <physdesc id="aspace_d81a2d683d7e06982fba7f116abc5f1e">videotape(s) (vhs)</physdesc>
+            <container id="aspace_af66720b499d1106b50a91e159f3e065" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo37" level="file">
+          <did>
+            <unittitle>Computer Musings W/O# 4080 [illegible note]</unittitle>
+            <unitid>16</unitid>
+            <unitdate datechar="creation">36578</unitdate>
+            <physdesc id="aspace_87f5d122096ab4c86b4cd343438ff6aa">videotape(s) (vhs)</physdesc>
+            <container id="aspace_423b08604d71bcc2337784d377faaa79" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo38" level="file">
+          <did>
+            <unittitle>Computer Musings W/O# 5113 [illegible note]</unittitle>
+            <unitid>17</unitid>
+            <unitdate datechar="creation">36676</unitdate>
+            <physdesc id="aspace_d351cf8b502aa468a2b451c9c50e28e3">videotape(s) (vhs)</physdesc>
+            <container id="aspace_210f398c239aafccf57584f206311b4a" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo39" level="file">
+          <did>
+            <unittitle>Computer Musings-Knuth "Trees, Forests, and Polynominoes"</unittitle>
+            <unitid>18</unitid>
+            <unitdate datechar="creation">36865</unitdate>
+            <physdesc id="aspace_8ca2c11fc7d386fb9ef72ecb53b2e88c">videotape(s) (vhs)</physdesc>
+            <container id="aspace_88ca0ae4102411e5a12ff1d7034fc786" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo40" level="file">
+          <did>
+            <unittitle>Don Knuth Computer Musings, W/O# 7104, Trees ad alphabetic [illegible]</unittitle>
+            <unitid>19</unitid>
+            <unitdate datechar="creation">36132</unitdate>
+            <physdesc id="aspace_ccfc1ce6359a8dbff2653725a44c0b7c">videotape(s) (vhs)</physdesc>
+            <container id="aspace_978973be302ed334d6cd7d8963a0a241" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b2fo41" level="file">
+          <did>
+            <unittitle>Don Knuth Lectures Christmas Tree Lecture</unittitle>
+            <unitid>20</unitid>
+            <unitdate datechar="creation">35767</unitdate>
+            <physdesc id="aspace_355b4cb56822434f535d5a60a61f06c7">videotape(s) (vhs)</physdesc>
+            <container id="aspace_aeaed9563ac4a1a79d322074d78960e0" label="Mixed Materials" type="Box">2</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo42" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 12 1/1</unittitle>
+            <unitid>1</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_1ff7986f1dd4d9c0ba28fe92922486ec">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_9f314cbcdf8182b5bbc655d80fb6cd26" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo43" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 1 1/1</unittitle>
+            <unitid>2</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_5c4b4e71597ec7dc5b22db4f7a14967a">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_e79ae8a20e280426fdd22d48c578f240" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo44" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 2 1/1</unittitle>
+            <unitid>3</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_8794108b3fd664829b8203da73cd63d6">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_fd4680b2c0639c6aed21b46384f4274a" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo45" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 3 1/1</unittitle>
+            <unitid>4</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_f9edca3e159b9470556fa77fcf582268">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_4480f9476de36bd789f7145b45b84cf5" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo46" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 4 1/1</unittitle>
+            <unitid>5</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_68944a67532f4dba2c51d7bad5b3ac09">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_d016ba15f3b9c6f8729af9dcba24ce64" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo47" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 5 1/1</unittitle>
+            <unitid>6</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_080fb42ebcc7a9958dc6012200235ea6">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_1caacaf7790fb74f4aa64c20ab7e8f60" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo48" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 6 1/1</unittitle>
+            <unitid>7</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_ab8f3015c0ab185c5e894e5413468f47">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_0cd09570c734ef84f49f56a578cef8b4" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo49" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 7 1/1</unittitle>
+            <unitid>8</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_60c1b2203b7c7cb02c3112a73a6275c2">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_0a7cf8efae5682acfedc33a9dc9f1d01" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo50" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 8 1/1</unittitle>
+            <unitid>9</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_484886e855cb027471d0c0a9c6b6becd">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_34ae9ddb29384012be97ae1b68695524" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo51" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 9 1/1</unittitle>
+            <unitid>10</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_e0feaed9da3a60dc204cb30549b9201e">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_e93775075142833686f2d3b0f0ee398b" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo52" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 10 1/1</unittitle>
+            <unitid>11</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_230d73e1064502623ecbe25ad17e3aa8">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_da2e37d0dae4c243387b33a00eb5c0ee" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b3fo53" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH session 11 1/1</unittitle>
+            <unitid>12</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_a372344adbe87bd009caf9630535601e">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_9ef4f71a11a0fdc6803e7cd191a828f1" label="Mixed Materials" type="Box">3</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo54" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1 of 1 #5 [illegible]</unittitle>
+            <unitid>1</unitid>
+            <unitdate datechar="creation">29651</unitdate>
+            <physdesc id="aspace_234c4ba78a5bcede596a9a5195f7b2ed">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_598923bff0656943d3fb9f699f87431e" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo55" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1 of 1 #4B</unittitle>
+            <unitid>2</unitid>
+            <unitdate datechar="creation">29650</unitdate>
+            <physdesc id="aspace_dc62b1d740b41ee51d120abf15ea3669">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_5396805604815c30059df16dd823aa05" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo56" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1/1 #3B</unittitle>
+            <unitid>3</unitid>
+            <unitdate datechar="creation">29649</unitdate>
+            <physdesc id="aspace_8dfcc20a3a5b60e21a42a8ff39206e57">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_f2f5c423be0cc461f70b8d1280ef1657" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo57" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1/1 #2B</unittitle>
+            <unitid>4</unitid>
+            <unitdate datechar="creation">29648</unitdate>
+            <physdesc id="aspace_fea8c8541f84c8b4a14bd2bfb2818f65">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_23d32e2efd4ed8caba90e344f617087c" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo58" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1/1 #1B w/o 4215</unittitle>
+            <unitid>5</unitid>
+            <unitdate datechar="creation">29647</unitdate>
+            <physdesc id="aspace_eefed709a7f6f7b83556efef23354ebb">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_8a2c7716e6c2ee72effb3678b1ad5f1f" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo59" level="file">
+          <did>
+            <unittitle>C.S. TEX KNUTH 1/1 #15A</unittitle>
+            <unitid>6</unitid>
+            <unitdate datechar="creation">29644</unitdate>
+            <physdesc id="aspace_f5e455cbfeab816e555e9e17826da4e0">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_c1e263ad59321c9e19e64cd44e92ca48" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo60" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1/1 #1A</unittitle>
+            <unitid>7</unitid>
+            <unitdate datechar="creation">29640</unitdate>
+            <physdesc id="aspace_6da37c9282e7cccb14eeb87d906d3fdf">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_2be81c8806965a66a117885073b573a6" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo61" level="file">
+          <did>
+            <unittitle>CS 144C Knuth 18 1/1 Back-Up</unittitle>
+            <unitid>8</unitid>
+            <unitdate datechar="creation">29353</unitdate>
+            <physdesc id="aspace_27a567033c4d9ea467ef84683532deb4">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_f7e4875cd43b73d84b13073ee8287d1a" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo62" level="file">
+          <did>
+            <unittitle>C.S. TEX Knuth 1 of 1 wo 4215</unittitle>
+            <unitid>9</unitid>
+            <unitdate datechar="creation">29643</unitdate>
+            <physdesc id="aspace_4fa00bdbeae706c4b00baf3d2c5db13b">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_7aa459177f6aa13798620de9b34836e3" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo63" level="file">
+          <did>
+            <unittitle>CS TEX Knuth 1/1 #2A w/o 4215</unittitle>
+            <unitid>10</unitid>
+            <unitdate datechar="creation">29641</unitdate>
+            <physdesc id="aspace_7a598f294bdaaf9982c8c058bdf631fb">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_79e40f2d6c1a63077db74f614ae51493" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b4fo64" level="file">
+          <did>
+            <unittitle>C.S. Tex KNUTH #3A 1 of 1 w/o 4215</unittitle>
+            <unitid>11</unitid>
+            <unitdate datechar="creation">29642</unitdate>
+            <physdesc id="aspace_000795c3b7a1f66561fdb20ec01783ee">videotape(s) (u-matic)</physdesc>
+            <container id="aspace_6bac19bdc1d052c0d068b037c0f3995e" label="Mixed Materials" type="Box">4</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo65" level="file">
+          <did>
+            <unittitle>Brown Corpus--Version I. Epoch 480 Magnetic Reel Tape. BYU Humanities Research Center</unittitle>
+            <unitid>1</unitid>
+            <physdesc id="aspace_ddceee60edb1aee5d07735589635ddb8">computer tape(s)</physdesc>
+            <container id="aspace_8a7e59991c560f696894fa12de78bb30" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo66" level="file">
+          <did>
+            <unittitle>LOB Corpus---Tagged Horizontal. Epoch 480 Magnetic Reel Tape. BYU Humanities Research Center</unittitle>
+            <unitid>2</unitid>
+            <physdesc id="aspace_f2f87eda136690920745914db6bfeaba">computer tape(s)</physdesc>
+            <container id="aspace_ffb86418605a4e49941113fbf786a2c0" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo67" level="file">
+          <did>
+            <unittitle>MELBOURNE SURREY CORPUS TEXT</unittitle>
+            <unitid>3</unitid>
+            <physdesc id="aspace_596681816d83e75b45f16653f9f71e09">videotape(s) (vhs)</physdesc>
+            <container id="aspace_e6cc13a0e1fbc54fe54cdec553a6b731" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo68" level="file">
+          <did>
+            <unittitle>DON KNUTH Q+A, 57 ANNES [illegible]</unittitle>
+            <unitid>4</unitid>
+            <unitdate datechar="creation">1999</unitdate>
+            <physdesc id="aspace_eadafb3f62c1db071727076122ccc661">audiocassette(s)</physdesc>
+            <container id="aspace_de21cf353bbdd0f79a443a1f9f9dbd80" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo69" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 6 Dub of master</unittitle>
+            <unitid>5</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_86cad1e924f6812bded65abb67d1dea2">videotape(s) (vhs)</physdesc>
+            <container id="aspace_fd0f297d9f84b38e2bfdf6001119d9bd" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo70" level="file">
+          <did>
+            <unittitle>CS TEX Knuth #4A</unittitle>
+            <unitid>6</unitid>
+            <unitdate datechar="creation">29643</unitdate>
+            <physdesc id="aspace_21f11930ebb9421b272297d0f07f2de1">videotape(s) (vhs)</physdesc>
+            <container id="aspace_23057b9b9d80c15f54b2da28acd8e530" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo71" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 9 Dub of master</unittitle>
+            <unitid>7</unitid>
+            <unitdate datechar="creation">30162</unitdate>
+            <physdesc id="aspace_7e7d673e39a0a42f299155fe6b324d6c">videotape(s) (vhs)</physdesc>
+            <container id="aspace_7dbc68e35899c2b832233e7dc090b27f" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo72" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 2</unittitle>
+            <unitid>8</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_6eab25d3731e15fb26e9ca727f467ff8">videotape(s) (vhs)</physdesc>
+            <container id="aspace_40b73f6f6ac7b3c29bf33c56591ec15f" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo73" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 8</unittitle>
+            <unitid>9</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_7e12da513b438fe57cfc22e4faebbe7a">videotape(s) (vhs)</physdesc>
+            <container id="aspace_d6a4eab290f219cb94e2b738273f1665" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo74" level="file">
+          <did>
+            <unittitle>CS TEX KNUTH #5B</unittitle>
+            <unitid>10</unitid>
+            <unitdate datechar="creation">29651</unitdate>
+            <physdesc id="aspace_80ce4198572862a9e3d3315d77d44bb8">videotape(s) (vhs)</physdesc>
+            <container id="aspace_57ede48ef9b9c92c94549c5c9189cbc9" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo75" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 4</unittitle>
+            <unitid>11</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_4c75e18032d0900ef48a6bbda04738d4">videotape(s) (vhs)</physdesc>
+            <container id="aspace_e9d717da562f5a819b194eaf11efec07" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo76" level="file">
+          <did>
+            <unittitle>CS TEX Knuth #2A</unittitle>
+            <unitid>12</unitid>
+            <unitdate datechar="creation">29641</unitdate>
+            <physdesc id="aspace_82f41b9a0b7483521be9e96a69431ccf">videotape(s) (vhs)</physdesc>
+            <container id="aspace_42b84db9873298ed6692f6754ab94fc4" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo77" level="file">
+          <did>
+            <unittitle>CS TEX Knuth #5A</unittitle>
+            <unitid>13</unitid>
+            <unitdate datechar="creation">29644</unitdate>
+            <physdesc id="aspace_1f5deb66fd8d800f4c694ebd7e86e526">videotape(s) (vhs)</physdesc>
+            <container id="aspace_ff4178e1f8870174ecd924f258542a80" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo78" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 5</unittitle>
+            <unitid>14</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_43af7860229d357a2954b391efe92e3c">videotape(s) (vhs)</physdesc>
+            <container id="aspace_8dc00205783c3125eea91097d46c57d9" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo79" level="file">
+          <did>
+            <unittitle>CS 144C Knuth</unittitle>
+            <unitid>15</unitid>
+            <unitdate datechar="creation">29359</unitdate>
+            <physdesc id="aspace_c52f9fcc58d32beffa8c6a8376a6271a">videotape(s) (vhs)</physdesc>
+            <container id="aspace_283f40d98792435787f4d04aaabe8152" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo80" level="file">
+          <did>
+            <unittitle>TEX 82 KNUTH Session 3 Dub of master</unittitle>
+            <unitid>16</unitid>
+            <unitdate datechar="creation">30160</unitdate>
+            <physdesc id="aspace_6d5eb570a953edd5e0b451e7101d96d1">videotape(s) (vhs)</physdesc>
+            <container id="aspace_22915761d0bd241e0c2fbf6c03b70c92" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+        <c id="aspace_s2022-104b5fo81" level="file">
+          <did>
+            <unittitle>TEX 82 Session 7</unittitle>
+            <unitid>17</unitid>
+            <unitdate datechar="creation">30161</unitdate>
+            <physdesc id="aspace_b816f4eea2e4abf6522789c5b970310e">videotape(s) (vhs)</physdesc>
+            <container id="aspace_d7dd85e44a4b4464196c07a3ab93be3d" label="Mixed Materials" type="Box">5</container>
+          </did>
+        </c>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>


### PR DESCRIPTION
Closes #442.

The existing fixture XML file didn't have anything that was "online". I added an additional file from the Knuth papers that does.

After:
![Screenshot 2024-03-18 at 2 51 43 PM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/49fbe7d2-5561-4099-9456-1a36d05be36d)
