### PR TITLE
Extract col-md-4 outside the navbar

### DIFF
--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -4,11 +4,13 @@
       <div class="col-md-8 d-flex justify-content-center justify-content-md-start align-items-center">
         <span class="h1 text-center text-md-start"><%= heading %></span>
       </div>
-      <nav class="col-md-4 navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">
-        <ul class="navbar-nav">
-          <%= render 'shared/main_menu_links' %>
-        </ul>
-      </nav>
+      <div class="col-md-4">
+        <nav class="navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">
+          <ul class="navbar-nav">
+            <%= render 'shared/main_menu_links' %>
+          </ul>
+        </nav>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Otherwise both navbar and col-md-4 apply different padding, which can make alignment difficult

Ref https://github.com/projectblacklight/arclight/pull/1551