### PR TITLE
Fix unbalanced margin on topbar when feedback open

### DIFF
--- a/app/assets/stylesheets/sulHeader.scss
+++ b/app/assets/stylesheets/sulHeader.scss
@@ -1,8 +1,10 @@
 $masthead-color: $stanford-white;
+.topbar {
+  --bs-navbar-padding-y: 0.75rem;
+}
 
 .navbar {
   --bs-navbar-hover-color: rgba(255, 255, 255, 1);
-  padding-top: 0.75rem;
 }
 
 .navbar-logo {
@@ -40,10 +42,6 @@ $masthead-color: $stanford-white;
   }
 
   .navbar-nav {
-    list-style-type: none;
-    padding-left: 0;
-    margin-right: 0.5rem;
-
     li.active a {
       color: $navbar-dark-color;
     }

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-8 d-flex justify-content-center justify-content-md-start">
-        <span class="h1 my-4"><%= heading %></span>
+        <span class="h1 my-3"><%= heading %></span>
       </div>
       <div class="col-md-4">
         <nav class="navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">


### PR DESCRIPTION
Before:
<img width="1169" alt="Screenshot 2024-06-13 at 11 46 44 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/92044/73e3d412-080e-4cbb-a9fa-bfcfae99c491">

After:
<img width="1192" alt="Screenshot 2024-06-13 at 11 46 31 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/92044/8ff937b0-4e95-4509-9c20-2e6a1bd16090">
