### PR TITLE
Move collections and repositories link into the hamburger menu

### DIFF
--- a/app/assets/stylesheets/sulBase.scss
+++ b/app/assets/stylesheets/sulBase.scss
@@ -30,8 +30,11 @@ a,
   box-shadow: 0 0 0 0.25rem rgba($link-dark-color, 0.25);
 }
 
-.bg-dark a {
-  color: $link-light-color;
+.bg-dark {
+  --bs-dropdown-divider-bg: white;
+  a {
+    color: $link-light-color;
+  }
 }
 
 .warning-icon svg {

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -4,7 +4,7 @@
       <div class="col-md-8 d-flex justify-content-center justify-content-md-start">
         <span class="h1 my-3"><%= heading %></span>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-4 d-none d-md-block">
         <nav class="navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">
           <ul class="navbar-nav">
             <%= render 'shared/main_menu_links' %>

--- a/app/components/user_util_links_component.html.erb
+++ b/app/components/user_util_links_component.html.erb
@@ -2,4 +2,11 @@
   <li class="nav-item"><%= render 'blacklight/nav/bookmark' %></li>
   <li class="nav-item"><%= render 'blacklight/nav/search_history' %></li>
   <li class="nav-item"><a href="#feedback" class="nav-link" data-bs-toggle="collapse" data-bs-target="#feedback">Feedback</a></li>
+  <li class="nav-item d-md-none"><hr class="dropdown-divider"></li>
+  <li class="nav-item d-md-none <%= repositories_active_class %>">
+    <%= link_to t('arclight.routes.repositories'), helpers.arclight_engine.repositories_path, class: 'nav-link' %>
+  </li>
+  <li class="nav-item d-md-none <%= helpers.collection_active_class %>">
+    <%= link_to t('arclight.routes.collections'), helpers.arclight_engine.collections_path, class: 'nav-link' %>
+  </li>
 </ul>

--- a/spec/features/navbar_spec.rb
+++ b/spec/features/navbar_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe 'Navbar' do
     end
 
     it "renders the 'Bookmark' and 'Search History' navigation items" do
-      expect(page).to have_css('#user-util-collapse .nav-item', count: 3)
+      expect(page).to have_css('#user-util-collapse .nav-item', count: 6)
       expect(page).to have_css('#user-util-collapse .nav-item a', text: 'Bookmarks')
       expect(page).to have_css('#user-util-collapse .nav-item a', text: 'History')
+      expect(page).to have_css('#user-util-collapse .nav-item.d-md-none a', text: 'Repositories')
+      expect(page).to have_css('#user-util-collapse .nav-item.d-md-none a', text: 'Collections')
     end
 
     it "always renders the 'Feedback' navigation item" do


### PR DESCRIPTION
This matches the DLSS component designs https://www.figma.com/design/K1syTsalaB1nlRftgOi0Pw/DLSS-Components\?node-id\=0-1\&t\=FOLafWldFP9lbzqm-0

Wider screens
<img width="913" alt="Screenshot 2024-06-18 at 10 40 52 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/92044/3c9ead2d-f4df-4e1d-b7b9-03a2e7d3fe4f">

Narrow screens with hamburger open
<img width="738" alt="Screenshot 2024-06-18 at 10 40 41 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/92044/f38213dd-8df7-4638-975f-a44108e7d6bf">

Narrow screens with hamburger closed
<img width="738" alt="Screenshot 2024-06-18 at 10 40 32 AM" src="https://github.com/sul-dlss/stanford-arclight/assets/92044/d8a1505c-73b1-419b-a2c3-3d685adfef8e">
