### PR TITLE
Remove list styles from autocomplete dropdown

### DIFF
--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -74,17 +74,18 @@ $featured-teaser-overhang: 1rem;
       padding-left: 0;
     }
     
-    ul li {
+    .search-links ul li {
       display: inline-block;
       margin-right: 1.5rem;
       position: relative;
     }
-    
-    ul li:not(:first-child)::before {
+
+    .search-links ul li:not(:first-child)::before {
       content: '•';
       position: absolute;
       left: -1rem;
       top: 0.05rem;
+      color: $stanford-digital-blue;
     }
   }
 


### PR DESCRIPTION
Closes #604 if I understood @taylor-steve correctly!


With this change:

<img width="683" alt="Screenshot 2024-05-13 at 14 13 14" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/62a44400-e773-4af8-a863-80c5e60e40f7">
