### PR TITLE
Use expires_in for library hours cache

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -18,7 +18,7 @@ class LandingPageController < ApplicationController
   def index
     @hours = Settings.hours_locations.map { |hours_config| LibraryHours.from_config(hours_config) }
     @collection_count = site_collection_count
-    @next_half_hour = TimeService.next_half_hour
+    @seconds_until_next_half_hour = TimeService.seconds_until_next_half_hour
   end
 
   private

--- a/app/services/time_service.rb
+++ b/app/services/time_service.rb
@@ -4,10 +4,15 @@
 class TimeService
   def self.next_half_hour
     now = Time.current
-    next30 = now.at_beginning_of_hour + (now.min < 30 ? 30.minutes : 60.minutes)
+    now.at_beginning_of_hour + (now.min < 30 ? 30.minutes : 60.minutes)
+  end
 
-    return next30 + 5.seconds if next30 - now < 5.seconds
+  def self.seconds_until_next_half_hour
+    delta = next_half_hour - Time.current
+    return 5.seconds if delta < 5.seconds
 
-    next30
+    return 30.minutes if delta > 30.minutes
+
+    delta
   end
 end

--- a/app/views/landing_page/_cards.html.erb
+++ b/app/views/landing_page/_cards.html.erb
@@ -4,7 +4,7 @@
       <%= image_tag 'locations.png', alt: '', class: 'card-img-top' %>
       <div class="card-body px-1">
         <h3 class="card-title"><%= t('.location.title') %></h3>
-        <% cache('location_hours', expires_at: @next_half_hour) do %>
+        <% cache('location_hours', expires_in: @seconds_until_next_half_hour) do %>
           <ul>
             <% @hours.each do |location_hours| %>
               <li><%= render 'landing_page/location_hours', location_hours: %></li>

--- a/spec/services/time_service_spec.rb
+++ b/spec/services/time_service_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe TimeService do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '.next_half_hour' do
-    it 'pads the next half-hour time with 5 seconds when the current time is less than 5 seconds away' do
-      travel_to Time.zone.local(2024, 5, 14, 9, 29, 56) do
-        expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 9, 30, 5))
-      end
-    end
-
     it 'returns the next half-hour when the current time is exactly the half-hour' do
       travel_to Time.zone.local(2024, 5, 14, 9, 30) do
         expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 14, 10, 0))
@@ -43,6 +37,33 @@ RSpec.describe TimeService do
     it 'correctly handles midnight' do
       travel_to Time.zone.local(2024, 5, 14, 23, 59) do
         expect(described_class.next_half_hour).to eq(Time.zone.local(2024, 5, 15, 0, 0))
+      end
+    end
+  end
+
+  describe '.seconds_until_next_half_hour' do
+    it 'returns the minimum of 5 seconds when the next half-hour is less than 5 seconds away' do
+      travel_to Time.zone.local(2024, 5, 14, 9, 29, 56) do
+        expect(described_class.seconds_until_next_half_hour).to eq(5.seconds)
+      end
+    end
+
+    it 'returns a maximum of 30 minutes' do
+      allow(described_class).to receive(:next_half_hour).and_return(45.minutes.from_now)
+      expect(described_class.seconds_until_next_half_hour).to eq(30.minutes)
+    end
+
+    it 'returns the correct number of seconds if the current time is within the thresholds' do
+      travel_to Time.zone.local(2024, 5, 14, 9, 30) do
+        expect(described_class.seconds_until_next_half_hour).to eq(30.minutes)
+      end
+
+      travel_to Time.zone.local(2024, 5, 14, 10, 0) do
+        expect(described_class.seconds_until_next_half_hour).to eq(30.minutes)
+      end
+
+      travel_to Time.zone.local(2024, 5, 14, 9, 20, 30) do
+        expect(described_class.seconds_until_next_half_hour).to eq(9.minutes + 30.seconds)
       end
     end
   end


### PR DESCRIPTION
The bug from https://github.com/sul-dlss/stanford-arclight/issues/685 happened again.

Upon inspection, the redis ttl for the cache key was `-1` for on both prod and stage. Once that's cleared, they work fine for a while. I know of at least two values that result in a `-1` ttl for `expires_at`:
* nil
* A time in the past

We had a guard in place for times in the past, but maybe it didn't account for all situations. This PR switches to using `expires_in` with a value with stricter bounds which is hopefully safer.