### PR TITLE
Prevent keyboard focus on hidden feedback form

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -23,9 +23,11 @@ header .topbar > .container-fluid {
   transition: all 0.5s ease-in-out;
   max-height: 0;
   background-color: white;
+  visibility: hidden;
 
   &.open {
     max-height: 100vh;
+    visibility: visible;
   }
 
   label {

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -3,8 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Feedback Form', :js, type: :feature do
-  it 'is visible after clicking the feedback link' do
+  it 'is visible only after clicking the feedback link' do
     visit root_path
+
+    feedback = page.find(:css, '#feedback', visible: false)
+    expect(feedback.native.style('visibility')).to eq('hidden')
+    expect(page).to have_css('#feedback', visible: :hidden)
+
     click_link 'Feedback'
     within '#feedback' do
       expect(page).to have_css('form')


### PR DESCRIPTION
Fix for this repo's part of #734.

Use visibility rather than display so the transition animation still works as expected.

If we're fine with this approach I can do VT as well.