### PR TITLE
Make the collection sidebar sticky and scrolling

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,4 +9,5 @@ $logo-width: 200px;
 $logo-height: 35px;
 @import 'blacklight-frontend/app/assets/stylesheets/blacklight/blacklight';
 @import 'arclight/app/assets/stylesheets/arclight/application';
+@import 'sulCollection';
 @import 'sulFooter';

--- a/app/assets/stylesheets/sulCollection.scss
+++ b/app/assets/stylesheets/sulCollection.scss
@@ -1,0 +1,16 @@
+#sidebar {
+  overflow-y: auto;
+
+  @include media-breakpoint-up(lg) {
+    overflow: hidden;
+    margin-bottom: 1rem;
+  }
+}
+
+#sidebar-scroll-wrapper {
+  @include media-breakpoint-up(lg) {
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: calc(100vh - 180px);
+  }
+}

--- a/app/components/arclight/sidebar_component.html.erb
+++ b/app/components/arclight/sidebar_component.html.erb
@@ -1,0 +1,11 @@
+<div class="offcanvas-lg offcanvas-start p-3 p-lg-1 sticky-lg-top" tabindex="-1" id="sidebar">
+  <%= collection_context %>
+  <div id="sidebar-scroll-wrapper">
+    <%= render 'show_tools', document: document %>
+    <%= collection_sidebar %>
+    <div id="collection-context" class="sidebar-section">
+      <h2><%= t('arclight.views.show.has_content') %></h2>
+      <%= turbo_frame_tag "al-hierarchy-#{document.root}", loading: 'lazy', src: hierarchy_solr_document_path(id: document.root, nest_path: @document.nest_path, hierarchy: true) %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Closes #439

This also adds scrolling to the collection overview/contents as discussed. This does not impact the sidebar when it is presented as a mobile menu.
 
For pages with significant front matter, I think this works well:

http://localhost:3000/catalog/ars0124aspace_ref42_5kr

For pages with a smaller amount of front matter, I'm more ambivalent about it (but we've established I have different tastes about this!):

http://localhost:3000/catalog/ars0124aspace_ref136_xr6

Reasons being in this case we could ideally be reducing the size of the scrollable sidebar by not just the header height, but potentially some proportion of the footer as well, depending on the height of the right panel content. Duke gets around this by not having a footer. Michigan has similar behavior as here.

Refinements like that (which I think would require JS) and replacing the hardcoded `180px` might be better left for the full design implementation, but I'm curious what you all think.