### PR TITLE
Fix accessibility issues

### DIFF
--- a/app/assets/stylesheets/cards.scss
+++ b/app/assets/stylesheets/cards.scss
@@ -44,7 +44,14 @@
     color: $link-dark-color;
   }
 
-  h3 {
+  h2 {
+    font-size: calc(1.3rem + 0.6vw);
+    @include media-breakpoint-up(xxl) {
+      font-size: 1.75rem;
+    }
+  }
+
+  h2, h3 {
     font-weight: bold;
   }
 }

--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -5,6 +5,7 @@
     color: $link-dark-color;
   }
 
+  #main-container h1,
   h2 {
     font-size: 2.25rem;
     font-family: $font-family-serif;
@@ -35,7 +36,6 @@ $featured-teaser-overhang: 1rem;
   }
 
   .featured-item-caption {
-    font-style: italic;
     text-align: left;
     background: rgba(0, 0, 0, 0.8);
   }

--- a/app/components/arclight/header_component.html.erb
+++ b/app/components/arclight/header_component.html.erb
@@ -1,4 +1,5 @@
 <header>
+  <%= render 'shared/stanford_stripe' %>
   <%= top_bar %>
   <%= masthead %>
   <% unless helpers.landing_page? %>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-sm-12 col-xxl-6 col-xl-7 col-lg-8 lg-pt-5 pe-5">
         <div class="d-flex">
-          <h2 class="pe-3 mb-0"><%= t '.title' %></h1>
+          <h1 class="pe-3 mb-0"><%= t '.title' %></h1>
         </div>
         <div class="d-flex">
           <p class="collection-count mt-2"><%= t('.collection_count', collection_count: number_with_delimiter(@collection_count)) %></p>

--- a/app/views/repositories/_browse_repositories.html.erb
+++ b/app/views/repositories/_browse_repositories.html.erb
@@ -3,9 +3,9 @@
     <div class="card h-100">
       <%= image_tag repository.thumbnail_url, alt: repository.name, class: 'card-img-top' %>
       <div class="card-body d-flex flex-column px-1">
-        <h3 class="card-title">
+        <h2 class="card-title">
           <%= repository.name %>
-        </h3>
+        </h2>
         <p class="card-text"><%= repository.description %></p>
         <% collection_text = repository.collection_count == 1 ? "collection" : "collections" %>
         <%= link_to("Browse #{repository.collection_count} #{collection_text}", repository_collections_path(repository), class: "btn btn-dark mt-auto mx-auto") %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,2 +1,0 @@
-<%= render 'shared/stanford_stripe' %>
-<%= render blacklight_config.header_component.new(blacklight_config: blacklight_config) %>

--- a/app/views/shared/_stanford_stripe.erb
+++ b/app/views/shared/_stanford_stripe.erb
@@ -1,5 +1,3 @@
-<section id="su-brand-bar" class="su-brand-bar">
-  <div class="container">
-      <a class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a>
-  </div>
-</section>
+<div class="container">
+    <a class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a>
+</div>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Home Page', type: :feature do
   end
 
   it 'has the title and subtitle' do
-    expect(page).to have_css('.blacklight-landing_page h2', text: 'Find archival materials')
+    expect(page).to have_css('.blacklight-landing_page h1', text: 'Find archival materials')
     expect(page).to have_css('.blacklight-landing_page .collection-count', text: 'Detailed inventories of')
   end
 


### PR DESCRIPTION
Addresses the following issues from #651:

- Global 1: Stanford Stripe header
- Homepage 1: level 1 heading
- Homepage 2: italicized text
- Browse all repositories: skipped h2

Other issues will be/have been addressed upstream or in separate PRs.