### PR TITLE
Make controller methods private

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -17,17 +17,10 @@ class LandingPageController < ApplicationController
   def index
     @hours = Settings.hours_locations.map { |hours_config| LibraryHours.from_config(hours_config) }
     @collection_count = site_collection_count
-    @next_half_hour = next_half_hour
+    @next_half_hour = TimeService.next_half_hour
   end
 
-  def next_half_hour
-    now = Time.current
-    next30 = now.at_beginning_of_hour + (now.min < 30 ? 30.minutes : 60.minutes)
-
-    return next30 + 5.seconds if next30 - now < 5.seconds
-
-    next30
-  end
+  private
 
   def site_collection_count
     Rails.cache.fetch('site_collection_count', expires_in: 1.hour) do

--- a/app/services/time_service.rb
+++ b/app/services/time_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Finds the next half hour from now, but lead the clock by 30s.
+class TimeService
+  def self.next_half_hour
+    now = Time.current
+    next30 = now.at_beginning_of_hour + (now.min < 30 ? 30.minutes : 60.minutes)
+
+    return next30 + 5.seconds if next30 - now < 5.seconds
+
+    next30
+  end
+end

--- a/spec/services/time_service_spec.rb
+++ b/spec/services/time_service_spec.rb
@@ -2,47 +2,47 @@
 
 require 'rails_helper'
 
-RSpec.describe LandingPageController, type: :controller do
+RSpec.describe TimeService do
   include ActiveSupport::Testing::TimeHelpers
 
-  describe '#next_half_hour' do
+  describe '.next_half_hour' do
     it 'pads the next half-hour time with 5 seconds when the current time is less than 5 seconds away' do
       travel_to Time.zone.local(2024, 5, 14, 9, 29, 56) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30, 5))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30, 5))
       end
     end
 
     it 'returns the next half-hour when the current time is exactly the half-hour' do
       travel_to Time.zone.local(2024, 5, 14, 9, 30) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
       end
 
       travel_to Time.zone.local(2024, 5, 14, 10, 0) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 30))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 30))
       end
     end
 
     it 'returns the half-hour if the current time is before the half-hour' do
       travel_to Time.zone.local(2024, 5, 14, 9, 20) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30))
       end
     end
 
     it 'returns the next hour if the current time is after the half-hour' do
       travel_to Time.zone.local(2024, 5, 14, 9, 40) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
       end
     end
 
     it 'correctly handles noon' do
       travel_to Time.zone.local(2024, 5, 14, 11, 59) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 12, 0))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 12, 0))
       end
     end
 
     it 'correctly handles midnight' do
       travel_to Time.zone.local(2024, 5, 14, 23, 59) do
-        expect(controller.next_half_hour).to eq(Time.zone.local(2024, 5, 15, 0, 0))
+        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 15, 0, 0))
       end
     end
   end


### PR DESCRIPTION
Non-endpoint methods of a rails controller should be private.  We needed to extract the TimeService into it's own module so that it could be tested directly.