### PR TITLE
Set sidekiq concurrency to 3

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,1 @@
+:concurrency: 3


### PR DESCRIPTION
Dialing back concurrency so maybe we can generate PDFs without bringing the VMs to a halt.