### PR TITLE
Limit the width of flash alerts

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -25,8 +25,13 @@
   }
 
   a {
-    color: $stanford-digital-blue
+    color: $stanford-digital-blue;
   }
+ }
+
+ #main-flashes {
+  // contain the width of the flashes to Bootstrap's container width
+  @extend .container;
  }
 
 .al-masthead {


### PR DESCRIPTION
<img width="1379" alt="Screenshot 2024-05-10 at 16 23 54" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/4af627e8-6bdc-4c14-b178-a2d78eda601b">

This gets us this far on #534 


As for making the "X" nicer looking, we may need to wait on[ this Blacklight PR]( https://github.com/projectblacklight/blacklight/pull/3153 ) in order to properly style it. I couldn't get very far with the invalid `<button-tag>`
