### PR TITLE
Link repositories to their search page in breadcrumbs

### DIFF
--- a/app/components/breadcrumb_component.rb
+++ b/app/components/breadcrumb_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Display the document hierarchy as "breadcrumbs"
+class BreadcrumbComponent < Arclight::BreadcrumbComponent
+  def build_repository_link
+    render RepositoryBreadcrumbComponent.new(document: @document)
+  end
+end

--- a/app/components/breadcrumbs_hierarchy_component.rb
+++ b/app/components/breadcrumbs_hierarchy_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Render the breadcrumb hierarchy for a document
+class BreadcrumbsHierarchyComponent < Arclight::BreadcrumbsHierarchyComponent
+  def repository
+    # Link to the search page, rather than the repository landing page.
+    link_to(document.repository_config.name, helpers.repository_collections_path(document.repository_config))
+  end
+end

--- a/app/components/repository_breadcrumb_component.html.erb
+++ b/app/components/repository_breadcrumb_component.html.erb
@@ -1,0 +1,11 @@
+<li class='breadcrumb-item'>
+  <span class="ml-3 ms-3" aria-hidden="true">
+    <%= blacklight_icon(:repository, classes: 'al-repository-content-icon') %>
+  </span>
+  <% if repository_path %>
+    <%= link_to(@document.repository, helpers.repository_collections_path(@document.repository_config)) %>
+  <% else %>
+    <%= @document.repository %>
+  <% end %>
+</li>
+

--- a/app/components/repository_breadcrumb_component.rb
+++ b/app/components/repository_breadcrumb_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Draws the repository breadcrumb item for a search result
+class RepositoryBreadcrumbComponent < Arclight::RepositoryBreadcrumbComponent
+end

--- a/app/components/search_result_breadcrumbs_component.rb
+++ b/app/components/search_result_breadcrumbs_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Render the breadcrumbs for a search result document
+class SearchResultBreadcrumbsComponent < Arclight::SearchResultBreadcrumbsComponent
+  def breadcrumbs
+    offset = grouped? ? 2 : 0
+
+    BreadcrumbComponent.new(document:, count: breadcrumb_count, offset:)
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -74,7 +74,7 @@ class CatalogController < ApplicationController
     # config.show.title_field = 'title_display'
     config.show.document_component = Arclight::DocumentComponent
     config.show.sidebar_component = Arclight::SidebarComponent
-    config.show.breadcrumb_component = Arclight::BreadcrumbsHierarchyComponent
+    config.show.breadcrumb_component = BreadcrumbsHierarchyComponent
     config.show.embed_component = Arclight::EmbedComponent
     config.show.access_component = Arclight::AccessComponent
     config.show.online_status_component = Arclight::OnlineStatusIndicatorComponent
@@ -164,7 +164,7 @@ class CatalogController < ApplicationController
     }, compact: true, component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'creator', accessor: true, component: Arclight::IndexMetadataFieldComponent
     config.add_index_field 'abstract_or_scope', accessor: true, truncate: true, repository_context: true, helper_method: :render_html_tags, component: Arclight::IndexMetadataFieldComponent
-    config.add_index_field 'breadcrumbs', accessor: :itself, component: Arclight::SearchResultBreadcrumbsComponent, compact: { count: 2 }
+    config.add_index_field 'breadcrumbs', accessor: :itself, component: SearchResultBreadcrumbsComponent, compact: { count: 2 }
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Search Catalog Page', type: :feature do
+  before do
+    visit search_catalog_path
+  end
+
+  it 'links repositories in search results to their search page' do
+    within('#facets') do
+      click_link('Archive of Recorded Sound')
+    end
+
+    within('#documents') do
+      expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
+    end
+
+    click_link('Grouped by collection')
+    within('#documents') do
+      expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
+    end
+  end
+end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Collection Page', type: :feature do
+  it 'links to the repository search page in the breadcrumbs' do
+    visit search_catalog_path
+    within('#facets') do
+      click_link('Archive of Recorded Sound')
+    end
+    all('#documents .document-title-heading a').first.click
+
+    within('.al-show-breadcrumb') do
+      expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #485.

Chasing down more repository links that need to link to the search page.
