### PR TITLE
Strip leading and trailing whitespace from hrefs

### DIFF
--- a/app/models/digital_object.rb
+++ b/app/models/digital_object.rb
@@ -20,6 +20,7 @@ class DigitalObject
   # the DigitalObject href in the sample data.
   # Ideally, this value would be consistent, but it is not currently.
   def self.normalize_href(href)
+    href = href.strip
     # Some complete Purl URLs do not use https, convert them
     return href.gsub('http://', 'https://') if href.match?(%r{https?://purl.stanford.edu})
     # Some hrefs contain only a druid, convert them to a complete Purl URL

--- a/spec/models/digital_object_spec.rb
+++ b/spec/models/digital_object_spec.rb
@@ -27,16 +27,19 @@ RSpec.describe DigitalObject do
   end
 
   describe "#{described_class}.normalize_href" do
-    it 'returns the href unchanged if it contains something other than a druid' do
+    it 'returns the href, without leading or trailing whitespace, if it contains something other than a druid' do
       expect(described_class.normalize_href('some-other-id')).to eq 'some-other-id'
+      expect(described_class.normalize_href(" some-other-id\t")).to eq 'some-other-id'
     end
 
-    it 'returns the href unchanged if it contains a URL that is not a Purl' do
+    it 'returns the href, without leading or trailing whitespace, if it contains a URL that is not a Purl' do
       expect(described_class.normalize_href('http://www.somewebsite/some-other-id')).to eq 'http://www.somewebsite/some-other-id'
+      expect(described_class.normalize_href(" http://www.somewebsite/some-other-id\t")).to eq 'http://www.somewebsite/some-other-id'
     end
 
-    it 'returns the href unchanged if it contains a complete Purl URL' do
+    it 'returns the href, without leading or trailing whitespace, if it contains a complete Purl URL' do
       expect(described_class.normalize_href('https://purl.stanford.edu/aa111bb2222')).to eq 'https://purl.stanford.edu/aa111bb2222'
+      expect(described_class.normalize_href(" https://purl.stanford.edu/aa111bb2222\t")).to eq 'https://purl.stanford.edu/aa111bb2222'
     end
 
     it 'returns the Purl URL but converts http to https' do
@@ -45,6 +48,7 @@ RSpec.describe DigitalObject do
 
     it 'returns a complete Purl URL if the href only contains a druid' do
       expect(described_class.normalize_href('aa111bb2222')).to eq 'https://purl.stanford.edu/aa111bb2222'
+      expect(described_class.normalize_href(" aa111bb2222\t")).to eq 'https://purl.stanford.edu/aa111bb2222'
     end
   end
 end


### PR DESCRIPTION
Fixes the case of https://archives.stanford.edu/catalog/ars0238_walking-dead-record-label-and_aspace_49ba1a5eac42903f24fb0a985e643dc4 that has an href with a trailing tab, which causes the PURL regex to fail.

This is literally the only case of this I can find where the whitespace results in a failure, so I'd be happy to not merge this and fix the data.

There are ~20 hrefs with trailing newlines, but they are complete URLs and work just fine as is.