### PR TITLE
Cache the library hours

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -5,6 +5,11 @@ class LandingPageController < ApplicationController
   def index
     @hours = Settings.hours_locations.map { |hours_config| LibraryHours.from_config(hours_config) }
     @collection_count = site_collection_count
+    @next_half_hour = next_half_hour
+  end
+
+  def next_half_hour
+    Time.current.at_beginning_of_hour + (Time.current.min < 30 ? 30.minutes : 60.minutes)
   end
 
   def site_collection_count

--- a/app/views/landing_page/_cards.html.erb
+++ b/app/views/landing_page/_cards.html.erb
@@ -4,11 +4,13 @@
       <%= image_tag 'locations.png', alt: '', class: 'card-img-top' %>
       <div class="card-body px-1">
         <h3 class="card-title"><%= t('.location.title') %></h3>
-        <ul>
-          <% @hours.each do |location_hours| %>
-            <li><%= render 'landing_page/location_hours', location_hours: %></li>
-          <% end %>
-        </ul>
+        <% cache('location_hours', expires_at: @next_half_hour) do %>
+          <ul>
+            <% @hours.each do |location_hours| %>
+              <li><%= render 'landing_page/location_hours', location_hours: %></li>
+            <% end %>
+          </ul>
+        <% end %>
       </div>
     </div>
   </div>

--- a/spec/controllers/landing_page_controller_spec.rb
+++ b/spec/controllers/landing_page_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LandingPageController, type: :controller do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '#next_half_hour' do
+    it 'returns the half-hour if the current time is before the half-hour' do
+      travel_to Time.zone.local(2024, 5, 14, 9, 20) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30))
+      end
+    end
+
+    it 'returns the next hour if the current time is after the half-hour' do
+      travel_to Time.zone.local(2024, 5, 14, 9, 40) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
+      end
+    end
+
+    it 'correctly handles noon' do
+      travel_to Time.zone.local(2024, 5, 14, 11, 59) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 12, 0))
+      end
+    end
+
+    it 'correctly handles midnight' do
+      travel_to Time.zone.local(2024, 5, 14, 23, 59) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 15, 0, 0))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #620.

Caches the library hours fragment on the landing page cards partial. It needed to be a fragment cache as the hours API object isn't serializable. Expires the cache at the next half hour because the libraries tend to open/close at the half hour.

Unsurprisingly this is much faster, 2.1ms versus ~750ms to fetch fresh:
```shell
17:15:07 web.1  | Read fragment views/landing_page/_cards:2de8cc75cc02aa10e3b2c517d27da179/location_hours (0.1ms)
17:15:07 web.1  |   Rendered landing_page/_cards.html.erb (Duration: 2.1ms | Allocations: 1917) [cache hit]
```

Remember to `touch tmp/caching-dev.txt` and restart if testing locally.