### PR TITLE
Add the public beta banner

### DIFF
--- a/app/assets/stylesheets/palette.scss
+++ b/app/assets/stylesheets/palette.scss
@@ -17,6 +17,7 @@ $stanford-digital-red: #b1040e;
 // https://identity.stanford.edu/design-elements/color/accent-colors/
 $stanford-fog: #dad7cb;
 $stanford-fog-light: #f4f4f4;
+$stanford-illuminating: #FEDD5C;
 $stanford-illuminating-dark: #FEC51D;
 $stanford-palo-alto-light: #2D716F;
 $stanford-palo-alto-dark: #014240;

--- a/app/assets/stylesheets/stanfordStripe.scss
+++ b/app/assets/stylesheets/stanfordStripe.scss
@@ -12,7 +12,6 @@
   font-variant-ligatures: discretionary-ligatures;
   font-feature-settings: "liga";
   margin-top: 0.125rem;
-  padding-left: 0.25rem;
   white-space: nowrap;
 
   &:hover,

--- a/app/assets/stylesheets/sulBase.scss
+++ b/app/assets/stylesheets/sulBase.scss
@@ -28,14 +28,6 @@ a {
   color: $stanford-digital-red;
 }
 
-.beta-tag {
-  background-color: $stanford-illuminating-dark;
-  color: $stanford-black;
-  font-family: $font-family-serif;
-  font-size: 0.875rem;
-  padding: 0.15rem 0.75rem 0.15rem 0.75rem;
-}
-
 .grecaptcha-badge {
   visibility: hidden;
 }

--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -9,6 +9,11 @@
   background-size: 258px 41px;
 }
 
+header .topbar > .container,
+header .topbar > .container-fluid {
+  padding-left: 0;
+}
+
 #feedback {
   overflow: hidden;
   transition: all .5s ease-in-out;
@@ -41,7 +46,7 @@
     display: inline;
     font-size: 1.5rem;
     font-weight: 600;
-    padding: 1.5rem 1.5rem 1.5rem 0;
+    padding-left: 0;
 
     @include media-breakpoint-up(lg) {
       font-size: 2rem;
@@ -104,7 +109,7 @@
   }
 }
 
-.al-masthead + .navbar-search {
+.al-masthead ~ .navbar-search {
   border-top: none;
   background-color: $navbar-background-color;
   margin-bottom: 0;
@@ -151,4 +156,8 @@
   #search_field {
     margin-right: .825rem;
   }
+}
+
+.beta-banner {
+  background-color: $stanford-illuminating;
 }

--- a/app/components/arclight/header_component.html.erb
+++ b/app/components/arclight/header_component.html.erb
@@ -2,6 +2,7 @@
   <%= render 'shared/stanford_stripe' %>
   <%= top_bar %>
   <%= masthead %>
+  <%= render 'shared/beta_banner' %>
   <% unless helpers.landing_page? %>
     <%= search_bar %>
   <% end %>

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -3,7 +3,6 @@
     <div class="row align-items-center">
         <div class="col-md-8 d-flex justify-content-center justify-content-md-start align-items-center">
           <span class="h1"><%= heading %></span>
-          <%= render 'shared/beta_tag' %>
         </div>
         <% unless helpers.landing_page? %>
           <nav class="col-md-4 nav-links d-flex justify-content-end" aria-label="browse">

--- a/app/views/shared/_beta_banner.html.erb
+++ b/app/views/shared/_beta_banner.html.erb
@@ -1,0 +1,7 @@
+<% if Settings.beta_banner.enabled %>
+<div class="beta-banner">
+  <div class="container">
+    <p class="m-0 py-3"><%= t '.beta_message_html' %></p>
+  </div>
+</div>
+<% end %>

--- a/app/views/shared/_beta_tag.html.erb
+++ b/app/views/shared/_beta_tag.html.erb
@@ -1,1 +1,0 @@
-<span class="beta-tag rounded-1">beta</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,8 @@ en:
       how_to_request: "How to request"
       access_and_use: "Access and use"
   shared:
+    beta_banner:
+      beta_message_html: Please note this is a public beta version of this application. Visit the <a href="https://oac.cdlib.org/">Online Archive of California</a> for the most up to date information and to make a request.
     content_warning:
       warning_html: Some materials and description may contain offensive content. <a href="https://library.stanford.edu/libraries/special-collections" class="fa fa-exclamation-circle">More info</a>
   landing_page:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+beta_banner:
+  enabled: true
+
 hours_api: 'https://library-hours.stanford.edu/'
 
 # Locations with a 'closed_note' will display the note in lieu of fetching hours from the API.

--- a/spec/features/beta_banner_spec.rb
+++ b/spec/features/beta_banner_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Beta banner', type: :feature do
+  context 'when the beta banner is enabled' do
+    before do
+      allow(Settings.beta_banner).to receive(:enabled).and_return(true)
+    end
+
+    it 'displays on the landing page' do
+      visit root_path
+      expect(page).to have_css('.beta-banner')
+    end
+
+    it 'appears on the catalog page' do
+      visit search_catalog_path
+      expect(page).to have_css('.beta-banner')
+    end
+
+    it 'appears on the repositories page' do
+      visit arclight_engine.repositories_path
+      expect(page).to have_css('.beta-banner')
+    end
+  end
+
+  context 'when the beta banner is disabled' do
+    before do
+      allow(Settings.beta_banner).to receive(:enabled).and_return(false)
+      visit root_path
+    end
+
+    it 'does not show the beta banner' do
+      expect(page).not_to have_css('.beta-banner')
+    end
+  end
+end


### PR DESCRIPTION
Closes #657.

Removes the beta tag as requested. Main pages checked with Siteimprove, no new issues were introduced.