### PR TITLE
Increase max heap size during PDF generation

### DIFF
--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -11,6 +11,9 @@ class GeneratePdfJob < ApplicationJob
   # succeed in a subsequent retry.
   sidekiq_options retry: 1
 
+  # This job can be resource intensive. The non-concurrent queue is configured to be a single thread per worker process.
+  queue_as :non_concurrent
+
   # Generate PDFs for all XML files contained within a directory (deeply).
   # PDF files will be created in the same directory as the XML and will share the same name.
   # For example `ead123.xml` would result in `ead123.pdf`.
@@ -62,8 +65,8 @@ class GeneratePdfJob < ApplicationJob
   end
 
   def fo_to_pdf_cmd(pdf_file_path:)
-    "#{Settings.pdf_generation.fop_path} -q -c #{Settings.pdf_generation.fop_config_path} " \
-    "- -pdf #{pdf_file_path}"
+    "FOP_OPTS=\"-Xmx2024m\" #{Settings.pdf_generation.fop_path} -q " \
+    "-c #{Settings.pdf_generation.fop_config_path} - -pdf #{pdf_file_path}"
   end
 
   def ead_xml(file_path:)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,1 +1,7 @@
 :concurrency: 3
+
+:capsules:
+  :non_concurrent:
+    :queues:
+      - non_concurrent
+    :concurrency: 1

--- a/spec/jobs/generate_pdf_job_spec.rb
+++ b/spec/jobs/generate_pdf_job_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe GeneratePdfJob do
           "java -jar #{Settings.pdf_generation.saxon_path} -s:- "\
           "-xsl:#{Settings.pdf_generation.ead_to_fo_xsl_path} " \
           "pdf_image=#{Settings.pdf_generation.logo_path} | " \
-          "#{Settings.pdf_generation.fop_path} -q -c #{Settings.pdf_generation.fop_config_path} " \
-          "- -pdf #{pdf_file_path}"
+          "FOP_OPTS=\"-Xmx2024m\" #{Settings.pdf_generation.fop_path} -q " \
+          "-c #{Settings.pdf_generation.fop_config_path} - -pdf #{pdf_file_path}"
         )
         expect(stdin_double).to have_received(:write).with(a_string_including('urn:isbn:1-931666-22-9'))
       end


### PR DESCRIPTION
Addresses part of #660.

Apache FOP is exceeding the default Java max heap size on prod (1024m) for large (15+ MB) XML files. This increases the max heap to 2024m during FOP execution. This does not alter the initial size of the heap, so this should only impact the system in 2 known cases.