### PR TITLE
Provide custom id normalizer for Solr documents

### DIFF
--- a/lib/traject/sul/normalized_id.rb
+++ b/lib/traject/sul/normalized_id.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'arclight/exceptions'
+
+module Sul
+  ##
+  # A utility class to normalize identifiers
+  class NormalizedId
+    # The Arclight to_field directive sends kwargs (:title and :repository)
+    # to this class and we use the id and title to form the collection id
+    def initialize(id, **kwargs)
+      @id = id
+      @title = kwargs[:title]
+    end
+
+    def to_s
+      normalize
+    end
+
+    private
+
+    attr_reader :id, :title
+
+    def normalize
+      # De-duplicate edge cases where id has been generated from title due to missing EAD ID
+      # E.g. don't return Université de Toulouse_universite-de-toulouse
+      # Instead, return only universite-de-toulouse.
+      # Otherwise return something like ars0009_belva-kibler-and-donald-morgan
+      normalized_id = [id, title].map do |string|
+        string&.truncate_words(5, omission: '')&.parameterize
+      end.compact.uniq.join('_')
+
+      raise Arclight::Exceptions::IDNotFound if normalized_id.blank?
+
+      normalized_id
+    end
+  end
+end

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'arclight'
+require_relative 'sul/normalized_id'
 
 settings do
   provide 'component_traject_config', File.join(__dir__, 'sul_component_config.rb')
   provide 'solr_writer.http_timeout', 1200
   provide 'resource_uri', ENV.fetch('RESOURCE_URI', nil)
+  provide 'id_normalizer', 'Sul::NormalizedId'
 end
 
 to_field 'ead_filename_ssi' do |_record, accumulator|

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -8,21 +8,52 @@ RSpec.describe 'Collection Page', type: :feature do
     within('#facet-level') do
       click_link('Collection')
     end
-    within('#facet-repository') do
-      click_link('Archive of Recorded Sound')
-    end
-    all('#documents .document-title-heading a').first.click
   end
 
-  it 'displays the call number in the summary section' do
-    within('#summary') do
-      expect(page).to have_text('Call number')
+  context 'when visiting a collection page' do
+    before do
+      visit search_catalog_path
+      within('#facet-level') do
+        click_link('Collection')
+      end
+      within('#facet-repository') do
+        click_link('Archive of Recorded Sound')
+      end
+      # Click on a specific collection
+      collection_title_element = find('#documents .document-title-heading a',
+                                      text: 'Ambassador Auditorium Collection, 1974-1995')
+      collection_title_element.click
+    end
+
+    it 'displays the call number in the summary section' do
+      within('#summary') do
+        expect(page).to have_text('Call number')
+      end
+    end
+
+    it 'links to the repository search page in the breadcrumbs' do
+      within('.al-show-breadcrumb') do
+        expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
+      end
+    end
+
+    it 'displays the normalized collection id in the URL' do
+      expect(page.current_url).to eq('http://www.example.com/catalog/ars-0043_ambassador-auditorium-collection')
     end
   end
 
-  it 'links to the repository search page in the breadcrumbs' do
-    within('.al-show-breadcrumb') do
-      expect(page).to have_link('Archive of Recorded Sound', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
+  context 'when visiting a collection page with an id derived from its title' do
+    before do
+      within('#facet-repository') do
+        click_link('Cubberley Education Library')
+      end
+      collection_title_element = find('#documents .document-title-heading a',
+                                      text: 'Université de Toulouse')
+      collection_title_element.click
+    end
+
+    it 'displays the normalized collection id in the URL' do
+      expect(page.current_url).to eq('http://www.example.com/catalog/universite-de-toulouse')
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Searching', :js, type: :feature do
 
   context 'when within a collection' do
     it 'does not group by collection' do
-      visit solr_document_path(id: 'ARS-0043')
+      visit solr_document_path(id: 'ars-0043_ambassador-auditorium-collection')
       fill_in 'q', with: 'jazz'
       click_on 'search'
       expect(page.current_url).not_to include('group=true')
@@ -38,7 +38,7 @@ RSpec.describe 'Searching', :js, type: :feature do
 
   context 'when within a collection and user selects group by all collections' do
     it 'groups by collection' do
-      visit solr_document_path(id: 'ARS-0043')
+      visit solr_document_path(id: 'ars-0043_ambassador-auditorium-collection')
       fill_in 'q', with: 'jazz'
       select('all collections', from: 'within_collection')
       click_on 'search'

--- a/spec/fixtures/ead/cubberley/toulouse.xml
+++ b/spec/fixtures/ead/cubberley/toulouse.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd"><eadheader countryencoding="iso3166-1" dateencoding="iso8601" findaidstatus="completed" langencoding="iso639-2b" repositoryencoding="iso15511"><eadid url="https://purl.stanford.edu/mg919tk8849">Université de Toulouse</eadid><filedesc><titlestmt><titleproper>Guide to Université de Toulouse Catalogs, etc. <num>Cubb.2033</num></titleproper><author>Kathy Kerns</author></titlestmt><publicationstmt><publisher>Cubberley Education Library</publisher><p><date>10/19/2023</date></p><address><addressline>485 Lasuen Mall</addressline><addressline>Stanford, CA 94305-3097</addressline><addressline>Business Number: 650.723.2121</addressline><addressline>Fax Number: 650.736.0536</addressline><addressline>cubberley@stanford.edu</addressline><addressline>URL: <extptr xlink:href="http://url.unspecified" xlink:show="new" xlink:title="http://url.unspecified" xlink:type="simple"/></addressline></address></publicationstmt></filedesc><profiledesc><creation>This finding aid was produced using ArchivesSpace on <date>2024-05-15 07:30:21 -0700</date>.</creation><langusage>English</langusage><descrules>Describing Archives: A Content Standard</descrules></profiledesc></eadheader><archdesc level="collection">
+  <did>
+    <repository>
+      <corpname>Cubberley Education Library</corpname>
+    </repository>
+    <unittitle>Université de Toulouse</unittitle>
+    <unitid>Cubb.2033</unitid>
+    <physdesc altrender="whole">
+      <extent altrender="materialtype spaceoccupied">85 item(s)</extent>
+    </physdesc>
+    <unitdate calendar="gregorian" datechar="creation" era="ce" normal="1902/1968" type="inclusive">1902-1968</unitdate>
+    <abstract id="aspace_892d4ff45335eba316d579f0313fda91">Located in Toulouse, France. Founded in 1229.</abstract>
+    <langmaterial>
+      <language langcode="eng">English</language>
+.    </langmaterial>
+    <container id="aspace_9d7703a99a804fa5caf47b9518364326" label="Mixed Materials" type="Box">2511</container>
+    <container id="aspace_bda817d85dd724564a8bee39b4fe26ec" label="Mixed Materials" type="Box">2512</container>
+  </did>
+  <controlaccess>
+    <geogname source="ingest">France</geogname>
+  </controlaccess>
+  <dsc><c id="aspace_86f6d51be37fad89ee11fc7f1e8a3666" level="subseries"><did><unittitle>Annuaire</unittitle><physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">22 item(s)</extent><extent altrender="carrier">Annuaire fo 1904/05-1909/10, 1911/12-1914/15, 1928/29-1929/20, 1931-1940</extent></physdesc><unitdate calendar="gregorian" datechar="creation" era="ce" normal="1904/1940" type="inclusive">1904-1940</unitdate><langmaterial><language langcode="eng">English</language>.</langmaterial><container id="aspace_8546747cf2755988c51f3960be2c7075" label="Mixed Materials" type="Box">2511</container></did></c><c id="aspace_07213c3865ba106abafd55c894405569" level="subseries"><did><unittitle>Guide de l'Étudiant</unittitle><physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">18 item(s)</extent><extent altrender="carrier">Guides for 1932/33, 1942/43, 1951/52, 1953/54-1967/68</extent></physdesc><unitdate calendar="gregorian" datechar="creation" era="ce" normal="1932/1968" type="inclusive">1932-1968</unitdate><langmaterial><language langcode="eng">English</language>.</langmaterial><container id="aspace_eae23811bf341f9a54df9f51ac595295" label="Mixed Materials" type="Box">2511</container></did></c><c id="aspace_3eff3f3fc7c240a924f8ae47ac264af4" level="subseries"><did><unittitle>Rapport Annuel</unittitle><physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">34 item(s)</extent><extent altrender="carrier">Bound together: Rapports for 1902/03-1903/04;
+Bound together: Rapports for 1904/05-1907/08;
+Separate: Rapports for 1909/10-1910/11;
+Bound together: Rapports for 1911/12-1916/17;
+Separate: Rapports for 1917/18-1936/37</extent></physdesc><unitdate calendar="gregorian" datechar="creation" era="ce" normal="1902/1902" type="inclusive">1902-</unitdate><langmaterial><language langcode="eng">English</language>.</langmaterial><container id="aspace_0cbf14f653a92d56aee320fd7f4e6a3f" label="Mixed Materials" type="Box">2512</container></did></c><c id="aspace_4a8d417222c82acc0d80be857342b3fa" level="subseries"><did><unittitle>Programme et Horaire des Cours et Conférences</unittitle><physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">8 item(s)</extent><extent altrender="carrier">Information for 1919/20-1926/27</extent></physdesc><unitdate calendar="gregorian" datechar="creation" era="ce" normal="1919/1926" type="inclusive">1919-1926</unitdate><langmaterial><language langcode="eng">English</language>.</langmaterial><container id="aspace_67f33d1e7917de9096a022731f827e90" label="Mixed Materials" type="Box">2512</container></did></c><c id="aspace_8534cb3de06352b8e6d7660c4adec64b" level="subseries"><did><unittitle>Comité de patronage des Étudiants étrangers</unittitle><physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">2 item(s)</extent><extent altrender="carrier">Notice sur la Ville et l'Université de Toulouse publiée [1914];
+Cours de vacances 1914
+</extent></physdesc><unitdate calendar="gregorian" datechar="creation" era="ce" normal="1914/1914">1914</unitdate><langmaterial><language langcode="eng">English</language>.</langmaterial><container id="aspace_d22d381b61257466714d3c975422d93e" label="Mixed Materials" type="Box">2512</container></did></c><c id="aspace_d99928d70b256025995a35b2190cec87" level="item"><did><unittitle>VIIe Centenaire de la Fondation de l'Université de Toulouse, 1229-1929</unittitle><physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">1 item(s)</extent></physdesc><unitdate calendar="gregorian" datechar="creation" era="ce" normal="1931/1931">1931</unitdate><langmaterial><language langcode="eng">English</language>.</langmaterial><container id="aspace_f8f64a096f94717d5f43cb8f0d5c5490" label="Mixed Materials" type="Box">2512</container></did></c></dsc>
+</archdesc>
+</ead>

--- a/spec/requests/download_spec.rb
+++ b/spec/requests/download_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Download finding aid file' do
   it 'downloads the file' do
-    get '/download/ARS-0043.xml'
+    get '/download/ars-0043_ambassador-auditorium-collection.xml'
 
     expect(response).to have_http_status(:ok)
     expect(Nokogiri::XML::Document.parse(response.body).at_css('ead').namespaces).to(
@@ -16,7 +16,7 @@ RSpec.describe 'Download finding aid file' do
 
   context 'when an EAD without namespaces is requested' do
     it 'downloads an EAD without namespaces' do
-      get '/download/ARS-0043.xml?without_namespace=true'
+      get '/download/ars-0043_ambassador-auditorium-collection.xml?without_namespace=true'
 
       expect(response).to have_http_status(:ok)
       expect(Nokogiri::XML::Document.parse(response.body).at_css('ead').namespaces).to be_empty


### PR DESCRIPTION
This normalizer is basically copied from some of @corylown's existing work. 

Closes #436 

Creates IDs that look like (check URL bar) ~
<img width="1507" alt="Screenshot 2024-05-14 at 13 38 00" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/3575ae1a-0869-448a-9f2f-c7358b019ca3">

<img width="1510" alt="Screenshot 2024-05-14 at 13 38 07" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/b434e62c-32df-4708-96aa-833a65aee6aa">

