### PR TITLE
Hide recaptcha badge

### DIFF
--- a/app/assets/stylesheets/sulBase.scss
+++ b/app/assets/stylesheets/sulBase.scss
@@ -38,3 +38,7 @@ a {
   font-size: 0.875rem;
   padding: 0.15rem 0.75rem 0.15rem 0.75rem;
 }
+
+.grecaptcha-badge {
+  visibility: hidden;
+}


### PR DESCRIPTION
We display "This site is protected by reCAPTCHA and the Google [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms) apply" in the feedback form so we don't need to display the badge on every page.

Closes #569 