### PR TITLE
Turn off group toggle for the bookmarks view

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Override of Blacklight's BookmarksController to remove the group toggle.
+class BookmarksController < CatalogController
+  include Blacklight::Bookmarks
+
+  configure_blacklight do |config|
+    config.view_config(:index).collection_actions.delete(:group_toggle)
+  end
+end


### PR DESCRIPTION
Closes #731 

I'm not sure yet what we want to do about the group by controls in ArcLight core. For now, let's shut them off in our app.