### PR TITLE
Improve PDF validation in PDF generation job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,8 @@ gem 'honeybadger', '~> 5.2'
 
 gem 'okcomputer', '~> 1.18'
 
+gem 'pdf-reader', '~> 2.12'
+
 gem 'cssbundling-rails', '~> 1.1'
 
 gem 'sidekiq', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.1)
     actioncable (7.1.3.3)
       actionpack (= 7.1.3.3)
       activesupport (= 7.1.3.3)
@@ -77,6 +78,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    afm (0.2.2)
     airbrussh (1.5.2)
       sshkit (>= 1.6.1, != 1.7.0)
     arclight (1.1.4)
@@ -197,6 +199,7 @@ GEM
       actionview (>= 5.1, < 7.2)
       railties (>= 5.1, < 7.2)
     hashdiff (1.1.0)
+    hashery (2.1.2)
     hashie (5.0.0)
     honeybadger (5.10.0)
     http (5.2.0)
@@ -300,6 +303,12 @@ GEM
     parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
+    pdf-reader (2.12.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.5.6)
     psych (5.1.2)
       stringio
@@ -415,6 +424,7 @@ GEM
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     rubyzip (2.3.2)
     scrub_rb (1.0.1)
     selenium-webdriver (4.21.1)
@@ -474,6 +484,8 @@ GEM
       deprecation
       jsonpath
       traject (~> 3.0)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     turbo-rails (2.0.5)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -542,6 +554,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   okcomputer (~> 1.18)
+  pdf-reader (~> 2.12)
   pg (~> 1.5)
   puma (~> 6.0)
   rails (~> 7.1.2)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,6 +26,10 @@ every :day do
   runner 'DownloadEadJob.enqueue_all_updated'
 end
 
+every :day, at: '3:00 am' do
+  runner 'GeneratePdfJob.enqueue_all_missing_and_invalid'
+end
+
 every 6.hours do
   runner 'DeleteEadJob.enqueue_all'
 end


### PR DESCRIPTION
Currently we only check for the existence of the PDF file as a success condition during PDF generation. Apache FOP is good at cleaning up after itself if the generation process fails, but if the job is terminated for any reason, a malformed file will remain.

Changes:
- Adds the pdf-reader gem, used to check that the generated PDF is valid
- Adds a `enqueue_all_missing_and_invalid` method to GeneratePdfJob, which is scheduled.
- For the purposes of `skip_existing`, an invalid PDF file does not count as 'existing'

Tested on demo by faking a malformed PDF and running `GeneratePdfJob.enqueue_all_missing_and_invalid`.