### PR TITLE
Fix spacing on inline lists

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -30,6 +30,8 @@
   }
 
   .navbar-nav {
+    list-style-type: none;
+    padding-left: 0;
     margin-right: 0.5rem;
 
     li.active a {
@@ -37,13 +39,19 @@
     }
 
     li {
-      float: left;
-      margin-right: 1rem;
-      list-style-type: disc;
+      display: inline-block;
+      position: relative;
     }
-  
-    li:first-child::marker {
-      color: transparent;
+
+    li:not(:last-child) {
+      margin-right: 1rem;
+    }
+
+    li:not(:first-child)::before {
+      content: '•';
+      position: absolute;
+      left: -1.165rem;
+      top: 0.25rem;
     }
   }
 }

--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -77,13 +77,22 @@ $featured-teaser-overhang: 4rem;
   }
 
   @include media-breakpoint-up(md) {
-    li {
-      float: left;
-      margin-right: 2rem;
+    ul {
+      list-style-type: none;
+      padding-left: 0;
     }
-
-    li:first-child::marker {
-      color: transparent;
+    
+    ul li {
+      display: inline-block;
+      margin-right: 1.5rem;
+      position: relative;
+    }
+    
+    ul li:not(:first-child)::before {
+      content: '•';
+      position: absolute;
+      left: -1rem;
+      top: 0.05rem;
     }
   }
 


### PR DESCRIPTION
Closes #516.

The spacing was indeed pure chaos at different scaling levels. I couldn't figure a good way of handling this with markers, so I went back to using pseudo elements here. Is there a better way anybody knows of?

The non-landing page header has this same problem so I'm attempting to sneak that in here too.