### PR TITLE
Hide collection contents in sidebar when empty

### DIFF
--- a/app/components/arclight/sidebar_component.html.erb
+++ b/app/components/arclight/sidebar_component.html.erb
@@ -3,9 +3,11 @@
   <div id="sidebar-scroll-wrapper">
     <%= render 'show_tools', document: document %>
     <%= collection_sidebar %>
+    <% if document.collection_components? %>
     <div id="collection-context" class="sidebar-section">
       <h2><%= t('arclight.views.show.has_content') %></h2>
       <%= turbo_frame_tag "al-hierarchy-#{document.root}", loading: 'lazy', src: hierarchy_solr_document_path(id: document.root, nest_path: @document.nest_path, hierarchy: true) %>
     </div>
+    <% end %>
   </div>
 </div>

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,6 +29,10 @@ class SolrDocument
     level&.parameterize == 'collection' && component_level.zero?
   end
 
+  def collection_components?
+    collection.total_component_count.to_i.positive?
+  end
+
   def ead_file_without_namespace_href
     params = { without_namespace: true }
 

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe 'Collection Page', type: :feature do
       end
     end
 
+    it 'displays the collection contents in the sidebar' do
+      expect(page).to have_css('#collection-context')
+    end
+
     it 'displays the Using these materials links' do
       within('#using-these-materials') do
         expect(page).to have_link('Info for visitors', href: Arclight::Repository.find_by(slug: 'ars').url)
@@ -62,6 +66,16 @@ RSpec.describe 'Collection Page', type: :feature do
 
     it 'displays the normalized collection id in the URL' do
       expect(page.current_url).to eq('http://www.example.com/catalog/universite-de-toulouse')
+    end
+  end
+
+  context 'when visiting a collection page with no collection contents' do
+    before do
+      visit solr_document_path('Cubb1967.xml')
+    end
+
+    it 'does not display the collection contents in the sidebar' do
+      expect(page).not_to have_css('#collection-context')
     end
   end
 end

--- a/spec/fixtures/ead/cubberley/cubb1967.xml
+++ b/spec/fixtures/ead/cubberley/cubb1967.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" findaidstatus="completed" langencoding="iso639-2b" repositoryencoding="iso15511">
+    <eadid>Cubb1967.xml</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>Guide to Aarhus Universitet Catalogs, etc. <num>Cubb.1967</num></titleproper>
+        <author>Kathy Kerns</author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>Cubberley Education Library</publisher>
+        <p>
+          <date>9/11/2023</date>
+        </p>
+        <address>
+          <addressline>485 Lasuen Mall</addressline>
+          <addressline>Stanford, CA 94305-3097</addressline>
+          <addressline>Business Number: 650.723.2121</addressline>
+          <addressline>Fax Number: 650.736.0536</addressline>
+          <addressline>cubberley@stanford.edu</addressline>
+          <addressline>URL: <extptr xlink:href="http://url.unspecified" xlink:show="new" xlink:title="http://url.unspecified" xlink:type="simple"/></addressline>
+        </address>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace on <date>2024-05-17 06:23:39 -0700</date>.</creation>
+      <langusage>English</langusage>
+      <descrules>Describing Archives: A Content Standard</descrules>
+    </profiledesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>Cubberley Education Library</corpname>
+      </repository>
+      <unittitle>Aarhus Universitet</unittitle>
+      <unitid>Cubb.1967</unitid>
+      <physdesc altrender="whole">
+        <extent altrender="materialtype spaceoccupied">19 item(s)</extent>
+        <extent altrender="carrier">Forelaesninger og øvelser for 1963-Spring 1972</extent>
+      </physdesc>
+      <unitdate calendar="gregorian" datechar="creation" era="ce" normal="1963/1972" type="inclusive">1963-1972</unitdate>
+      <abstract id="aspace_33a4ba687554ce0502e445db3d709b51">Located in Aarhus, Denmark. Founded in 1928.</abstract>
+      <langmaterial><language langcode="eng">English</language>
+.    </langmaterial>
+      <container id="aspace_1e30288c3f4810d65a72f6b0f4111b20" label="Mixed Materials [36105120452797]" type="Box">2411</container>
+    </did>
+    <controlaccess>
+      <geogname source="ingest">Denmark</geogname>
+    </controlaccess>
+    <dsc/>
+  </archdesc>
+</ead>


### PR DESCRIPTION
Part of #651.

Previous behavior was to display an empty list. Lists have an implicit aria role of "list". Containers with that role should not be empty.

Before:
![Screenshot 2024-05-21 at 9 02 04 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/da695c78-257b-42c8-8ba0-6ef4c815d090)

After:
![Screenshot 2024-05-21 at 9 02 21 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/99a8251e-51d0-423a-abdb-2acf82df9800)
