### PR TITLE
Use valid style for Digital Content text

### DIFF
--- a/app/assets/stylesheets/sulCollection.scss
+++ b/app/assets/stylesheets/sulCollection.scss
@@ -288,7 +288,7 @@ article.document .al-online-content-icon .blacklight-icons svg {
 .title-container .online-contents h2 {
   text-transform: none;
   margin-bottom: 0;
-  align-content: center;
+  align-self: center;
   margin-left: 1rem;
 }
 


### PR DESCRIPTION
Fixes #669 

Firefox/Chrome handled this differently -- the style was invalid since the element is not a flex container itself. But Chrome somehow knew to render it correctly. 

Firefox now:
<img width="979" alt="Screenshot 2024-05-23 at 11 08 21" src="https://github.com/sul-dlss/stanford-arclight/assets/1328900/443a7aac-bf5b-4c9a-a501-cd7a1fb02a32">
