### PR TITLE
Add the page title to the repositories page

### DIFF
--- a/app/views/arclight/repositories/index.html.erb
+++ b/app/views/arclight/repositories/index.html.erb
@@ -4,6 +4,7 @@
 <h1 class="sr-only visually-hidden"><%= t('arclight.repositories') %></h1>
 
 <div class="al-repositories container">
+    <% @page_title = t('arclight.views.repositories.title') %>
     <%= render 'shared/breadcrumbs' %>
     <h1><%= t('arclight.repositories') %></h1>
     <% @repositories.each_slice(3) do |repositories_chunk| %>

--- a/spec/features/repositories_page_spec.rb
+++ b/spec/features/repositories_page_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe 'Repositories Page', type: :feature do
     visit arclight_engine.repositories_path
   end
 
+  it 'has a title' do
+    expect(page).to have_title('Repositories - Archival Collections at Stanford')
+  end
+
   it 'links repositories to their search page with collection count' do
     expect(page).to have_link('Browse 1 collection', href: 'http://www.example.com/catalog?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=Archive+of+Recorded+Sound')
   end


### PR DESCRIPTION
Looks like we dropped this line from upstream: https://github.com/projectblacklight/arclight/blob/094e10f0ec65070bc53a71d41385be3ad6aa6f90/app/views/arclight/repositories/index.html.erb#L6