### PR TITLE
Fix beta banner contrast

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -162,4 +162,11 @@ header .topbar > .container-fluid {
 
 .beta-banner {
   background-color: $stanford-illuminating;
+  // These aren't official stanford colors
+  // but no combination of official interactive colors
+  // meet accessibility contrast requirements on this background.
+  color: #000
+  a {
+    color: #0065AD;
+  }
 }


### PR DESCRIPTION
I'm not bothering with variables because this banner is going to go away after the production launch and we're not using this background color anywhere else.

<img width="742" alt="Screenshot 2024-06-04 at 9 35 49 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/458247/dcdb10e5-8170-4d97-bf1c-d4c2a9ffeea5">

Barely noticeable difference from the official stanford colors, but these meet the contrast requirements for level A and AA compliance on the yellow background.

<img width="453" alt="Screenshot 2024-06-04 at 9 34 24 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/458247/c119e650-aa19-43f2-bef2-f9e67438cbc4">
<img width="453" alt="Screenshot 2024-06-04 at 9 34 29 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/458247/bcb562b3-6e9f-4aba-ad2a-ca7ecfabcf9f">
