### PR TITLE
Fix searches containing standalone punctuation

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -202,6 +202,23 @@
       </analyzer>
     </fieldType>
 
+    <!-- single token with punctuation terms removed so edismax doesn't look for punctuation terms in these fields -->
+    <!-- On client side, Lucene query parser breaks things up by whitespace *before* field analysis for edismax -->
+    <!-- so punctuation terms (& : ;) are stopwords to allow results from other fields when these chars -->
+    <!-- are surrounded by spaces in query. -->
+    <fieldType name="string_punct_stop" class="solr.TextField" omitNorms="true">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUNormalizer2FilterFactory" mode="compose" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUNormalizer2FilterFactory" mode="compose" />
+        <!-- removing punctuation for Lucene query parser issues -->
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_punctuation.txt"  />
+      </analyzer>
+    </fieldType>
+
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -292,6 +309,7 @@
    <field name="text" type="text" indexed="true" stored="true" multiValued="true"/>
    <field name="unitid_identifier_match" type="identifier_match" indexed="true" stored="false" multiValued="true" />
    <field name="ead_identifier_match" type="identifier_match" indexed="true" stored="false" multiValued="true" />
+   <field name="identifier_search" type="string_punct_stop" indexed="true" stored="false" multiValued="true"/>
 
    <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
    <field name="_nest_parent_" type="string" indexed="true" stored="true"/>
@@ -348,6 +366,12 @@
    <copyField source="names_ssim" dest="name_teim"/>
    <copyField source="access_subjects_ssim" dest="subject_teim"/>
    <copyField source="containers_ssim" dest="container_teim" />
+
+   <!-- catch all identifier field suitable for search -->
+   <copyField source="id" dest="identifier_search" />
+   <copyField source="ead_ssi" dest="identifier_search" />
+   <copyField source="ref_ssm" dest="identifier_search" />
+   <copyField source="unitid_ssm" dest="identifier_search" />
 
    <!-- The catch all `text` field -->
    <!-- grab the fielded searches -->

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -107,10 +107,7 @@
          name_teim^10
          place_teim^10
          subject_teim^2
-         id
-         ead_ssi
-         ref_ssm
-         unitid_ssm
+         identifier_search
          container_teim
          parent_unittitles_tesim
          text
@@ -124,10 +121,7 @@
          name_teim^20
          place_teim^20
          subject_teim^5
-         id^2
-         ead_ssi^2
-         ref_ssm^2
-         unitid_ssm^2
+         identifier_search^2
          container_teim^2
          parent_unittitles_tesim^2
          text^2
@@ -140,19 +134,13 @@
          container_teim^2
        </str>
        <str name="qf_identifier">
-         id
-         ead_ssi
+         identifier_search
          ead_identifier_match
-         ref_ssm
-         unitid_ssm
          unitid_identifier_match
        </str>
        <str name="pf_identifier">
-         id^2
-         ead_ssi^2
+         identifier_search^2
          ead_identifier_match^2
-         ref_ssm^2
-         unitid_ssm^2
          unitid_identifier_match^2
        </str>
        <str name="qf_name">

--- a/solr/conf/stopwords_punctuation.txt
+++ b/solr/conf/stopwords_punctuation.txt
@@ -1,0 +1,23 @@
+# Punctuation characters we want to ignore as terms (i.e., when surrounded 
+# by whitespace in a query, like 'fred : the puppy') in queries
+# ONLY FOR SINGLE TOKEN ANALYZED FIELDS
+#   see https://issues.apache.org/jira/browse/SOLR-3085
+# Note that plusses and double hyphens are not treated as terms
+#   per debugQuery
+:
+;
+&
+/
+=
+>
+<
+,
+.
+(
+)
+…
+»
+§
+•
+·
+-

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -47,4 +47,16 @@ RSpec.describe 'Searching', :js do
       expect(page.current_url).to include('group=true')
     end
   end
+
+  context 'when a query contains a dash surrounded by spaces' do
+    before do
+      visit search_catalog_path
+      fill_in 'q', with: 'Academy of Ancient Music - Broadway Celebration'
+      click_on 'Search'
+    end
+
+    it 'returns the expected number of results' do
+      expect(page).to have_content(/1 collections found/)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #698 (modeled on this arclight change: https://github.com/projectblacklight/arclight/pull/1590/commits/0cb0910aa28dc650487925418a3e8580d317780a)