### PR TITLE
Fix feedback form height for short viewport

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -26,7 +26,7 @@ header .topbar > .container-fluid {
   visibility: hidden;
 
   &.open {
-    max-height: 100vh;
+    max-height: none;
     visibility: visible;
   }
 


### PR DESCRIPTION
Fixes #741.

I don't think we need to specify a max-height when open, we only need to remove the `max-height: 0;` we set during the closed state.

![Screenshot 2024-06-10 at 9 14 07 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/3b2b853f-e5d5-4974-bbe2-1404e5f18412)
