### PR TITLE
Enable download of EAD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This command will loop through all the directories under `spec/fixtures/ead`, fo
 
 The easiest way to load data other than the fixtures is to use the `DownloadEadJob` and/or the `IndexEadJob`. See below for instructions about how to use Sidekiq to run these jobs in development. Under most circumstances it's fine to use the default `:async` adapter to run these jobs without Sidekiq in development. 
 
-By default the `DownloadEadJob` will store EAD files in the `./data` directory at the root of the application. You can choose a different location by setting the `DATA_DIR` environment variable or passing `data_dir:` argument to the job method.
+By default the `DownloadEadJob` will store EAD files in the directory set in `./config/settings.yml` as `Settings.data_dir`. You can choose a different location by setting the `DATA_DIR` environment variable, passing `data_dir:` argument to the job method, or by setting a different location for `data_dir` in `./config/settings.local.yml`
 
 The `DownloadEadJob` will attempt to use the ASpace API to download EADs. You will need to configure the API URL with username and password in order to connect to ASpace. To do this you will need to add the following to `config/settings.local.yml` with the correct URL, port, and account information:
 

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Controller for downloading finding aid files
+class DownloadController < ApplicationController
+  def show
+    doc = SolrDocument.find(params[:id])
+
+    data_dir = ENV.fetch('DATA_DIR', Rails.root.join('data').to_s)
+    repository_id = doc.repository_config.slug
+
+    respond_to do |format|
+      format.xml do
+        send_file File.join(data_dir, repository_id, doc.ead_filename)
+      end
+    end
+  end
+end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -5,7 +5,7 @@ class DownloadController < ApplicationController
   def show
     doc = SolrDocument.find(params[:id])
 
-    data_dir = ENV.fetch('DATA_DIR', Rails.root.join('data').to_s)
+    data_dir = Settings.data_dir
     repository_id = doc.repository_config.slug
 
     respond_to do |format|

--- a/app/jobs/download_ead_job.rb
+++ b/app/jobs/download_ead_job.rb
@@ -13,7 +13,7 @@ class DownloadEadJob < ApplicationJob
   # @param updated_after [String] YYYY-MM-DD optionally limit the response to resources updated after a specific date
   # @param data_dir [String] the path where the file should be saved, such as '/opt/app/arclight/data/ars'
   # @param index [Boolean] if true an IndexEadJob will be queued up with the downloaded file
-  def self.enqueue_all(updated_after: nil, data_dir: ENV.fetch('DATA_DIR', 'data'), index: true)
+  def self.enqueue_all(updated_after: nil, data_dir: Settings.data_dir, index: true)
     create_directories(data_dir:)
     AspaceRepositories.all_harvestable.each do |aspace_repository_code, aspace_repository_id|
       enqueue(aspace_repository_id:, aspace_repository_code:, updated_after:, data_dir:, index:)
@@ -26,7 +26,7 @@ class DownloadEadJob < ApplicationJob
   # @param data_dir [String] the path where the file should be saved, such as '/opt/app/arclight/data/ars'
   # @param index [Boolean] if true an IndexEadJob will be queued up with the downloaded file
   def self.enqueue_one_by(aspace_repository_code:, updated_after: nil,
-                          data_dir: ENV.fetch('DATA_DIR', 'data'), index: true)
+                          data_dir: Settings.data_dir, index: true)
     create_directories(data_dir:)
     aspace_repository_id = AspaceRepositories.find_by(code: aspace_repository_code)
     enqueue(aspace_repository_id:, aspace_repository_code:, updated_after:, data_dir:, index:)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -5,6 +5,8 @@ class SolrDocument
   include Blacklight::Solr::Document
   include Arclight::SolrDocument
 
+  attribute :ead_filename, :string, 'ead_filename_ssi'
+
   # Override Arclight::SolrDocument.digital_objects to use
   # local DigitalObject class that adds the Purl URL
   # Demo data href only contains the ID

--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -9,17 +9,8 @@
 #               - Pass a size_accessor key to pull the size of
 #                 the file from an accessor in the solr document
 #
-sample_unitid:
-  pdf:
-    href: 'http://example.com/sample.pdf'
-    size: '1.23MB'
-  ead:
-    href: 'http://example.com/sample.xml'
-    size: 123456
-    # size_accessor: 'level'
 default:
-  disabled: true
-  pdf:
-    template: 'http://example.com/%{unitid}.pdf'
   ead:
-    template: 'http://example.com/%{unitid}.xml'
+    template: '/download/%{id}.xml'
+  # pdf:
+  #   template: '/download/%{id}.pdf'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,9 @@ Rails.application.routes.draw do
       delete 'clear'
     end
   end
+
+  get '/download/:id' => 'download#show'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,4 @@ aspace:
     - cubberley
     - eal
     - speccoll
+data_dir: <%= ENV['DATA_DIR'] || './spec/fixtures/ead' %>

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -7,4 +7,8 @@ settings do
   provide 'solr_writer.http_timeout', 1200
 end
 
+to_field 'ead_filename_ssi' do |_record, accumulator|
+  accumulator << File.basename(settings['command_line.filename'])
+end
+
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb"))

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe SolrDocument do
+  describe 'custom accessors' do
+    let(:document) { described_class.new }
+
+    it { expect(document).to respond_to(:ead_filename) }
+  end
+
   describe 'digital objects' do
     let(:document) do
       described_class.new(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,9 +29,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 #
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-# The download controller needs to know where the EAD files are stored
-ENV['DATA_DIR'] ||= Rails.root.join('spec/fixtures/ead').to_s
-
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,9 @@ WebMock.disable_net_connect!(allow_localhost: true)
 #
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
+# The download controller needs to know where the EAD files are stored
+ENV['DATA_DIR'] ||= Rails.root.join('spec/fixtures/ead').to_s
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/requests/download_spec.rb
+++ b/spec/requests/download_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Download finding aid file' do
+  it 'downloads the file' do
+    get '/download/ARS-0043.xml'
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  context 'when the finding aid does not exist' do
+    it 'returns not found' do
+      get '/download/does_not_exist.xml'
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
Closes #434 

Because this relies on the filename being stored in Solr we'll need to re-index after this is merged.