### PR TITLE
Update finding aid when a linked agent has changed

### DIFF
--- a/app/models/aspace/repository.rb
+++ b/app/models/aspace/repository.rb
@@ -38,6 +38,17 @@ module Aspace
       end
     end
 
+    def each_published_resource_with_updated_agents(updated_after:, uris_to_exclude: nil)
+      unless block_given?
+        return enum_for(:each_published_resource_with_updated_agents, updated_after:, uris_to_exclude:)
+      end
+
+      client.published_resource_with_linked_agent_uris(repository_id: id, updated_after:,
+                                                       uris_to_exclude:).each do |resource|
+        yield Aspace::Resource.new(**resource.symbolize_keys.merge({ repository_code: code }))
+      end
+    end
+
     private
 
     def client

--- a/app/services/aspace_search_query.rb
+++ b/app/services/aspace_search_query.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Paginated Aspace Search Query that accepts a search query string.
+class AspaceSearchQuery
+  include AspacePaginatedQuery
+
+  attr_reader :client, :repository_id, :query
+
+  def initialize(client:, repository_id:, query:)
+    @client = client
+    @repository_id = repository_id
+    @query = query
+  end
+end

--- a/app/services/concerns/aspace_paginated_query.rb
+++ b/app/services/concerns/aspace_paginated_query.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Module to handle paginated ASpace queries.
+module AspacePaginatedQuery
+  PAGE_SIZE = 250
+
+  def each(&block)
+    return enum_for(:each) unless block_given?
+
+    this_page = 0
+    last_page = nil
+    while last_page.nil? || this_page < last_page
+      this_page += 1
+      response = fetch_page(this_page)
+      last_page = response['last_page'].to_i
+
+      resources = response['results'].map { |result| result.slice(*keys_to_return) }
+      resources.each(&block)
+    end
+  end
+
+  def query_params
+    { q: query }
+  end
+
+  def keys_to_return
+    ['uri']
+  end
+
+  private
+
+  def fetch_page(page_number)
+    params = { page: page_number, page_size: PAGE_SIZE }.merge(query_params)
+    response = client.authenticated_post("repositories/#{repository_id}/search", params)
+    JSON.parse(response)
+  end
+end

--- a/spec/jobs/download_ead_job_spec.rb
+++ b/spec/jobs/download_ead_job_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe DownloadEadJob do
       ).and_return(
         [{ 'uri' => '/repositories/11/resources/3', 'ead_id' => 'ars789' }]
       )
+      allow(client).to receive(:published_resource_with_linked_agent_uris).with(
+        repository_id: '11', updated_after: '2023-12-12',
+        uris_to_exclude: ['/repositories/11/resources/1', '/repositories/11/resources/2']
+      ).and_return(
+        [{ 'uri' => '/repositories/11/resources/4', 'ead_id' => 'ars000' }]
+      )
       allow(client).to receive(:published_resource_uris).with(
         repository_id: '4', updated_after: '2023-12-12'
       ).and_return(
@@ -106,6 +112,12 @@ RSpec.describe DownloadEadJob do
       ).and_return(
         [{ 'uri' => '/repositories/4/resources/3', 'ead_id' => 'eal789' }]
       )
+      allow(client).to receive(:published_resource_with_linked_agent_uris).with(
+        repository_id: '4', updated_after: '2023-12-12',
+        uris_to_exclude: ['/repositories/4/resources/1', '/repositories/4/resources/2']
+      ).and_return(
+        [{ 'uri' => '/repositories/4/resources/4', 'ead_id' => 'eal000' }]
+      )
     end
 
     it 'fetches all resource uris from aspace limited to a specified date' do
@@ -116,8 +128,18 @@ RSpec.describe DownloadEadJob do
         updated_after: '2023-12-12',
         uris_to_exclude: ['/repositories/11/resources/1', '/repositories/11/resources/2']
       )
+      expect(client).to have_received(:published_resource_with_linked_agent_uris).with(
+        repository_id: '11',
+        updated_after: '2023-12-12',
+        uris_to_exclude: ['/repositories/11/resources/1', '/repositories/11/resources/2']
+      )
       expect(client).to have_received(:published_resource_uris).with(repository_id: '4', updated_after: '2023-12-12')
       expect(client).to have_received(:published_resource_with_updated_component_uris).with(
+        repository_id: '4',
+        updated_after: '2023-12-12',
+        uris_to_exclude: ['/repositories/4/resources/1', '/repositories/4/resources/2']
+      )
+      expect(client).to have_received(:published_resource_with_linked_agent_uris).with(
         repository_id: '4',
         updated_after: '2023-12-12',
         uris_to_exclude: ['/repositories/4/resources/1', '/repositories/4/resources/2']

--- a/spec/models/aspace/repository_spec.rb
+++ b/spec/models/aspace/repository_spec.rb
@@ -47,4 +47,19 @@ RSpec.describe Aspace::Repository do
                        .to_a.first).to be_a Aspace::Resource
     end
   end
+
+  describe '#each_published_resource_with_updated_agents' do
+    before do
+      allow(client).to(receive(:published_resource_with_linked_agent_uris))
+                   .with(repository_id: '11', updated_after: '2024-05-09', uris_to_exclude: nil)
+                   .and_return([{ ead_id: 'ARS123', uri: '/repositories/11/resources/12' }])
+    end
+
+    it 'returns instances of Aspace::Resource' do
+      expect(repository.each_published_resource_with_updated_agents(updated_after: '2024-05-09')
+                      .to_a.size).to eq 1
+      expect(repository.each_published_resource_with_updated_agents(updated_after: '2024-05-09')
+                      .to_a.first).to be_a Aspace::Resource
+    end
+  end
 end

--- a/spec/services/aspace_paginated_query_spec.rb
+++ b/spec/services/aspace_paginated_query_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AspacePaginatedQuery do
+  let(:aspace_client) { instance_double('AspaceClient') }
+  let(:mocked_query_class) do
+    Class.new do
+      include AspacePaginatedQuery
+
+      attr_reader :client, :repository_id, :query
+
+      def initialize(client:, repository_id:, query:)
+        @client = client
+        @repository_id = repository_id
+        @query = query
+      end
+    end
+  end
+  let(:mocked_query) { mocked_query_class.new(client: aspace_client, repository_id: '1', query: 'test') }
+
+  describe '#each' do
+    context 'when there is a single page of results' do
+      before do
+        allow(aspace_client).to receive(:authenticated_post).and_return(
+          { 'last_page' => 1, 'results' => [{ 'uri' => '/repositories/1/resources/1' }] }.to_json
+        )
+      end
+
+      it 'yields the only page' do
+        expect { |block| mocked_query.each(&block) }.to yield_with_args(
+          { 'uri' => '/repositories/1/resources/1' }
+        )
+      end
+    end
+
+    context 'when there are multiple pages of results' do
+      before do
+        allow(aspace_client).to receive(:authenticated_post).and_return(
+          { 'last_page' => 2, 'results' => [{ 'uri' => '/repositories/1/resources/1' }] }.to_json,
+          { 'last_page' => 2, 'results' => [{ 'uri' => '/repositories/1/resources/2' }] }.to_json
+        )
+      end
+
+      it 'yields each page' do
+        expect { |block| mocked_query.each(&block) }.to yield_successive_args(
+          { 'uri' => '/repositories/1/resources/1' },
+          { 'uri' => '/repositories/1/resources/2' }
+        )
+      end
+    end
+  end
+
+  describe '#query_params' do
+    it 'returns query params that can be safely merged with the pagination params' do
+      expect { {}.merge(mocked_query.query_params) }.not_to raise_error
+      expect(mocked_query.query_params).not_to have_key('page')
+    end
+  end
+
+  describe '#keys_to_return' do
+    it 'returns an array of keys to fetch from the query results' do
+      expect(mocked_query.keys_to_return).to be_an(Array).and all(be_a(String))
+      expect(mocked_query.keys_to_return).not_to be_empty
+    end
+  end
+end

--- a/spec/services/aspace_query_spec.rb
+++ b/spec/services/aspace_query_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AspaceQuery, type: :service do
+  let(:aspace_client) { instance_double('AspaceClient') }
+  let(:options) do
+    { published: true, suppressed: false, contains_fields: ['ead_id'], select_fields: %w[ead_id uri] }
+  end
+  let(:aspace_query) { described_class.new(client: aspace_client, repository_id: '1', options:) }
+
+  describe '#query_params' do
+    it 'returns query params using the aq parameter using valid JSON' do
+      expect(aspace_query.query_params).to eq({ aq: '{'\
+        '"query":{"jsonmodel_type":"boolean_query","op":"AND","subqueries":['\
+          '{"field":"publish","value":true,"jsonmodel_type":"field_query","negated":false,"literal":false},'\
+          '{"field":"primary_type","value":"resource","jsonmodel_type":"field_query","negated":false,"literal":false},'\
+          '{"field":"ead_id","value":"*","jsonmodel_type":"field_query","negated":false,"literal":false}'\
+        ']}'\
+      '}' })
+    end
+  end
+
+  describe '#keys_to_return' do
+    it 'uses the fields specified in the options as the keys to return' do
+      expect(aspace_query.keys_to_return).to match_array(%w[ead_id uri])
+    end
+  end
+end

--- a/spec/services/aspace_search_query_spec.rb
+++ b/spec/services/aspace_search_query_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AspaceSearchQuery, type: :service do
+  let(:aspace_client) { instance_double('AspaceClient') }
+  let(:aspace_search_query) { described_class.new(client: aspace_client, repository_id: '1', query: 'test') }
+
+  describe '#query_params' do
+    it 'returns query params using the q parameter' do
+      expect(aspace_search_query.query_params).to eq({ q: 'test' })
+    end
+  end
+
+  describe '#keys_to_return' do
+    it 'uses uri as the key to return' do
+      expect(aspace_search_query.keys_to_return).to eq(['uri'])
+    end
+  end
+end


### PR DESCRIPTION
Closes #557.

Changes `DownloadEadJob` so that it can detect when a resource (or a contained record) has a linked agent that has been updated. This allows us to update the finding aid in situations where ArchivesSpace does not report the resource itself as modified, similar to #556.

### Notable Changes
- The Aspace client page handling has been moved into `AspacePaginatedQuery`
- There is a new query type `AspaceSearchQuery` that uses the `q:search` syntax. The linked agent data was inaccessible to the `aq` query
- `check_component_dates` is now `check_record_dates` and will trigger both the sub-resource level (e.g., archival object) and the linked agent check

### Seeing it in action
- Find an agent that's linked to a published, unsuppressed resource (or one of its records) in a harvestable repository (e.g., ars).
- Use one of the bulk actions on the agent. Either "Publish All" in the web UI (even if it's already published) or use the `/agents/{agent_type}/:id/publish` endpoint on the API.

You can use the ASpace client to see specifically which resources have updated agents:
```ruby
aspace = AspaceClient.new
aspace.published_resource_with_linked_agent_uris(repository_id: 11, updated_after: (Time.zone.now - 1.days).strftime('%Y-%m-%d')).each.to_a
```
You can use the download job to see it fetch and index the updated resource(s):
```ruby
DownloadEadJob.enqueue_all_updated
``` 
