### PR TITLE
Change using these materials heading

### DIFF
--- a/app/components/using_these_materials_component.html.erb
+++ b/app/components/using_these_materials_component.html.erb
@@ -1,5 +1,5 @@
 <div id="using-these-materials">
-  <h3 class="al-show-sub-heading"><%= t("using_these_materials.heading") %></h3>
+  <h2 class="al-show-sub-heading"><%= t("using_these_materials.heading") %></h2>
   <div class="pt-2">
     <ul>
       <li>


### PR DESCRIPTION
Siteimprove wants headings to be structured on collection/component pages.

![Screenshot 2024-06-11 at 8 13 44 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/10becb7c-0228-4804-b94f-768c22dda42b)
