### PR TITLE
Avoid unnecessary warnings on prod

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,18 +10,18 @@ task default: :ci
 
 Rails.application.load_tasks
 
-begin
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    task.fail_on_error = true
-  end
-rescue LoadError
-  # this rescue block is here for deployment to production, where
-  # certain dependencies are not expected, and that is OK
-  warn 'WARNING: Rubocop was not found and could not be required.'
-end
-
 unless Rails.env.production?
+  begin
+    require 'rubocop/rake_task'
+    RuboCop::RakeTask.new(:rubocop) do |task|
+      task.fail_on_error = true
+    end
+  rescue LoadError
+    # this rescue block is here for deployment to production, where
+    # certain dependencies are not expected, and that is OK
+    warn 'WARNING: Rubocop was not found and could not be required.'
+  end
+
   begin
     require 'solr_wrapper/rake_task'
   rescue LoadError


### PR DESCRIPTION
These cause cron to send everyone an email.  We don't ever run rubocop in the production environment