### PR TITLE
Hide feedback form during page loads

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -15,6 +15,8 @@ header .topbar > .container-fluid {
 }
 
 #feedback {
+  // The feedback form is hidden, using inline style, to prevent it from being shown during slow page loads.
+  display: block !important;
   overflow: hidden;
   transition: all .5s ease-in-out;
   max-height: 0;

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -14,7 +14,7 @@
     </nav>
   </div>
   
-  <div data-feedback-target="container" id="feedback">
+  <div data-feedback-target="container" id="feedback" style="display:none;">
     <div class="container mt-3">
       <div class="row justify-content-center">
         <%= form_with url: feedback_path, method: :post, class: 'col-md-8' do |f| %>

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Feedback Form', :js, type: :feature do
+  it 'is visible after clicking the feedback link' do
+    visit root_path
+    click_link 'Feedback'
+    within '#feedback' do
+      expect(page).to have_css('form')
+    end
+  end
+end


### PR DESCRIPTION
Closes #684.

This is maybe a bit silly but throwing this in a turbo frame seemed excessive? Open to it...

It does need to be an inline style. At the point in which the page looks like the screenshot in the issue, neither our CSS nor Bootstrap's CSS is available yet.