### PR TITLE
Replace image carousel with single featured image

### DIFF
--- a/app/assets/stylesheets/featuredItemTeasers.scss
+++ b/app/assets/stylesheets/featuredItemTeasers.scss
@@ -1,8 +1,14 @@
-.carousel-item {
+// this css copies from bootstrap's carousel component
+.featured-item {
   position: relative;
+  float: left;
+  width: 100%;
+  margin-right: -100%;
+  backface-visibility: hidden;
+  display: block;
 }
 
-.carousel-caption {
+.featured-item-caption {
   position: absolute;
   bottom: 0;
   left: 0;

--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -34,8 +34,9 @@
 
 $featured-item-height: 22rem;
 $featured-teaser-overhang: 1rem;
-#featured-items-carousel {
-  .carousel-item {
+
+#featured-item-wrapper {
+  .featured-item {
 
     @include media-breakpoint-up(lg) {
       img {
@@ -45,7 +46,7 @@ $featured-teaser-overhang: 1rem;
     }
   }
 
-  .carousel-caption {
+  .featured-item-caption {
     font-style: italic;
     text-align: left;
     background: rgba(0, 0, 0, 0.8);

--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -97,6 +97,12 @@ $featured-teaser-overhang: 1rem;
   }
 }
 
+#about-landing {
+  // 30px matches height of stanford top white brand bar
+  padding-top: 30px;
+  padding-bottom: 30px;
+}
+
 .search-query-form > .input-group {
   padding: 0;
   border: 1px solid black;

--- a/app/views/landing_page/_featured_item_teasers.html.erb
+++ b/app/views/landing_page/_featured_item_teasers.html.erb
@@ -1,4 +1,4 @@
-<div id="featured-item-wrapper" class="d-lg-block">
+<div id="featured-item-wrapper" class="d-none d-lg-block">
   <% item = Settings.featured_items.sample %>
     <div class="featured-item">
       <img src="<%= item.image_url %>" class="d-block w-100" alt="<%= item.image_alt %>">

--- a/app/views/landing_page/_featured_item_teasers.html.erb
+++ b/app/views/landing_page/_featured_item_teasers.html.erb
@@ -1,12 +1,9 @@
-<div id="featured-items-carousel" class="carousel slide carousel-fade d-none d-lg-block" data-bs-ride="carousel" data-bs-interval="6000">
-  <div class="carousel-inner">
-    <% Settings.featured_items.each_with_index do |item, index| %>
-      <div class="carousel-item<%= ' active' if index == 0 %>" data-bs-interval="6000">
-        <img src="<%= item.image_url %>" class="d-block w-100" alt="<%= item.image_alt %>">
-        <div class="carousel-caption d-none d-md-block py-1 px-3">
-          <p class="mb-1"><%= item.caption_html.html_safe %></p>
-        </div>
+<div id="featured-item-wrapper" class="d-lg-block">
+  <% item = Settings.featured_items.sample %>
+    <div class="featured-item">
+      <img src="<%= item.image_url %>" class="d-block w-100" alt="<%= item.image_alt %>">
+      <div class="featured-item-caption d-md-block py-1 px-3">
+        <p class="mb-1"><%= item.caption_html.html_safe %></p>
       </div>
-    <% end %>
-  </div>
+    </div>
 </div>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -1,11 +1,11 @@
 <div id="landing-page-search" class="pb-3">
   <div class="container mx-auto">
     <div class="row">
-      <div class="col-sm-12 col-xxl-6 col-xl-7 col-lg-8 pt-5 pe-5">
-        <div class="d-flex justify-content-center justify-content-md-start align-items-center">
+      <div class="col-sm-12 col-xxl-6 col-xl-7 col-lg-8 lg-pt-5 pe-5">
+        <div class="d-flex">
           <h2 class="pe-3 mb-0"><%= t '.title' %></h1>
         </div>
-        <div class="d-flex justify-content-center justify-content-md-start">
+        <div class="d-flex">
           <p class="collection-count mt-2"><%= t('.collection_count', collection_count: number_with_delimiter(@collection_count)) %></p>
         </div>
         <div class="mt-2">
@@ -24,7 +24,7 @@
 </div>
 
 <div class="container mx-auto">
-  <div class="row py-lg-5">
+  <div class="row" id="about-landing">
     <div class="col-md-12">
       <%= render 'landing_page/about' %>
     </div>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Home Page', type: :feature do
     expect(page).to have_css('.blacklight-landing_page .collection-count', text: 'Detailed inventories of')
   end
 
-  it 'has featured items' do
-    expect(page).to have_css('#featured-items-carousel')
+  it 'has a featured item' do
+    expect(page).to have_css('#featured-item-wrapper')
   end
 
   it 'has the about section' do


### PR DESCRIPTION
Closes #540 

The image is randomly selected with the `.sample` method on each page load. 
Heads up, I did `rake assets:clobber` and hard refreshed before the CSS looked right.

<img width="1389" alt="Screenshot 2024-04-19 at 16 11 11" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/bc9cb1a6-75b6-4222-bafe-80942478f33c">
