### PR TITLE
Switch from mysql to postgres in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 group :production do
-  gem 'mysql2'
+  gem 'pg', '~> 1.5'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,6 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
-    mysql2 (0.5.6)
     net-http (0.4.1)
       uri
     net-imap (0.4.10)
@@ -299,6 +298,7 @@ GEM
     parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.6)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -535,8 +535,8 @@ DEPENDENCIES
   honeybadger (~> 5.2)
   importmap-rails
   jbuilder
-  mysql2
   okcomputer (~> 1.18)
+  pg (~> 1.5)
   puma (~> 6.0)
   rails (~> 7.1.2)
   recaptcha (~> 5.16)


### PR DESCRIPTION
sul-arclight-demo is now on postgres. We'll just let sul-arclight-prod hum along on mysql until we switch over to the new load-balanced prod VMs and then shut it down.