### PR TITLE
Set correct link title for library logo link

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <nav class="navbar navbar-expand-md navbar-dark topbar" role="navigation">
       <div class="<%= container_classes %>">
-        <%= logo_link %>
+        <%= logo_link(title: 'Stanford Libraries') %>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>


### PR DESCRIPTION
By default it gets set to the application title, which is wrong in this case.