### PR TITLE
Use default blacklight pagination translations

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,12 +1,3 @@
 en:
   blacklight:
     application_name: 'Archival Collections at Stanford'
-    search:
-      entry_pagination_info:
-        one: "1 of 1"
-        other: "%{current} of %{total}"
-      pagination_info:
-        pages:
-          one: "%{start_num} - %{end_num} of %{total_num}"
-          other: "%{start_num} - %{end_num} of %{total_num}"
-        single_item_found: "1 %{entry_name} found"


### PR DESCRIPTION
Based on the arclight figma designs we had removed the `<strong>` tag around components of the pagination translations, but after discussion with the team we decided we want the default blacklight behavior.