### PR TITLE
Expand available words during ID normalization

### DIFF
--- a/lib/traject/sul/normalized_id.rb
+++ b/lib/traject/sul/normalized_id.rb
@@ -27,8 +27,8 @@ module Sul
       # Instead, return only universite-de-toulouse.
       # Otherwise return something like ars0009_belva-kibler-and-donald-morgan
       normalized_id = [id, title].compact.reject(&:empty?).map do |string|
-        string&.truncate_words(5, omission: '')&.parameterize
-      end.uniq.join('_')
+        string.split.map(&:parameterize).reject(&:empty?).take(5).join('-')
+      end.reject(&:blank?).uniq.join('_')
 
       raise Arclight::Exceptions::IDNotFound if normalized_id.blank?
 

--- a/spec/lib/traject/sul/normalized_id_spec.rb
+++ b/spec/lib/traject/sul/normalized_id_spec.rb
@@ -13,6 +13,50 @@ RSpec.describe Sul::NormalizedId do
     expect(normalized_id).to eq 'abc1234_a-collection-of-papers'
   end
 
+  context 'when the title is empty' do
+    let(:title) { '' }
+
+    it 'returns a normalized id using the eadid' do
+      expect(normalized_id).to eq 'abc1234'
+    end
+  end
+
+  context 'when the title has over 5 words' do
+    let(:title) do
+      'Lopez v. Monterey County : photocopies of court case research ' \
+      'documenting historical discrimination against Mexicans in Monterey County, California'
+    end
+
+    it 'returns a normalized id using the first 5 words' do
+      expect(normalized_id).to eq 'abc1234_lopez-v-monterey-county-photocopies'
+    end
+  end
+
+  context 'when the title contains words that parameterize would make into empty strings' do
+    let(:title) { 'Универзитет „Кирил и Методиј" во Скопје/Ss. Cyril and Methodius University of Skopje' }
+
+    it 'returns a normalized id using the first 5 non-empty parameterized words' do
+      expect(normalized_id).to eq 'abc1234_ss-cyril-and-methodius-university'
+    end
+  end
+
+  context 'when the title contains only words that parameterize would make into empty strings' do
+    let(:title) { 'Универзитет „Кирил и Методиј" во Скопје' }
+
+    it 'returns a normalized id using the eadid' do
+      expect(normalized_id).to eq 'abc1234'
+    end
+  end
+
+  context 'when the title and the eadid are the same' do
+    let(:ead_id) { 'Université de Toulouse' }
+    let(:title) { ead_id }
+
+    it 'returns a normalized id without duplication' do
+      expect(normalized_id).to eq 'universite-de-toulouse'
+    end
+  end
+
   context 'when the eadid is empty' do
     let(:ead_id) { '' }
 
@@ -26,6 +70,15 @@ RSpec.describe Sul::NormalizedId do
 
     it 'returns a normalized id' do
       expect(normalized_id).to eq 'a-collection-of-papers'
+    end
+  end
+
+  context 'when both the title and eadid are empty' do
+    let(:ead_id) { '' }
+    let(:title) { '' }
+
+    it 'raises an error' do
+      expect { normalized_id }.to raise_error(Arclight::Exceptions::IDNotFound)
     end
   end
 end


### PR DESCRIPTION
Closes #723.

Run parameterize per word so we can filter out the empty results.

### This would change 59 IDs on prod:

[normalized_id_diff.csv](https://github.com/user-attachments/files/15687167/normalized_id_diff.csv)

One of those is the problematic ID from the issue.

If we can't be bothered to clean up those IDs at this stage, which is totally valid, I'd suggest we drop the bulk of my change and only keep `end.reject(&:blank?).uniq.join('_')`. That would drop the offending trailing '_' from the ID in question.

I'm finding it difficult to achieve closer parity without really complicating this. `truncate_words` counts anything wrapped in whitespace, including punctuation, as a word. That's why in these few cases this adds an additional word or two to the normalized ID.