### PR TITLE
Remove Bootstrap 4 submit button

### DIFF
--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -1,0 +1,12 @@
+<%# The upstream template currently provides two submit buttons, one for Bootstrap 4 and one for 5. The unused button is
+    only visually hidden, creating an accessibility issue. This template removes the BS4 button. If blacklight_range_limit
+    drops support for BS4 we can likely remove this override. %>
+<%= form_tag search_action_path, method: :get, class: [@classes[:form], "range_#{@facet_field.key} d-flex justify-content-center"].join(' ') do %>
+  <%= render hidden_search_state %>
+
+  <div class="input-group input-group-sm mb-3 flex-nowrap range-limit-input-group">
+    <%= render_range_input(:begin, begin_label) %>
+    <%= render_range_input(:end, end_label) %>
+    <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit], name: nil %>
+  </div>
+<% end %>


### PR DESCRIPTION
The BS4 submit button from blacklight_range_limit is only visually hidden, it can still be tabbed to/is accessible to screen readers.

![Screenshot 2024-06-20 at 11 34 48 AM](https://github.com/sul-dlss/stanford-arclight/assets/4421877/7cf15fab-d962-4db8-aef6-de47e7c3a7e0)
