### PR TITLE
Handle empty string arguments in NormalizedId

### DIFF
--- a/lib/traject/sul/normalized_id.rb
+++ b/lib/traject/sul/normalized_id.rb
@@ -26,9 +26,9 @@ module Sul
       # E.g. don't return Université de Toulouse_universite-de-toulouse
       # Instead, return only universite-de-toulouse.
       # Otherwise return something like ars0009_belva-kibler-and-donald-morgan
-      normalized_id = [id, title].map do |string|
+      normalized_id = [id, title].compact.reject(&:empty?).map do |string|
         string&.truncate_words(5, omission: '')&.parameterize
-      end.compact.uniq.join('_')
+      end.uniq.join('_')
 
       raise Arclight::Exceptions::IDNotFound if normalized_id.blank?
 

--- a/spec/lib/traject/sul/normalized_id_spec.rb
+++ b/spec/lib/traject/sul/normalized_id_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'traject/sul/normalized_id'
+
+RSpec.describe Sul::NormalizedId do
+  subject(:normalized_id) { described_class.new(ead_id, title:).to_s }
+
+  let(:ead_id) { 'abc1234' }
+  let(:title) { 'A Collection of Papers' }
+
+  it 'returns a normalized id' do
+    expect(normalized_id).to eq 'abc1234_a-collection-of-papers'
+  end
+
+  context 'when the eadid is empty' do
+    let(:ead_id) { '' }
+
+    it 'returns a normalized id' do
+      expect(normalized_id).to eq 'a-collection-of-papers'
+    end
+  end
+
+  context 'when the eadid is nil' do
+    let(:ead_id) { nil }
+
+    it 'returns a normalized id' do
+      expect(normalized_id).to eq 'a-collection-of-papers'
+    end
+  end
+end


### PR DESCRIPTION
In cases where we're missing an eadid we're getting ids like `_native-american-alumni-oral-histories` instead of `native-american-alumni-oral-histories`.