### PR TITLE
Fix Stanford University link in header

### DIFF
--- a/app/views/shared/_stanford_stripe.erb
+++ b/app/views/shared/_stanford_stripe.erb
@@ -1,3 +1,3 @@
 <div class="container">
-    <a class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a>
+    <a class="su-brand-bar__logo" href="https://www.stanford.edu">Stanford University</a>
 </div>


### PR DESCRIPTION
So that siteimprove will stop complaining that `www.stanford.edu` and [stanford.edu](url) are different.