### PR TITLE
Add numbered_cs param when fetching EAD XML

### DIFF
--- a/app/services/aspace_client.rb
+++ b/app/services/aspace_client.rb
@@ -48,7 +48,8 @@ class AspaceClient
             '/repositories/{REPOSITORY_ID}/resources/{RESOURCE_ID}'
     end
 
-    authenticated_get("#{resource_uri.gsub('/resources/', '/resource_descriptions/')}.xml?include_daos=true")
+    query_params = 'include_daos=true&numbered_cs=true'
+    authenticated_get("#{resource_uri.gsub('/resources/', '/resource_descriptions/')}.xml?#{query_params}")
   end
 
   # Returns an instance of AspaceQuery that response to :each returning

--- a/spec/services/aspace_client_spec.rb
+++ b/spec/services/aspace_client_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe AspaceClient do
 
   describe '#resource_description' do
     it 'sends an authenticated request with correct auth header to the resource_desriptions address' do
-      stub_request(:get, "#{url}/repositories/2/resource_descriptions/10208.xml?include_daos=true")
+      request_url = "#{url}/repositories/2/resource_descriptions/10208.xml?include_daos=true&numbered_cs=true"
+      stub_request(:get, request_url)
       client.resource_description('repositories/2/resources/10208')
-      expect(WebMock).to have_requested(:get,
-                                        "#{url}/repositories/2/resource_descriptions/10208.xml?include_daos=true")
+      expect(WebMock).to have_requested(:get, request_url)
         .with(headers: { 'X-ArchivesSpace-Session' => 'token1' }).once
     end
 


### PR DESCRIPTION
When numbered_cs is set to true, ASpace will output numbered tags (e.g., c01 rather than c).

https://archivesspace.github.io/archivesspace/api/#get-an-ead-representation-of-a-resource

RuboCop felt all the lines were too long, which is why it isn't added inline.

I tested this with one `DownloadEadJob.enqueue_one_by` job and it worked as expected.