### PR TITLE
Link repositories directly to collection search results

### DIFF
--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -1,0 +1,34 @@
+<div class='al-grouped-title-bar'>
+  <div class='row'>
+    <div class='col-md-12'>
+      <% if document.repository_config.present? %>
+        <div class='al-grouped-repository breadcrumb-links'>
+          <%= link_to(document.repository_config.name, helpers.search_action_url(f: { repository: [document.repository_config.name], level: ['Collection'] })) %>
+        </div>
+      <% end %>
+      <h3><%= helpers.link_to_document document %></h3>
+      <% document.extent.each do |extent| %>
+        <%= tag.span extent, class: 'al-document-extent badge' unless compact? %>
+      <% end %>
+      <dl>
+        <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<div class="grouped-documents">
+  <div class="al-grouped-more">
+    <% if @group.total > 3 %>
+      <%= t('arclight.views.index.top_group_results', count: 3) %>
+      <%= link_to(
+        t('arclight.views.index.all_group_results', count: @group.total),
+        search_within_collection_url)
+      %>
+    <% else %>
+      <%= t('arclight.views.index.group_results_count', count: @group.total) %>
+    <% end %>
+  </div>
+
+  <%= helpers.render_document_index @group.docs %>
+</div>

--- a/app/components/arclight/repository_location_component.html.erb
+++ b/app/components/arclight/repository_location_component.html.erb
@@ -1,0 +1,20 @@
+<%= render(@layout.new(field: @field)) do |component| %>
+  <% component.with_label do %>
+    <%= label %>
+  <% end %>
+  <% component.with_value do %>
+    <div class='al-in-person-repository-name'>
+      <% if repository.thumbnail_url %>
+        <%= image_tag repository.thumbnail_url, alt: '', class: 'img-fluid float-left' %>
+      <% end %>
+      <div>
+        <%= link_to(repository.name, helpers.search_action_url(f: { repository: [repository.name], level: ['Collection'] })) %>
+      </div>
+    </div>
+    <div class='al-in-person-repository-location'>
+      <address>
+        <%= repository.location %>
+      </address>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -1,0 +1,43 @@
+<div class="mb-3 mx-auto al-repository">
+  <div class="container">
+    <div class='row'>
+      <div class='col-2 align-self-center d-none d-lg-block al-repository-thumbnail'>
+        <%= image_tag repository.thumbnail_url, alt: repository.name, class: 'img-fluid d-block mx-auto' %>
+      </div>
+
+      <div class="col-sm-12 col-lg-10 py-3 al-repository-information">
+        <%= content_tag(params[:id] == repository.slug ? :h1 : :h2, class: 'h5 mb-3 repo-name') do %>
+        <%= link_to_unless(params[:id] == repository.slug || repository.collection_count.to_i <= 0, repository.name, repository_collections_path(repository)) %>
+        <% end %>
+        <div class='row no-gutters justify-content-center'>
+          <div class='col-12 col-sm-4 col-md-3 fw-light al-repository-contact'>
+            <address class="text-break">
+              <div class="mb-3 al-repository-street-address">
+                <%= repository.location %>
+              </div>
+
+              <div class="al-repository-contact-info">
+                <%= repository.contact %>
+              </div>
+            </address>
+          </div>
+
+          <div class='col-12 col-sm mt-3 mt-sm-0 al-repository-description'>
+            <%= repository.description %>
+          </div>
+
+          <% if on_repositories_index? %>
+          <div class='col-12 col-lg-2 mt-3 mt-lg-0 text-center al-repository-extra'>
+            <div class='mb-1 fst-italic fw-bold'>
+              <%= t(:'arclight.views.repositories.number_of_collections', count: repository.collection_count) %>
+            </div>
+            <% if repository.collection_count&.positive? %>
+            <%= link_to(t(:'arclight.views.repositories.view_more'), repository_collections_path(repository), class: 'btn btn-secondary btn-sm') %>
+            <% end %>
+          </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/features/repositories_page_spec.rb
+++ b/spec/features/repositories_page_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Repositories Page', type: :feature do
+  before do
+    visit arclight_engine.repositories_path
+  end
+
+  it 'links repositories to the search page' do
+    expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
+  end
+end


### PR DESCRIPTION
Closes #429.

In Slack we also discussed changing the repository link in this same way in other areas. I will PR that separately if/when we are happy with how this is done.