### PR TITLE
Index the EAD source repository on the collection

### DIFF
--- a/app/jobs/download_ead_job.rb
+++ b/app/jobs/download_ead_job.rb
@@ -80,7 +80,7 @@ class DownloadEadJob < ApplicationJob
       f.puts ead.to_xml(indent: 2)
     end
 
-    IndexEadJob.perform_later(file_path:) if index
+    IndexEadJob.perform_later(file_path:, resource_uri:) if index
     GeneratePdfJob.perform_later(file_path:, file_name:, data_dir:) if generate_pdf
   end
 end

--- a/app/jobs/index_ead_job.rb
+++ b/app/jobs/index_ead_job.rb
@@ -10,14 +10,17 @@ class IndexEadJob < ApplicationJob
 
   # @example IndexEadJob.perform_later(file_path: '/data/ars/ars1234.xml')
   # @param file_path [String] the path to the file to be indexed, such as, '/data/ars/ars1234.xml'
+  # @param resource_uri [String] the resource URI for the record in ASpace
   # @param arclight_repository_code [String] the arclight repository code, such as 'ars'
   # @param solr_url [String] the web address for Solr where the file should be indexed
   # @param app_dir [Pathname] directory where the index command should be executed
   def perform(file_path:,
+              resource_uri: nil,
               arclight_repository_code: nil,
               solr_url: ENV.fetch('SOLR_URL', Blacklight.default_index.connection.base_uri),
               app_dir: Rails.root)
-    env = { 'REPOSITORY_ID' => arclight_repository_code || arclight_repository_code(file_path) }
+    env = { 'REPOSITORY_ID' => arclight_repository_code || arclight_repository_code(file_path),
+            'RESOURCE_URI' => resource_uri }
     cmd = "bundle exec traject -u #{solr_url} -i xml -c ./lib/traject/sul_config.rb #{file_path}"
 
     output, status = Open3.capture2(env, cmd, chdir: app_dir)

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -5,10 +5,19 @@ require 'arclight'
 settings do
   provide 'component_traject_config', File.join(__dir__, 'sul_component_config.rb')
   provide 'solr_writer.http_timeout', 1200
+  provide 'resource_uri', ENV.fetch('RESOURCE_URI', nil)
 end
 
 to_field 'ead_filename_ssi' do |_record, accumulator|
   accumulator << File.basename(settings['command_line.filename'])
+end
+
+to_field 'repository_uri_ssi' do |_record, accumulator|
+  accumulator << settings['resource_uri'].to_s[%r{/repositories/\d*}]
+end
+
+to_field 'resource_uri_ssi' do |_record, accumulator|
+  accumulator << settings['resource_uri']
 end
 
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb"))

--- a/spec/jobs/download_ead_job_spec.rb
+++ b/spec/jobs/download_ead_job_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe DownloadEadJob do
       expect do
         described_class.perform_now(resource_uri: '/repositories/1/resources/123', file_name: 'abc123',
                                     data_dir: '/data/archive/', index: true)
-      end.to enqueue_job(IndexEadJob).once.with(file_path: '/data/archive/abc123.xml')
+      end.to enqueue_job(IndexEadJob).once.with(file_path: '/data/archive/abc123.xml',
+                                                resource_uri: '/repositories/1/resources/123')
     end
   end
 

--- a/spec/jobs/index_ead_job_spec.rb
+++ b/spec/jobs/index_ead_job_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe IndexEadJob do
   it 'sends a command to index the EAD in Solr with traject' do
     described_class.perform_now(file_path: 'data/sample.xml',
                                 arclight_repository_code: 'ars',
+                                resource_uri: '/repositories/2/resources/123',
                                 solr_url: 'http://localhost/solr/core',
                                 app_dir: '/some/directory')
     expect(Open3).to have_received(:capture2).with(
-      { 'REPOSITORY_ID' => 'ars' },
+      { 'REPOSITORY_ID' => 'ars', 'RESOURCE_URI' => '/repositories/2/resources/123' },
       ['bundle',
        'exec',
        'traject',
@@ -34,10 +35,13 @@ RSpec.describe IndexEadJob do
   context 'when the arclight repository code is not provided as an argument' do
     it 'infers the repository code from the file path' do
       described_class.perform_now(file_path: '/data/archive/sample.xml',
+                                  resource_uri: '/repositories/2/resources/123',
                                   solr_url: 'http://localhost/solr/core',
                                   app_dir: '/some/directory')
 
-      expect(Open3).to have_received(:capture2).with({ 'REPOSITORY_ID' => 'archive' }, anything, anything)
+      expect(Open3).to have_received(:capture2).with({ 'REPOSITORY_ID' => 'archive',
+                                                       'RESOURCE_URI' => '/repositories/2/resources/123' },
+                                                     anything, anything)
     end
   end
 
@@ -50,6 +54,7 @@ RSpec.describe IndexEadJob do
       expect do
         described_class.perform_now(file_path: 'data/sample.xml',
                                     arclight_repository_code: 'ars',
+                                    resource_uri: '/repositories/2/resources/123',
                                     solr_url: 'http://localhost/solr/core',
                                     app_dir: '/some/directory')
       end.to raise_error(IndexEadJob::IndexEadError)


### PR DESCRIPTION
Closes #564 

I opted to only index the resource_uri and the repository_uri on the collection document which is all we need to handle automated deletes. I'll set up the delete job in a separate PR.
