### PR TITLE
Update landing page design

### DIFF
--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -6,14 +6,10 @@
     color: $link-dark-color;
   }
 
-  h1 {
+  h2 {
     font-size: 2.25rem;
     font-family: $font-family-serif;
-    font-weight: 500;
-  }
-
-  h2 {
-    font-weight: 300;
+    font-weight: bold;
   }
 
   #main-container .container {
@@ -37,7 +33,7 @@
 }
 
 $featured-item-height: 22rem;
-$featured-teaser-overhang: 4rem;
+$featured-teaser-overhang: 1rem;
 #featured-items-carousel {
   .carousel-item {
 
@@ -52,6 +48,7 @@ $featured-teaser-overhang: 4rem;
   .carousel-caption {
     font-style: italic;
     text-align: left;
+    background: rgba(0, 0, 0, 0.8);
   }
 }
 
@@ -61,9 +58,9 @@ $featured-teaser-overhang: 4rem;
 }
 
 #landing-page-search {
-  a, h1, li, p {
-    color: $link-light-color;
-  }
+  background-image: linear-gradient(to right, #EFEFEF, #D0D8D8);
+  // 30px matches height of stanford top white brand bar
+  padding-top: 30px;
 
   #autocomplete-popup li {
     color: $stanford-black;
@@ -99,9 +96,17 @@ $featured-teaser-overhang: 4rem;
   }
 }
 
-.input-group > .search-autocomplete-wrapper, .input-group {
-  border-radius: 0;
+.search-query-form > .input-group {
+  padding: 0;
+  border: 1px solid black;
+  height: 3rem;
+}
 
+.input-group > .search-autocomplete-wrapper, #autocomplete-popup {
+  border-radius: 0;
+}
+
+.input-group {
   input {
     font-style: italic;
   }
@@ -145,6 +150,6 @@ $featured-teaser-overhang: 4rem;
   }
 
   h3 {
-    font-weight: 300;
+    font-weight: bold;
   }
 }

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -1,17 +1,17 @@
 <div class='al-masthead bg-dark'>
   <div class="container">
     <div class="row align-items-center">
-      <% unless helpers.landing_page? %>
         <div class="col-md-8 d-flex justify-content-center justify-content-md-start align-items-center">
           <span class="h1"><%= heading %></span>
           <%= render 'shared/beta_tag' %>
         </div>
-        <nav class="col-md-4 nav-links d-flex justify-content-end" aria-label="browse">
-          <ul class="navbar-nav">
-            <%= render 'shared/main_menu_links' %>
-          </ul>
-        </nav>
-      <% end %>
+        <% unless helpers.landing_page? %>
+          <nav class="col-md-4 nav-links d-flex justify-content-end" aria-label="browse">
+            <ul class="navbar-nav">
+              <%= render 'shared/main_menu_links' %>
+            </ul>
+          </nav>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/components/landing_page_search_bar_component.html.erb
+++ b/app/components/landing_page_search_bar_component.html.erb
@@ -17,7 +17,8 @@
   </div>
   <div class="search-links col-12">
     <ul class="ps-md-0 pt-3">
-      <li><%= link_to 'Advanced Search', advanced_search_catalog_path %></li>
+      <%# Temporarily removing Advanced Search link per https://github.com/sul-dlss/stanford-arclight/issues/554 %> 
+       <%# <li> link_to 'Advanced Search', advanced_search_catalog_path</li> %>
       <li><%= link_to 'Browse all collections', helpers.arclight_engine.collections_path %></li>
       <li><%= link_to 'Browse repositories', helpers.arclight_engine.repositories_path %></li>
     </ul>

--- a/app/components/landing_page_search_bar_component.html.erb
+++ b/app/components/landing_page_search_bar_component.html.erb
@@ -3,25 +3,23 @@
 
   <%= f.label @query_param, scoped_t('search.label'), class: 'sr-only visually-hidden' %>
   
-  <div class="row">
-    <div class="input-group col-12">
-      <% if autocomplete_path.present? %>
-        <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
-          <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
-          <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>"></ul>
-        </auto-complete>
-      <% else %>
-        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-0 me-xl-3", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
-      <% end %>
-      <%= append %>
-      <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
-    </div>
-    <div class="search-links col-12">
-      <ul class="ps-md-0 pt-3">
-        <li><%= link_to 'Advanced Search', advanced_search_catalog_path %></li>
-        <li><%= link_to 'Browse all collections', helpers.arclight_engine.collections_path %></li>
-        <li><%= link_to 'Browse repositories', helpers.arclight_engine.repositories_path %></li>
-      </ul>
-    </div>
+  <div class="input-group col-12">
+    <% if autocomplete_path.present? %>
+      <auto-complete src="<%= autocomplete_path %>" for="autocomplete-popup" class="search-autocomplete-wrapper">
+        <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", autofocus: @autofocus, aria: { label: scoped_t('search.label'), autocomplete: 'list', controls: 'autocomplete-popup' }  %>
+        <ul id="autocomplete-popup" role="listbox" aria-label="<%= scoped_t('search.label') %>"></ul>
+      </auto-complete>
+    <% else %>
+      <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-0 me-xl-3", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
+    <% end %>
+    <%= append %>
+    <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
+  </div>
+  <div class="search-links col-12">
+    <ul class="ps-md-0 pt-3">
+      <li><%= link_to 'Advanced Search', advanced_search_catalog_path %></li>
+      <li><%= link_to 'Browse all collections', helpers.arclight_engine.collections_path %></li>
+      <li><%= link_to 'Browse repositories', helpers.arclight_engine.repositories_path %></li>
+    </ul>
   </div>
 <% end %>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -1,15 +1,14 @@
-<div id="landing-page-search" class="bg-dark pb-3">
+<div id="landing-page-search" class="pb-3">
   <div class="container mx-auto">
     <div class="row">
       <div class="col-sm-12 col-xxl-6 col-xl-7 col-lg-8 pt-5 pe-5">
         <div class="d-flex justify-content-center justify-content-md-start align-items-center">
-          <h1 class="pe-3 mb-0"><%= t '.title' %></h1>
-          <%= render 'shared/beta_tag' %>
+          <h2 class="pe-3 mb-0"><%= t '.title' %></h1>
         </div>
         <div class="d-flex justify-content-center justify-content-md-start">
           <p class="collection-count mt-2"><%= t('.collection_count', collection_count: number_with_delimiter(@collection_count)) %></p>
         </div>
-        <div class="mt-4">
+        <div class="mt-2">
           <%= render(LandingPageSearchBarComponent.new(
             url: search_action_url,
             params: search_state.params_for_search.except(:qt),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
       warning_html: Some materials and description may contain offensive content. <a href="https://library.stanford.edu/libraries/special-collections" class="fa fa-exclamation-circle">More info</a>
   landing_page:
     index:
-      title: 'Find Archival Materials'
+      title: 'Find archival materials'
       collection_count: Detailed inventories of %{collection_count} collections
     about:
       heading: 'About this site'

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Home Page', type: :feature do
   end
 
   it 'has the title and subtitle' do
-    expect(page).to have_css('.blacklight-landing_page h1', text: 'Find Archival Materials')
+    expect(page).to have_css('.blacklight-landing_page h2', text: 'Find archival materials')
     expect(page).to have_css('.blacklight-landing_page .collection-count', text: 'Detailed inventories of')
   end
 


### PR DESCRIPTION
Closes #538
Closes #554 
Closes #552 

Fulfilling #538 (make headers bold) does make the text appear bolder than in the Figma designs, but I went ahead with that since we discussed it as a team. 

Here's how it's looking:
<img width="1476" alt="Screenshot 2024-04-19 at 13 24 33" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/c7af89fa-28f5-4ac2-9764-bb985dab3d44">
