### PR TITLE
Revert "Wrap config that sends logs to STDOUT in an ENV flag"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,12 +51,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    # Rails 7.1 introduced this new logger setup.
-    config.logger = ActiveSupport::Logger.new(STDOUT)
-      .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-  end
+  # Log to STDOUT by default
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
This reverts commit 4d9c62131e50003f5985ff29ad907658e4a3438c.

When logging to `STDOUT` the application logs get redirected to `/var/log/apache2/error.log`. One advantage of this set up instead of logging to `production.log` is that the logs automatically get sent to CloudWatch without additional configuration in puppet. See discussion on https://github.com/sul-dlss/stanford-arclight/issues/532