### PR TITLE
Fix broken thumbnail links

### DIFF
--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -11,7 +11,7 @@ ars:
   country: 'USA'
   phone: ''
   contact_info: 'soundarchive@stanford.edu'
-  thumbnail_url: 'https://library.stanford.edu/sites/default/files/styles/150x150/public/branch/image/Edison_002LowRes.jpg'
+  thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/sul_ars_202302_web_0055.jpg&w=1080&q=75'
 
 cubberley:
   name: 'Cubberley Education Library'
@@ -26,7 +26,7 @@ cubberley:
   country: 'USA'
   phone: ''
   contact_info: 'cubberley@stanford.edu'
-  thumbnail_url: 'http://library.stanford.edu/sites/default/files/styles/150x150/public/branch/image/ed%20main.jpg'
+  thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/education.jpg&w=1080&q=75'
 
 # hoover:
 #   name: 'Hoover Institution Archives'
@@ -68,7 +68,7 @@ eal:
   country: 'USA'
   phone: '(650) 725-3435'
   contact_info: 'eastasialibrary@stanford.edu'
-  thumbnail_url: 'https://library.stanford.edu/sites/default/files/styles/150x150/public/branch/image/DSC_0011_150.jpg'
+  thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/placeholder_only_sul_eal_022123_0082-reduced_0.jpg&w=1080&q=75'
 
 speccoll:
   name: 'Special Collections'
@@ -83,7 +83,7 @@ speccoll:
   country: 'USA'
   phone: '(650) 725-1022'
   contact_info: 'specialcollections@stanford.edu'
-  thumbnail_url: 'https://library.stanford.edu/sites/default/files/styles/150x150/public/branch/image/DSC_0011_150.jpg'
+  thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/sul_speccoll_archives_202302_web_0019.jpg&w=1080&q=75'
 
 uarc:
   name: 'University Archives'
@@ -98,4 +98,4 @@ uarc:
   country: 'USA'
   phone: '(650) 725-1022'
   contact_info: 'specialcollections@stanford.edu'
-  thumbnail_url: 'https://library.stanford.edu/sites/default/files/styles/150x150/public/branch/image/DSC_0011_150.jpg'
+  thumbnail_url: 'https://library.sites-pro.stanford.edu/sites/library/files/media/image/sul_speccoll_archives_202302_web_0033.jpg'


### PR DESCRIPTION
These may not be the final images but would rather see them than broken links every day :)

Before
<img width="658" alt="Screenshot 2024-03-19 at 2 55 40 PM" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/a2d27626-2ebf-4e23-a97b-4a8d798d3d3e">



After
<img width="659" alt="Screenshot 2024-03-19 at 2 55 16 PM" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/dfebf878-da50-4288-917d-c04982ea3acb">
