### PR TITLE
Solr config/schema updates for improved id search

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -174,6 +174,10 @@
 
     <fieldType name="identifier_match" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
+        <!-- Some EAD IDs contain .xml or .sgm file extensions.
+             Removing these characters allows search to work whether or not these are
+             present in the indexed value or in the query. -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\.?(xml|XML|sgm|SGM)" replacement=" " />
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.WordDelimiterGraphFilterFactory"
           catenateWords="1"
@@ -184,6 +188,10 @@
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
       </analyzer>
       <analyzer type="query">
+        <!-- Some EAD IDs contain .xml or .sgm file extensions.
+             Removing these characters allows search to work whether or not these are
+             present in the indexed value or in the query. -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\.?(xml|XML|sgm|SGM)" replacement=" " />
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.WordDelimiterGraphFilterFactory"
           catenateWords="1"
@@ -283,6 +291,7 @@
    <!-- default, catch all search field, also used for search term highlighting (requires stored="true") -->
    <field name="text" type="text" indexed="true" stored="true" multiValued="true"/>
    <field name="unitid_identifier_match" type="identifier_match" indexed="true" stored="false" multiValued="true" />
+   <field name="ead_identifier_match" type="identifier_match" indexed="true" stored="false" multiValued="true" />
 
    <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
    <field name="_nest_parent_" type="string" indexed="true" stored="true"/>
@@ -379,6 +388,7 @@
    <!-- grab structured data that's important -->
    <copyField source="unitid_ssm" dest="text" />
    <copyField source="unitid_ssm" dest="unitid_identifier_match" />
+   <copyField source="ead_ssi" dest="ead_identifier_match" />
 
    <!-- sort fields -->
    <copyField source="normalized_title_ssm" dest="title_sort"/> <!-- TODO: assumes single values -->

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -103,6 +103,7 @@
          title_tesim^100
          normalized_title_teim^100
          unitid_identifier_match^40
+         ead_identifier_match^40
          name_teim^10
          place_teim^10
          subject_teim^2
@@ -119,6 +120,7 @@
          title_tesim^200
          normalized_title_teim^200
          unitid_identifier_match^80
+         ead_identifier_match^80
          name_teim^20
          place_teim^20
          subject_teim^5
@@ -140,14 +142,18 @@
        <str name="qf_identifier">
          id
          ead_ssi
+         ead_identifier_match
          ref_ssm
          unitid_ssm
+         unitid_identifier_match
        </str>
        <str name="pf_identifier">
          id^2
          ead_ssi^2
+         ead_identifier_match^2
          ref_ssm^2
          unitid_ssm^2
+         unitid_identifier_match^2
        </str>
        <str name="qf_name">
          name_teim


### PR DESCRIPTION
Fixes #490 

These changes make it so that searches in All Fields and Identifier return expected results for the following queries:

ARS-0043
ARS-0043xml
ARS-0043.xml
ARS-0043-xml
ARS-0043 xml
ARS.0043
ARS.0043xml
ARS.0043.xml
ARS.0043-xml
ARS.0043 xml
ARS0043
ARS0043xml
ARS0043.xml
ARS0043-xml
ARS0043 xml
ARS 0043
ARS 0043xml
ARS 0043.xml
ARS 0043-xml
ARS 0043 xml
