### PR TITLE
Configure sidekiq log for both client and server

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 if defined?(Sidekiq) && ENV['SIDEKIQ_REDIS_URL']
+
   Sidekiq.configure_server do |config|
     config.logger.level = Logger.const_get(ENV.fetch('RAILS_LOG_LEVEL', 'info').upcase.to_s)
     config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL') }
   end
 
   Sidekiq.configure_client do |config|
+    config.logger.level = Logger.const_get(ENV.fetch('RAILS_LOG_LEVEL', 'info').upcase.to_s)
     config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL') }
   end
 end


### PR DESCRIPTION
This should prevent cron emails from being sent with just the Sidekiq connecting to Redis message