### PR TITLE
Use the IndexEadJob to index the EAD seed data

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,11 +45,13 @@ task ci: %i[rubocop environment] do
 end
 
 desc 'Seed ArcLight fixture data'
-task :seed do
+task seed: :environment do
   # Read the repository configuration
   repo_config = YAML.safe_load(File.read('./config/repositories.yml'))
   repo_config.keys.map do |repository|
-    # Index a directory with a given repository ID that matches its filename
-    system("DIR=./spec/fixtures/ead/#{repository} REPOSITORY_ID=#{repository} rake arclight:index_dir")
+    # Index all EAD fixtures in directories matching the configured repository codes
+    Dir.glob(Rails.root.join('spec', 'fixtures', 'ead', repository, '*.xml').to_s).each do |file|
+      IndexEadJob.perform_now(file_path: file, arclight_repo_code: repository)
+    end
   end
 end


### PR DESCRIPTION
This change is necessary so that the seed data is indexed using the local traject configurations and not the traject configurations from upstream arclight.