### PR TITLE
Pin blacklight to 8.1.0 until JS in 8.2 is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ group :test do
   gem 'webmock'
 end
 
+# Pin Blacklight to 8.1.0 until a fix is in for: https://github.com/projectblacklight/blacklight/commit/d8c0ec4435db34b85f83a2e4799bc15b0469ef27
+gem 'blacklight', '~> 8.1.0'
 gem 'arclight', '>= 1.1.0', '< 2'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bigdecimal (3.1.8)
     bindex (0.8.1)
-    blacklight (8.2.0)
+    blacklight (8.1.0)
       globalid
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
@@ -189,7 +189,12 @@ GEM
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -534,6 +539,7 @@ PLATFORMS
 
 DEPENDENCIES
   arclight (>= 1.1.0, < 2)
+  blacklight (~> 8.1.0)
   blacklight-locale_picker
   blacklight_range_limit (~> 8.5)
   bootsnap

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "arclight": "^1.0.0",
-    "blacklight-frontend": "^8",
+    "blacklight-frontend": "8.0.1",
     "bootstrap": "^5",
     "sass": "^1.59.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-blacklight-frontend@^8:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.2.0.tgz#fadd4b13594a429febbccada88643db661c76471"
-  integrity sha512-pJo5tvFu1hv7u9jU4nxCwGPrxwOIj/ZOx52nBVHAZBdpwpLAapV/+oxHyb5dfeXzq/kbFP4gDZhXCGF3KHksTg==
+blacklight-frontend@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.0.1.tgz#20c923ea45e0d9c774ad3d23ef0bed2e31a12c71"
+  integrity sha512-KVQ4txligEJb3RZx4LpGEx/YDWRWgSDP7xdJOzudFLFwZ8eJAwbwc7L5ErXvuNwdSz0o6v5vf6IIr66Hpbg5TA==
   dependencies:
     bootstrap ">=4.3.1 <6.0.0"
 


### PR DESCRIPTION
JS imports are broken in Blacklight 8.2
Commit that broke it: projectblacklight/blacklight@d8c0ec4
Proposing a revert: projectblacklight/blacklight#3164