### PR TITLE
Set up Aeon requests but leave configurations commented out

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,6 +29,12 @@ class SolrDocument
     level&.parameterize == 'collection' && component_level.zero?
   end
 
+  def ead_file_without_namespace_href
+    params = { without_namespace: true }
+
+    "#{ead_file.href}?#{params.to_query}"
+  end
+
   # self.unique_key = 'id'
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document

--- a/app/views/arclight/requests/_aeon_web_ead.html.erb
+++ b/app/views/arclight/requests/_aeon_web_ead.html.erb
@@ -1,0 +1,6 @@
+<% if document.ead_file %>
+  <% aeon_web_ead ||= Arclight::Requests::AeonWebEad.new(document, "#{request.base_url}#{document.ead_file_without_namespace_href}") %>
+  <% aeon_web_ead_url = aeon_web_ead&.url %>
+
+  <%= link_to 'Request', aeon_web_ead_url, class: 'al-request-button btn btn-primary btn-sm me-1' %>
+<% end %>

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -13,6 +13,10 @@ ars:
   contact_html: |
      <div class="al-repository-contact-info"><a href="mailto:soundarchive@stanford.edu">soundarchive@stanford.edu</a></div>
   thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/sul_ars_202302_web_0055.jpg&w=1080&q=75'
+  # request_types:
+  #   aeon_web_ead:
+  #     request_url: 'https://stanford.aeon.atlas-sys.com/logon'
+  #     request_mappings: 'Action=10&Form=31&Value=ead_url'
 
 cubberley:
   name: 'Cubberley Education Library'
@@ -73,6 +77,10 @@ eal:
   contact_html: |
      <div class="al-repository-contact-info"><a href="eastasialibrary@stanford.edu">eastasialibrary@stanford.edu</a></div>  
   thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/placeholder_only_sul_eal_022123_0082-reduced_0.jpg&w=1080&q=75'
+  # request_types:
+  #   aeon_web_ead:
+  #     request_url: 'https://stanford.aeon.atlas-sys.com/logon'
+  #     request_mappings: 'Action=10&Form=31&Value=ead_url'
 
 manuscripts:
   name: 'Manuscripts'
@@ -89,6 +97,11 @@ manuscripts:
   contact_html: |
      <div class="al-repository-contact-info"><a href="specialcollections@stanford.edu">specialcollections@stanford.edu</a></div>  
   thumbnail_url: 'https://library.stanford.edu/_next/image?url=https://library.sites-pro.stanford.edu/sites/library/files/media/image/sul_speccoll_archives_202302_web_0019.jpg&w=1080&q=75'
+  # request_types:
+  #   aeon_web_ead:
+  #     request_url: 'https://stanford.aeon.atlas-sys.com/logon'
+  #     request_mappings: 'Action=10&Form=31&Value=ead_url'
+
 mhc:
   name: 'Medical History Center'
   description: 'The Stanford Medical History Center collects and maintains materials related to the history of health care, medical research, and medical education at Stanford and beyond.'
@@ -103,6 +116,11 @@ mhc:
   contact_html: |
        <div class="al-repository-contact-info"><a href="https://lane.stanford.edu/contacts/index.html">Contact Lane Medical Library</a></div> 
   thumbnail_url: 'https://lane.stanford.edu/graphics/about/lane-entrance.jpg'
+  # request_types:
+  #   aeon_web_ead:
+  #     request_url: 'https://stanford.aeon.atlas-sys.com/logon'
+  #     request_mappings: 'Action=10&Form=31&Value=ead_url'
+
 uarc:
   name: 'University Archives'
   visit_note: 'Special Collections and University Archives materials are stored offsite and must be paged 36 hours in advance.'
@@ -118,3 +136,7 @@ uarc:
   contact_html: |
      <div class="al-repository-contact-info"><a href="specialcollections@stanford.edu">specialcollections@stanford.edu</a></div> 
   thumbnail_url: 'https://library.sites-pro.stanford.edu/sites/library/files/media/image/sul_speccoll_archives_202302_web_0033.jpg'
+  # request_types:
+  #   aeon_web_ead:
+  #     request_url: 'https://stanford.aeon.atlas-sys.com/logon'
+  #     request_mappings: 'Action=10&Form=31&Value=ead_url'

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Request', type: :feature do
+  before do
+    visit '/catalog/ARS-0043_aspace_ref463_1bu'
+  end
+
+  it 'has an Aeon request button', skip: 'Skipped until we enable Aeon requesting' do
+    expect(page).to have_link(
+      'Request',
+      href: 'https://stanford.aeon.atlas-sys.com/logon' \
+            '?Action=10&Form=31' \
+            '&Value=http%3A%2F%2Fwww.example.com%2Fdownload%2FARS-0043_aspace_ref463_1bu.xml' \
+            '%3Fwithout_namespace%3Dtrue'
+    )
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -58,4 +58,16 @@ RSpec.describe SolrDocument do
       it { expect(document.collection?).to be false }
     end
   end
+
+  describe '#ead_file_without_namespace_href' do
+    let(:document) do
+      described_class.new(
+        id: 'ars0001'
+      )
+    end
+
+    it 'returns the href for the EAD file without a namespace' do
+      expect(document.ead_file_without_namespace_href).to eq '/download/ars0001.xml?without_namespace=true'
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures')
+  config.fixture_paths = Rails.root.join('spec/fixtures')
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Closes #510 

This wires up Aeon requesting without enabling the request feature via the repositories.yml config. If you want to test this locally un-comment one of the request_types config sets for one of the repositories.