### PR TITLE
Update PDF config to better handle OAC EADs

### DIFF
--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -62,6 +62,8 @@ class GeneratePdfJob < ApplicationJob
 
     # OAC strips the default EAD namespace and our XSLT expects it
     doc.root.add_namespace_definition(nil, 'urn:isbn:1-931666-22-9') unless doc.root.namespace
+    # Some EADs from OAC use a ns2 namespace but the declaration has been stripped, which causes Saxon to fail.
+    doc.root.add_namespace_definition('ns2', 'http://example.com/ns2') unless doc.namespaces.include?('xmlns:ns2')
     doc.to_xml
   end
 


### PR DESCRIPTION
Fixes #633 with the exception of the invalid metadata files that have been documented.

- Defines a placeholder namespace 'ns2' during PDF generation. Some OAC elements use this but as we know, OAC strips namespace definitions.
- Adds handling for nested `controlaccess` elements
- Adds handling for nested `indexentry` elements
- Prevents some identifier duplications

These changes should be OAC specific. ArchivesSpace doesn't seem to generate EAD XML that uses these (valid) features. This has been tested on a subset (~200) of previously working files with no new failures.

It should not be necessary to regenerate PDFs for ASpace EADs. Existing PDFs from OAC EADs could benefit slightly from being regenerated if they use `indexentry` elements with multiple sub-elements. The display for those has been ever so slightly improved (tiny bit of padding).