### PR TITLE
Style tweaks for the search bar

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -86,6 +86,7 @@
     padding: 0;
     border-radius: 0;
     color: $stanford-palo-alto-dark;
+    padding-right: 5px;
 
     .blacklight-icons {
       margin-top: 0.5rem;

--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -105,7 +105,6 @@ $featured-teaser-overhang: 1rem;
 
 .search-query-form > .input-group {
   padding: 0;
-  border: 1px solid black;
   height: 3rem;
 }
 


### PR DESCRIPTION
Fixes border issue reported in slack
Makes magnifying glass icon have padding to look more like mockups.

<img width="1125" alt="Screenshot 2024-05-01 at 09 57 42" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/b3ff5709-599b-46cc-86cd-2cdbbb78178b">
