### PR TITLE
Use our embed component template

### DIFF
--- a/app/components/embed_component.rb
+++ b/app/components/embed_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Render digital object links for a document
+class EmbedComponent < Arclight::EmbedComponent
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,7 +77,7 @@ class CatalogController < ApplicationController
     config.show.document_component = Arclight::DocumentComponent
     config.show.sidebar_component = Arclight::SidebarComponent
     config.show.breadcrumb_component = BreadcrumbsHierarchyComponent
-    config.show.embed_component = Arclight::EmbedComponent
+    config.show.embed_component = EmbedComponent
     config.show.access_component = Arclight::AccessComponent
     config.show.online_status_component = Arclight::OnlineStatusIndicatorComponent
     config.show.display_type_field = 'level_ssm'


### PR DESCRIPTION
The current `embed_component.html.erb` is present but not being used (from https://github.com/sul-dlss/stanford-arclight/commit/2be2c02b972a69c9f471a68ba3df2c5b155711de), which is also causing our local OembedViewerComponent to not be used. This hooks it up, if that's what we want.

I spot tested a few and couldn't notice a difference other than the slightly increased bottom margin. OembedViewerComponent switches the stimulus (?) controller to 'sul-embed'. I could use another set of eyes on that.