### PR TITLE
Execute reCAPTCHA on form submit

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -14,7 +14,7 @@
 <div id="feedback" class="collapse">
   <div class="container pt-3">
     <div class="row justify-content-center">
-      <%= form_with url: feedback_path, method: :post, class: 'col-md-8' do |f| %>
+      <%= form_with url: feedback_path, method: :post, class: 'col-md-8', html: { name: 'feedback_form' } do |f| %>
         <%= f.hidden_field :reporting_from, value: request.original_url %>
         <div class="alert alert-info" role="alert">
           <%= t('feedbacks.reporting_from', url: request.original_url) %>
@@ -40,7 +40,17 @@
         </div>
         <div class="mb-3 row">
           <div class="col-md-9 offset-md-3">
-            <%= recaptcha_v3(action: 'feedback', turbolinks: true) %>
+            <%= recaptcha_v3(action: 'feedback') %>
+            <script type="text/javascript">
+              document.forms.feedback_form.addEventListener('submit', async function(e) {
+                e.preventDefault();
+                const response = await window.executeRecaptchaForFeedbackAsync();
+                if (response) {
+                  setInputWithRecaptchaResponseTokenForFeedback('g-recaptcha-response-data-feedback', response);
+                }
+                this.submit();
+              });
+            </script>
           </div>
         </div>
         <div class="mb-3 row">

--- a/spec/features/feedback_form_spec.rb
+++ b/spec/features/feedback_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Feedback Form', :js do
 
     click_on 'Feedback'
     within '#feedback' do
-      expect(page).to have_css('form')
+      expect(page).to have_css('form[name="feedback_form"]')
     end
   end
 end


### PR DESCRIPTION
Closes #774

Similar to what https://github.com/ambethia/recaptcha recommends for v3, executing reCAPTCHA at submit time rather than setting a timer to refresh it every two minutes.

I kept it inline because the name/action that determine the names of the helper functions from the recaptcha gem are here. 

There are at least 3 other sites that will need something similar.