### PR TITLE
Remove EAD download links for missing files

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -4,11 +4,10 @@
 class DownloadController < ApplicationController
   def show
     doc = SolrDocument.find(params[:id])
-    ead_file = File.join(Settings.data_dir, doc.repository_config.slug, doc.ead_filename)
 
     respond_to do |format|
-      format.xml { handle_download { send_ead(ead_file) } }
-      format.pdf { handle_download { send_pdf(ead_file) } }
+      format.xml { handle_download { send_ead(DocumentLocalFileMapper.new(document: doc, format: :xml).path) } }
+      format.pdf { handle_download { send_file(DocumentLocalFileMapper.new(document: doc, format: :pdf).path) } }
     end
   end
 
@@ -33,10 +32,5 @@ class DownloadController < ApplicationController
     doc = Nokogiri::XML(File.read(ead_file))
     xslt  = Nokogiri::XSLT(File.read(Rails.root.join('app/xslt/ead_remove_namespace.xsl').to_s))
     xslt.transform(doc).to_xml(indent: 2)
-  end
-
-  def send_pdf(ead_file)
-    pdf_file = ead_file.sub(/(xml)?$/i, 'pdf')
-    send_file pdf_file
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -39,6 +39,14 @@ class SolrDocument
     "#{ead_file.href}?#{params.to_query}"
   end
 
+  def local_ead_file_size
+    DocumentLocalFileMapper.new(document: self).size
+  end
+
+  def local_pdf_file_size
+    DocumentLocalFileMapper.new(document: self, format: :pdf).size
+  end
+
   # self.unique_key = 'id'
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document

--- a/app/overrides/document_downloads_override.rb
+++ b/app/overrides/document_downloads_override.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Monkey patch DocumentDownloads to limit files to those that exist and have content
+  class DocumentDownloads
+    # rubocop:disable Metrics/AbcSize
+    def files
+      data = self.class.config[id] || self.class.config['default']
+      disabled = data.delete('disabled')
+      return [] if disabled
+
+      files ||= data.map do |file_type, file_data|
+        self.class.file_class.new(type: file_type, data: file_data, document:)
+      end.compact
+
+      files.select! do |file|
+        file.size&.positive?
+      end
+      @files = files
+    end
+    # rubocop:enable Metrics/AbcSize
+  end
+end

--- a/app/services/document_local_file_mapper.rb
+++ b/app/services/document_local_file_mapper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Class to handle logic for mapping a document's downloadable EAD files to a local file system.
+class DocumentLocalFileMapper
+  class UnsupportedFormatError < StandardError; end
+
+  attr_reader :document, :format
+
+  # @param document [SolrDocument] The EAD document
+  # @param format [Symbol] The file format (:ead, :xml, :pdf)
+  def initialize(document:, format: :ead)
+    @document = document
+    @format = format
+  end
+
+  def path
+    case format
+    when :ead, :xml
+      ead_file_path
+    when :pdf
+      ead_file_path&.sub(/(xml)?$/i, 'pdf')
+    else
+      raise UnsupportedFormatError, "Unsupported format: #{format}"
+    end
+  end
+
+  def size
+    return nil unless path
+
+    return nil unless File.exist?(path)
+
+    File.size(path)
+  end
+
+  private
+
+  def ead_file_path
+    return nil unless path_components?
+
+    File.join(Settings.data_dir, document.repository_config.slug, document.ead_filename)
+  end
+
+  def path_components?
+    document.repository_config.slug.present? && document.ead_filename.present?
+  end
+end

--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -12,5 +12,7 @@
 default:
   ead:
     template: '/download/%{id}.xml'
+    size_accessor: 'local_ead_file_size'
   pdf:
     template: '/download/%{id}.pdf'
+    size_accessor: 'local_pdf_file_size'

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe SolrDocument do
     end
 
     it 'returns the href for the EAD file without a namespace' do
+      mapper = instance_double(DocumentLocalFileMapper)
+      allow(DocumentLocalFileMapper).to receive(:new).with(document:).and_return(mapper)
+      allow(mapper).to receive(:path).and_return('/data/ars0001.xml')
+      allow(mapper).to receive(:size).and_return(1000)
+      allow(DocumentLocalFileMapper).to receive(:new).with(document:, format: :pdf).and_return(mapper)
+      allow(mapper).to receive(:path).and_return(nil)
       expect(document.ead_file_without_namespace_href).to eq '/download/ars0001.xml?without_namespace=true'
     end
   end

--- a/spec/services/document_local_file_mapper_spec.rb
+++ b/spec/services/document_local_file_mapper_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DocumentLocalFileMapper do
+  let(:document) do
+    SolrDocument.new(
+      id: 'ars0001',
+      level_ssm: ['collection'],
+      ead_filename_ssi: 'ars0001.xml'
+    )
+  end
+  let(:data_dir) { '/data' }
+
+  before do
+    allow(Settings).to receive(:data_dir).and_return(data_dir)
+    allow(document).to receive(:repository_config).and_return(
+      Arclight::Repository.new(slug: 'ars')
+    )
+  end
+
+  describe '#path' do
+    context 'when ead_filename is populated' do
+      context 'when the format is not specified' do
+        let(:mapper) { described_class.new(document:) }
+
+        it 'returns the path to the EAD XML file' do
+          expect(mapper.path).to eq('/data/ars/ars0001.xml')
+        end
+      end
+
+      context 'when the format is :ead' do
+        let(:mapper) { described_class.new(document:, format: :ead) }
+
+        it 'returns the path to the EAD XML file' do
+          expect(mapper.path).to eq('/data/ars/ars0001.xml')
+        end
+      end
+
+      context 'when the format is :xml' do
+        let(:mapper) { described_class.new(document:, format: :xml) }
+
+        it 'returns the path to the EAD XML file' do
+          expect(mapper.path).to eq('/data/ars/ars0001.xml')
+        end
+      end
+
+      context 'when the format is :pdf' do
+        let(:mapper) { described_class.new(document:, format: :pdf) }
+
+        it 'returns the path to the EAD PDF file' do
+          expect(mapper.path).to eq('/data/ars/ars0001.pdf')
+        end
+      end
+    end
+
+    context 'when ead_filename is empty' do
+      let(:document) do
+        SolrDocument.new(
+          id: 'ars0001',
+          level_ssm: ['collection'],
+          ead_filename_ssi: ''
+        )
+      end
+
+      context 'when the format is :xml' do
+        let(:mapper) { described_class.new(document:, format: :xml) }
+
+        it 'returns nil' do
+          expect(mapper.path).to eq(nil)
+        end
+      end
+
+      context 'when the format is :pdf' do
+        let(:mapper) { described_class.new(document:, format: :pdf) }
+
+        it 'returns nil' do
+          expect(mapper.path).to eq(nil)
+        end
+      end
+    end
+
+    context 'when the format is not supported' do
+      let(:mapper) { described_class.new(document:, format: :zip) }
+
+      it 'raises an error' do
+        expect { mapper.path }.to raise_error(described_class::UnsupportedFormatError, 'Unsupported format: zip')
+      end
+    end
+  end
+
+  describe '#size' do
+    let(:mapper) { described_class.new(document:, format: :xml) }
+
+    context 'when the file path is present and the file exists' do
+      it 'returns the size of the file' do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:size).and_return(1000)
+        expect(mapper.size).to eq(1000)
+      end
+    end
+
+    context 'when the file path is present but the file does not exist' do
+      it 'returns nil' do
+        allow(File).to receive(:exist?).and_return(false)
+        expect(mapper.size).to eq(nil)
+      end
+    end
+
+    context 'when the file path is missing' do
+      it 'returns nil' do
+        allow(mapper).to receive(:path).and_return(nil)
+        expect(mapper.size).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of #660.

Displays download links only for files that exist and have a non-zero size.

- Push logic of where EAD XML/PDFs live on the local file system out of DownloadController to a service
- Implement ArcLight download size accessors that use the service
- Patch ArcLight DocumentDownloads to filter based on size

If we wanted to go this direction, there's an argument to be made for refactoring `GeneratePdfJob` to also use the service.