### PR TITLE
Display call number on collection pages

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,6 +272,7 @@ class CatalogController < ApplicationController
     # Collection Show Page - Summary Section
     config.add_summary_field 'creators', field: 'creator_ssim', link_to_facet: true
     config.add_summary_field 'abstract', field: 'abstract_html_tesm', helper_method: :render_html_tags
+    config.add_summary_field 'unitid_ssm', label: 'Call number'
     config.add_summary_field 'extent', field: 'extent_ssm'
     config.add_summary_field 'language', field: 'language_ssim'
 

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -3,13 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe 'Collection Page', type: :feature do
-  it 'links to the repository search page in the breadcrumbs' do
+  before do
     visit search_catalog_path
-    within('#facets') do
+    within('#facet-level') do
+      click_link('Collection')
+    end
+    within('#facet-repository') do
       click_link('Archive of Recorded Sound')
     end
     all('#documents .document-title-heading a').first.click
+  end
 
+  it 'displays the call number in the summary section' do
+    within('#summary') do
+      expect(page).to have_text('Call number')
+    end
+  end
+
+  it 'links to the repository search page in the breadcrumbs' do
     within('.al-show-breadcrumb') do
       expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
     end


### PR DESCRIPTION
Closes #443.

![Screenshot 2024-05-01 at 12 15 06 PM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/b2ec80f8-7f43-4464-8540-d9a9356a1aa7)

Also changes the collection page test feature spec to actually visit a collection, which I missed the first time around.