### PR TITLE
Add job to delete finding aids unpublished in aspace

### DIFF
--- a/app/jobs/delete_ead_job.rb
+++ b/app/jobs/delete_ead_job.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+##
+# Background job that deletes an indexed collection from Solr
+# if we find it is no longer published or no longer exists in ASpace
+class DeleteEadJob < ApplicationJob
+  def self.enqueue_all
+    AspaceRepositories.all_harvestable.each_value do |repository_id|
+      perform_later(repository_id:)
+    end
+  end
+
+  # @param repository_id [String] the ASpace repository id, such as '11'
+  def perform(repository_id:)
+    indexed_eads = IndexedEads.new(repository_id:).all
+    published_eads = AspaceClient.new.all_published_resource_uris_by(repository_id:)
+
+    eads_to_delete = indexed_eads.keys - published_eads
+    ids_to_delete = indexed_eads.slice(*eads_to_delete).values
+
+    return if ids_to_delete.none?
+
+    Blacklight.default_index.connection.delete_by_id(ids_to_delete)
+    Blacklight.default_index.connection.commit
+  end
+
+  # Fetches all the indexed EAD files for an aspace repository
+  class IndexedEads
+    attr_reader :repository_id
+
+    PAGE_SIZE = 250
+
+    def initialize(repository_id:)
+      @repository_id = repository_id
+    end
+
+    # returns a hash where each key is an aspace resource uri and each value is a Solr document id
+    # e.g. {'/repositories/1/resources/123' => 'sc0908-xml', '/repositories/1/resources/456'' => 'm0001-xml'}
+    def all
+      ids = []
+      each { |id| ids << id }
+
+      ids.to_h
+    end
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def each(&block)
+      return enum_for(:each) unless block_given?
+
+      this_page = 0
+      last_page = nil
+
+      while last_page.nil? || this_page < last_page
+        response = repository.search(
+          rows: PAGE_SIZE,
+          start: this_page,
+          fl: 'id,resource_uri_ssi',
+          fq: "repository_uri_ssi:\"/repositories/#{repository_id}\""
+        )
+
+        this_page += PAGE_SIZE
+        last_page = response.dig('response', 'numFound')
+
+        response.dig('response', 'docs').map { |result| [result['resource_uri_ssi'], result['id']] }.each(&block)
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    delegate :repository, to: :blacklight_config
+
+    def blacklight_config
+      @blacklight_config ||= CatalogController.blacklight_config.configure
+    end
+  end
+end

--- a/app/services/aspace_client.rb
+++ b/app/services/aspace_client.rb
@@ -64,6 +64,19 @@ class AspaceClient
     AspaceQuery.new(client: self, repository_id:, updated_after:)
   end
 
+  # Returns an array of all published resource uris in ASpace for the specified repository
+  # e.g. ["/repositories/2/resources/5363", "/repositories/2/resources/3635"]
+  # @example client.all_published_resource_uris_by(repository_id: '2')
+  # @param repository_id [String] the repository id in ASpace
+  def all_published_resource_uris_by(repository_id:)
+    ead_ids = []
+    published_resource_uris(repository_id:).each do |uri|
+      ead_ids << uri['uri']
+    end
+
+    ead_ids
+  end
+
   # send an authenticated GET request to Aspace
   def authenticated_get(path, body = nil)
     raise ArgumentError, 'Please provide a path for the request' unless path

--- a/spec/jobs/delete_ead_job_spec.rb
+++ b/spec/jobs/delete_ead_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteEadJob do
+  let(:client) { instance_double(AspaceClient, all_published_resource_uris_by: ['/repositories/1/resources/2']) }
+  let(:indexed_eads) do
+    instance_double(DeleteEadJob::IndexedEads,
+                    all: { '/repositories/1/resources/2' => 'ead123', '/repositories/1/resources/3' => 'ead456' })
+  end
+  let(:rsolr_client) { instance_double(RSolr::Client) }
+  let(:repository) { instance_double(Blacklight::Solr::Repository, connection: rsolr_client) }
+
+  before do
+    allow(AspaceClient).to receive(:new).and_return(client)
+    allow(DeleteEadJob::IndexedEads).to receive(:new).and_return(indexed_eads)
+    allow(Blacklight).to receive(:default_index).and_return(repository)
+    allow(rsolr_client).to receive(:commit)
+    allow(rsolr_client).to receive(:delete_by_id)
+  end
+
+  it 'deletes any eads not published in ASpace' do
+    described_class.perform_now(repository_id: 1)
+
+    expect(DeleteEadJob::IndexedEads).to have_received(:new).with(repository_id: 1)
+    expect(client).to have_received(:all_published_resource_uris_by).with(repository_id: 1)
+    expect(rsolr_client).to have_received(:delete_by_id).with(['ead456'])
+    expect(rsolr_client).to have_received(:commit)
+  end
+
+  describe '.enqueue_all' do
+    let(:aspace_repository) { instance_double(AspaceRepositories, all_harvestable: { 'ars' => '11', 'eal' => '2' }) }
+
+    before do
+      allow(AspaceRepositories).to receive(:new).and_return(aspace_repository)
+    end
+
+    it 'assembles and enqueues a job for each harvestable repository' do
+      expect do
+        described_class.enqueue_all
+      end.to enqueue_job(described_class).exactly(2).times
+      expect(aspace_repository).to have_received(:all_harvestable).exactly(1).time
+    end
+  end
+end

--- a/spec/services/aspace_client_spec.rb
+++ b/spec/services/aspace_client_spec.rb
@@ -66,6 +66,24 @@ RSpec.describe AspaceClient do
     end
   end
 
+  describe '#all_published_resource_uris_by' do
+    let(:published_resource_uris) do
+      [{ 'ead_id' => 'abc123', 'uri' => '/repositories/3/resources/2' },
+       { 'ead_id' => 'abc456', 'uri' => '/repositories/3/resources/4' }]
+    end
+
+    before do
+      allow(AspaceClient::AspaceQuery).to receive(:new).with(client:, repository_id: 3, updated_after: nil)
+                                                       .and_return(published_resource_uris)
+    end
+
+    it 'returns an array of published resource uris' do
+      expect(client.all_published_resource_uris_by(repository_id: 3)).to eq(
+        ['/repositories/3/resources/2', '/repositories/3/resources/4']
+      )
+    end
+  end
+
   describe '#authenticated_get' do
     it 'sends an authenticated request with correct auth header to the specified address' do
       stub_request(:get, "#{url}/some_request")


### PR DESCRIPTION
Closes #550 

This doesn't schedule the job to run. I thought we'd do that when we work on the configuration specified in #424 