### PR TITLE
Adjust landing page search focus styling

### DIFF
--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -67,6 +67,14 @@ $featured-teaser-overhang: 1rem;
     color: $stanford-black;
   }
 
+  .input-group > .search-autocomplete-wrapper input:focus {
+    box-shadow: none;
+  }
+
+  .search-query-form .input-group:focus-within {
+    box-shadow: 0 0 0 0.25rem rgba($link-dark-color, 0.25);
+  }
+
   li a {
     font-size: 1.125rem;
     font-weight: 350;


### PR DESCRIPTION
Not requested, feel free to discard. This is my own personal pet peeve.

Changes the focus styling on the landing page search to encompass the search button.

Old:
![Screenshot 2024-05-02 at 3 30 07 PM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/7deca612-3ad1-4044-b36a-2ca95d2385f4)

New:
![Screenshot 2024-05-02 at 3 30 15 PM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/88fd37e8-6d59-4635-9c61-f99da4134fc5)

Does not modify any behavior on the other pages.
