### PR TITLE
Allow featured image captions to have links

### DIFF
--- a/app/views/landing_page/_featured_item_teasers.html.erb
+++ b/app/views/landing_page/_featured_item_teasers.html.erb
@@ -2,9 +2,9 @@
   <div class="carousel-inner">
     <% Settings.featured_items.each_with_index do |item, index| %>
       <div class="carousel-item<%= ' active' if index == 0 %>" data-bs-interval="6000">
-        <img src="<%= item.image_url %>" class="d-block w-100" alt="<%= item.caption %>">
+        <img src="<%= item.image_url %>" class="d-block w-100" alt="<%= item.image_alt %>">
         <div class="carousel-caption d-none d-md-block py-1 px-3">
-          <p class="mb-1"><%= item.caption %></p>
+          <p class="mb-1"><%= item.caption_html.html_safe %></p>
         </div>
       </div>
     <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,11 +2,14 @@ hours_api: 'https://library-hours.stanford.edu/'
 
 featured_items:
   - image_url: https://stacks.stanford.edu/image/iiif/qy843rv0944/qy843rv0944_0080/200,700,2000,2500/!800,800/0/default.jpg
-    caption: USA Exhibit 388, Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945‑46
+    image_alt: USA Exhibit 388, Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46
+    caption_html: USA Exhibit 388, Taube Archive of the International Military Tribunal (IMT) at Nuremberg, 1945-46
   - image_url: https://stacks.stanford.edu/image/iiif/gs873gr6640/gs873gr6640_0001/full/!800,800/0/default.jpg
-    caption: Crucifix, Fear, Lynn Beldner Punk Music Photograph Collection
+    image_alt: Crucifix, Fear, from Lynn Beldner Punk Music Photograph Collection
+    caption_html: Crucifix, Fear, Lynn Beldner Punk Music Photograph Collection
   - image_url: https://stacks.stanford.edu/image/iiif/xc332sx6392/xc332sx6392_0001/full/!800,800/0/default.jpg
-    caption: Monterey Jazz Festival Program. 1972, Programs, 1958-2019; 2021
+    image_alt: Monterey Jazz Festival Program. 1972, Programs, 1958-2019; 2021
+    caption_html: Monterey Jazz Festival Program. 1972, Programs, 1958-2019; 2021
 
 # Locations with a 'closed_note' will display the note in lieu of fetching hours from the API.
 hours_locations:


### PR DESCRIPTION
Closes #524.

This is the way Duke and Michigan do it.

https://gitlab.oit.duke.edu/dul-its/dul-arclight/-/blob/main/config/featured_images.yml?ref_type=heads

We need the additional `image_alt` because alt text was specified in the original landing page issue (Duke and Michigan use a background image with no alt text).

I only added a link to the one image because it's the only one that has a corresponding link in demo currently.