### PR TITLE
Fix header navbar padding

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -11,7 +11,7 @@
 
 header .topbar > .container,
 header .topbar > .container-fluid {
-  padding-left: 0;
+  padding: 0;
 }
 
 #feedback {


### PR DESCRIPTION
I snuck the left padding fix in the other day but missed the right padding. Looking at the designs, I think these are supposed to line up on the right side.

Old:
![Screenshot 2024-05-24 at 11 48 35 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/a389f5a8-d47e-44ed-a83a-c2dfda496c69)

New: 
![Screenshot 2024-05-24 at 11 50 18 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/4bdb3e8c-a31b-407a-a5a3-d3e683b40367)
