### PR TITLE
Fix rake task for deleting a collection and its children

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ bin/rails runner 'DownloadEadJob.enqueue_one_by(aspace_repository_code: "ars", u
 ### Deleting a collection
 There is a rake task for deleting a single collection and all of its components from the Solr index.
 
-1. Find the Solr document id for the collection (which is the EAD ID)
+1. Find the Solr document id for the collection (which is a form of the EAD ID)
 2. Run the rake task:
 ```shell
 # Some shells (such as zsh) require that the brackets are escaped.
-bundle exec rake stanford_arclight:delete_by_ead_id\['ars0167'\]
+bundle exec rake stanford_arclight:delete_by_id\['ars0167'\]
 ```
 3. Enter YES at the prompt to delete the collection and its components.

--- a/lib/tasks/stanford_arclight.rake
+++ b/lib/tasks/stanford_arclight.rake
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 namespace :stanford_arclight do
-  desc 'Delete a collection and its components from Solr by EAD ID'
-  task :delete_by_ead_id, %i[ead_id] => :environment do |_task, args|
-    puts "Are you sure you want to delete #{args[:ead_id]} from ArcLight?\nEnter YES to proceed:"
+  desc 'Delete a collection and its components from Solr by document ID'
+  task :delete_by_id, %i[id] => :environment do |_task, args|
+    puts "Are you sure you want to delete #{args[:id]} from ArcLight?\nEnter YES to proceed:"
     input = $stdin.gets.chomp
-    raise "#{args[:ead_id]} will NOT be deleted." unless input == 'YES'
+    raise "#{args[:id]} will NOT be deleted." unless input == 'YES'
 
-    puts "Deleting #{args[:ead_id]} from the index..."
-    Blacklight.default_index.connection.delete_by_query("id:#{args[:ead_id]}")
+    puts "Deleting #{args[:id]} from the index..."
+    Blacklight.default_index.connection.delete_by_id(args[:id])
     Blacklight.default_index.connection.commit
   end
 end


### PR DESCRIPTION
I found while working on https://github.com/sul-dlss/stanford-arclight/issues/550 that in order for Solr to correctly delete a parent and all its children (nested documents) you must delete by id and not by query.