### PR TITLE
Adjust library hours cache timing

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -16,7 +16,12 @@ class LandingPageController < ApplicationController
   end
 
   def next_half_hour
-    Time.current.at_beginning_of_hour + (Time.current.min < 30 ? 30.minutes : 60.minutes)
+    now = Time.current
+    next30 = now.at_beginning_of_hour + (now.min < 30 ? 30.minutes : 60.minutes)
+
+    return next30 + 5.seconds if next30 - now < 5.seconds
+
+    next30
   end
 
   def site_collection_count

--- a/spec/controllers/landing_page_controller_spec.rb
+++ b/spec/controllers/landing_page_controller_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe LandingPageController, type: :controller do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '#next_half_hour' do
+    it 'pads the next half-hour time with 5 seconds when the current time is less than 5 seconds away' do
+      travel_to Time.zone.local(2024, 5, 14, 9, 29, 56) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30, 5))
+      end
+    end
+
+    it 'returns the next half-hour when the current time is exactly the half-hour' do
+      travel_to Time.zone.local(2024, 5, 14, 9, 30) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
+      end
+
+      travel_to Time.zone.local(2024, 5, 14, 10, 0) do
+        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 30))
+      end
+    end
+
     it 'returns the half-hour if the current time is before the half-hour' do
       travel_to Time.zone.local(2024, 5, 14, 9, 20) do
         expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30))


### PR DESCRIPTION
Might close #685?

I'm not sure if it is *the* bug but I do believe this fixes *a* bug.

Currently it is possible to try to set a cache time that's too close to the current time. In my dev environment, setting the cache time to `Time.current + 0.4.seconds` using the Redis cache reliably creates a cache key with no expiry time. I suspect the point at which this occurs will vary depending on performance.

Here I pad the time with 5 seconds if it's close, to give the cache system a minimum time difference.
