### PR TITLE
Change default search grouping to 'collection'

### DIFF
--- a/app/components/arclight/search_bar_component.html.erb
+++ b/app/components/arclight/search_bar_component.html.erb
@@ -1,8 +1,9 @@
 <%= render(Blacklight::SearchBarComponent.new(
       **@kwargs,
-      params: @params.merge(f: (@params[:f] || {}).except(:collection)),
+      params: @params.merge(f: (@params[:f] || {}).except(:collection), group: true),
                             q: @q,
-                            search_field: @search_field)) do |c| %>
+                            search_field: @search_field,
+                            form_options: { data: { controller: "search-form" } })) do |c| %>
 
   <% c.with_before_input_group do %>
     <div class="input-group within-collection-dropdown">

--- a/app/components/landing_page_search_bar_component.rb
+++ b/app/components/landing_page_search_bar_component.rb
@@ -2,4 +2,10 @@
 
 # A version of the ArcLight/Blacklight search bar that only shows the text input.
 class LandingPageSearchBarComponent < Arclight::SearchBarComponent
+  def initialize(**kwargs)
+    super
+
+    # Default to grouping search results by collection.
+    @params = @params.merge(@params, group: true)
+  end
 end

--- a/app/javascript/controllers/search_form_controller.js
+++ b/app/javascript/controllers/search_form_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.addEventListener('submit', this.handleSubmit.bind(this));
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+
+    const selectElement = this.element.querySelector('[id^="within_collection"]');
+    const groupByCollection = this.element.querySelector('input[name="group"]');
+
+    // See https://github.com/sul-dlss/stanford-arclight/issues/544
+    // We default to grouping results by collection, but if the user
+    // is searching within a collection then default to all results.
+    if (selectElement.value) {
+      groupByCollection?.remove();
+    }
+
+    this.element.submit();
+  }
+}

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -2,25 +2,47 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Search', type: :feature do
-  before do
-    visit search_catalog_path
+RSpec.describe 'Searching', :js, type: :feature do
+  context 'when not within a collection' do
+    before do
+      visit search_catalog_path
 
-    # Fill in the search input with some text
-    fill_in 'q', with: 'Example search query'
+      # Fill in the search input with some text
+      fill_in 'q', with: 'Example search query'
 
-    click_button 'Search'
+      click_button 'Search'
+    end
+
+    it 'renders the search results page with default params' do
+      expect(page.current_url).to include('search_field=keyword&q=Example+search+query')
+      expect(page.current_url).to include('group=true')
+
+      expect(page).to have_content(/You searched for:\s*Keyword Example search query/)
+    end
+
+    it 'creates Start Over link with the group=true parameter' do
+      click_link('Start Over')
+
+      expect(page).to have_current_path(search_catalog_path(group: true))
+    end
   end
 
-  it 'Renders the search results page with default params' do
-    expect(page).to have_current_path('/catalog?search_field=keyword&q=Example+search+query')
-
-    expect(page).to have_content('You searched for: Keyword Example search query')
+  context 'when within a collection' do
+    it 'does not group by collection' do
+      visit solr_document_path(id: 'ARS-0043')
+      fill_in 'q', with: 'jazz'
+      click_on 'search'
+      expect(page.current_url).not_to include('group=true')
+    end
   end
 
-  it 'Creates Start Over link with the group=true parameter' do
-    click_link('Start Over')
-
-    expect(page).to have_current_path(search_catalog_path(group: true))
+  context 'when within a collection and user selects group by all collections' do
+    it 'groups by collection' do
+      visit solr_document_path(id: 'ARS-0043')
+      fill_in 'q', with: 'jazz'
+      select('all collections', from: 'within_collection')
+      click_on 'search'
+      expect(page.current_url).to include('group=true')
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+Capybara.javascript_driver = :selenium_chrome_headless
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = Rails.root.join('spec/fixtures')


### PR DESCRIPTION
Closes #544.

I make a small modification to the ask here, by grouping by "all results" when searching within a collection. This is explained in #544. We should wait for @dinahhandel or @corylown to weigh in before accepting.