### PR TITLE
Add autocomplete and search icon to landing page

### DIFF
--- a/app/assets/stylesheets/palette.scss
+++ b/app/assets/stylesheets/palette.scss
@@ -18,6 +18,7 @@ $stanford-digital-red: #b1040e;
 $stanford-fog: #dad7cb;
 $stanford-fog-light: #f4f4f4;
 $stanford-illuminating-dark: #FEC51D;
+$stanford-palo-alto-light: #2D716F;
 $stanford-palo-alto-dark: #014240;
 $stanford-stone: #7F7776;
 $stanford-stone-light: #D4D1D1;

--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -56,6 +56,31 @@
   }
 }
 
+.input-group {
+  .search-btn {
+    background-color: $navbar-dark-color;
+    border-color: #dee2e6; // Border color of Blacklight inputs
+    border-left: none;
+    padding: 0;
+    border-radius: 0;
+    color: $stanford-palo-alto-dark;
+
+    .blacklight-icons {
+      margin-top: 0.5rem;
+    }
+
+    &.btn:active {
+      background-color: $stanford-palo-alto-light;
+      border-color: $stanford-palo-alto-light;
+    }
+  }
+
+  > .search-autocomplete-wrapper ul li:active {
+    color: $stanford-black;
+    background-color: $grey-lighter;
+  }
+}
+
 .al-masthead + .navbar-search {
   border-top: none;
   background-color: $navbar-background-color;
@@ -67,21 +92,6 @@
     font-weight: 700;
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
-  }
-
-  .input-group {
-    .search-btn {
-      background-color: $navbar-dark-color;
-      border-color: #dee2e6; // Border color of Blacklight inputs
-      border-left: none;
-      padding: 0;
-      border-radius: 0;
-      color: $stanford-palo-alto-dark;
-
-      .blacklight-icons {
-        margin-top: 0.5rem;
-      }
-    }
   }
 
   .within-collection-dropdown {

--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -71,6 +71,10 @@ $featured-teaser-overhang: 4rem;
     color: $link-light-color;
   }
 
+  #autocomplete-popup li {
+    color: $stanford-black;
+  }
+
   li a {
     font-size: 1.125rem;
     font-weight: 350;

--- a/app/components/landing_page_search_bar_component.html.erb
+++ b/app/components/landing_page_search_bar_component.html.erb
@@ -5,7 +5,16 @@
   
   <div class="row">
     <div class="input-group col-12">
-      <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-0 me-xl-3", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+      <% if autocomplete_path.present? %>
+        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
+          <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
+          <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>"></ul>
+        </auto-complete>
+      <% else %>
+        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-0 me-xl-3", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+      <% end %>
+      <%= append %>
+      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
     </div>
     <div class="search-links col-12">
       <ul class="ps-md-0 pt-3">


### PR DESCRIPTION
Closes #525.

Brings the autocomplete and search icon back in from the Blacklight component:

![Screenshot 2024-04-15 at 11 19 16 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/e68eaf44-160c-481e-a3b4-a11d6d21455f)

Doesn't look like it'll conflict, but we might want to wait until #513 is merged. This PR would be way easier to rebase if needed.
