### PR TITLE
Update facet modal style to use new design

### DIFF
--- a/app/assets/stylesheets/sulBase.scss
+++ b/app/assets/stylesheets/sulBase.scss
@@ -2,15 +2,20 @@ body {
   --bs-heading-color: $primary;
 }
 
-a {
+@mixin sulLinkStyle {
   text-decoration: none;
   color: $link-dark-color;
   font-weight: 450;
 
   &:hover,
   &:focus-visible {
+    color: $link-dark-color;
     text-decoration: underline;
   }
+}
+
+a {
+  @include sulLinkStyle;
 }
 
 .form-control:focus {
@@ -38,4 +43,10 @@ a {
 
 .grecaptcha-badge {
   visibility: hidden;
+}
+
+.modal-header {
+  .btn-close:focus {
+    box-shadow: none;
+  }
 }

--- a/app/assets/stylesheets/sulFacets.scss
+++ b/app/assets/stylesheets/sulFacets.scss
@@ -44,3 +44,7 @@
 .applied-filter .filter-name:after {
   color: black;
 }
+
+.facet-pagination a.btn-link {
+  @include sulLinkStyle;
+}


### PR DESCRIPTION
The facet modals (any facet with a 'more >>' link) still have some old styling elements.

Old:

![Screenshot 2024-05-22 at 10 56 44 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/705767f8-d892-4c94-94ba-aa08957cff26)

New:
![Screenshot 2024-05-22 at 10 56 54 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/2237595f-1510-482b-95c5-3c4dcf2ba360)
