### PR TITLE
Refine hover colors for search constraints

### DIFF
--- a/app/assets/stylesheets/sulCollection.scss
+++ b/app/assets/stylesheets/sulCollection.scss
@@ -184,6 +184,13 @@ a.btn-outline-secondary:hover,
 a.btn-outline-secondary:focus {
   background-color: $secondary;
   border-color: $secondary;
+  text-decoration: none;
+}
+
+span.constraint-value:hover, 
+span.constraint-value:focus {
+  background-color: white;
+  color: black;
 }
 
 .dropdown-item.active {


### PR DESCRIPTION
Closes #617 

@corylown I went with your suggestion to do nothing if hovering over the non-actionable text of the constraint.

(hover state on the X button:)


<img width="326" alt="Screenshot 2024-05-13 at 13 24 45" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/2c59bcf4-0491-4569-a71b-0c908fba24aa">
