### PR TITLE
Stretch the search element to fill the container

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -20,7 +20,7 @@ header .topbar > .container-fluid {
   // The feedback form is hidden, using inline style, to prevent it from being shown during slow page loads.
   display: block !important;
   overflow: hidden;
-  transition: all .5s ease-in-out;
+  transition: all 0.5s ease-in-out;
   max-height: 0;
   background-color: white;
 
@@ -36,12 +36,12 @@ header .topbar > .container-fluid {
   a {
     color: $stanford-digital-blue;
   }
- }
+}
 
- #main-flashes {
+#main-flashes {
   // contain the width of the flashes to Bootstrap's container width
   @extend .container;
- }
+}
 
 .al-masthead {
   color: $masthead-color;
@@ -80,7 +80,7 @@ header .topbar > .container-fluid {
     }
 
     li:not(:first-child)::before {
-      content: '•';
+      content: "•";
       position: absolute;
       left: -1.165rem;
       top: 0.25rem;
@@ -117,6 +117,10 @@ header .topbar > .container-fluid {
   border-top: none;
   background-color: $navbar-background-color;
   margin-bottom: 0;
+
+  search {
+    width: 100%;
+  }
 
   .input-group-text {
     background-color: $navbar-background-color;
@@ -158,7 +162,7 @@ header .topbar > .container-fluid {
   }
 
   #search_field {
-    margin-right: .825rem;
+    margin-right: 0.825rem;
   }
 }
 
@@ -169,6 +173,6 @@ header .topbar > .container-fluid {
   // meet accessibility contrast requirements on this background.
   color: #000;
   a {
-    color: #0065AD;
+    color: #0065ad;
   }
 }


### PR DESCRIPTION
This is necessary after https://github.com/projectblacklight/blacklight/pull/3166 so that the search form uses the full area.