### PR TITLE
Revert "Use dark link color for beta banner to meet contrast requirements

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -162,7 +162,4 @@ header .topbar > .container-fluid {
 
 .beta-banner {
   background-color: $stanford-illuminating;
-  a {
-    color: $link-dark-color;
-  }
 }


### PR DESCRIPTION
This reverts commit 2ef4d369578b0792dc7d5d1d436494de093cb502.

This didn't fix our contrast issue. I opened https://github.com/sul-dlss/stanford-arclight/issues/712 to address this.