### PR TITLE
Add and configure blacklight_range_limit gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ gem 'rsolr', '>= 1.0', '< 3'
 gem 'devise'
 gem 'devise-guests', '~> 0.8'
 gem 'blacklight-locale_picker'
+gem 'blacklight_range_limit', '~> 8.5'
 
 gem 'config'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
       view_component (>= 2.66, < 4)
     blacklight-locale_picker (1.1.0)
       rails (>= 5.2.3, < 7.2)
+    blacklight_range_limit (8.5.0)
+      blacklight (>= 7.25.2, < 9)
+      deprecation
+      view_component (>= 2.54, < 4)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -508,6 +512,7 @@ PLATFORMS
 DEPENDENCIES
   arclight (>= 1.1.0, < 2)
   blacklight-locale_picker
+  blacklight_range_limit (~> 8.5)
   bootsnap
   capistrano (~> 3.0)
   capistrano-bundler

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -16,3 +16,4 @@ $logo-height: 35px;
 @import 'sulLanding';
 @import 'sulCollection';
 @import 'sulFooter';
+@import 'sulFacets';

--- a/app/assets/stylesheets/sulFacets.scss
+++ b/app/assets/stylesheets/sulFacets.scss
@@ -1,0 +1,14 @@
+/* Date Range Facet */
+
+#facet-date_range {
+  // Hide some features that don't work or we don't want
+  .distribution, .more_facets, .facet-values.missing, .facet-count {
+    display: none;
+  }
+  p.range.subsection {
+    .facet-limit-active & {
+      // Don't show the complete date range if one is already applied
+      display: none;
+    }
+  }
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@
 # Blacklight controller that handles searches and document requests
 class CatalogController < ApplicationController
   include Blacklight::Catalog
+  include BlacklightRangeLimit::ControllerOverride
   include Arclight::Catalog
 
   configure_blacklight do |config|
@@ -143,7 +144,11 @@ class CatalogController < ApplicationController
     }
     config.add_facet_field 'collection', field: 'collection_ssim', limit: 10
     config.add_facet_field 'creators', field: 'creator_ssim', limit: 10
-    config.add_facet_field 'date_range', field: 'date_range_isim', range: true
+    config.add_facet_field 'date_range', field: 'date_range_isim',
+                                         range: {
+                                           chart_js: false,
+                                           slider_js: false
+                                         }
     config.add_facet_field 'level', field: 'level_ssim', limit: 10
     config.add_facet_field 'names', field: 'names_ssim', limit: 10
     config.add_facet_field 'repository', field: 'repository_ssim', limit: 10

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,6 +2,7 @@
 
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightRangeLimit::RangeLimitBuilder
   include Arclight::SearchBehavior
 
   ##

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   mount Blacklight::Engine => '/'
   mount Arclight::Engine => '/'
   mount Sidekiq::Web => '/sidekiq'
@@ -12,6 +13,7 @@ Rails.application.routes.draw do
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
+    concerns :range_searchable
   end
   devise_for :users
 


### PR DESCRIPTION
Closes #523 

Some of the JavaScript driven features (sliders and histogram) do not work with Blacklight 8 (see upstream issues: https://github.com/projectblacklight/blacklight_range_limit/issues/236), but it does support entering a date range.

Display with facet is not applied
<img width="327" alt="Screenshot 2024-04-15 at 10 43 28 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/458247/2f96649b-b214-4b73-b83c-8f767193f172">

Display when facet is applied
<img width="334" alt="Screenshot 2024-04-15 at 10 44 33 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/458247/257d3c2b-6921-4248-9536-b235397eb78f">
