### PR TITLE
Adjust call number pill so it looks good whether wrapped or not

### DIFF
--- a/app/components/arclight/document_component.html.erb
+++ b/app/components/arclight/document_component.html.erb
@@ -10,7 +10,7 @@
 
 <div class="title-container">
   <%= content_tag :h1 do %>
-    <%= document.normalized_title %>
+    <span class="me-2"><%= document.normalized_title %></span>
     <%= render CollectionUnitidPillComponent.new(document: document) %>
   <% end %>
   <%= render 'arclight/requests', document: document %>

--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -7,7 +7,9 @@
         </div>
       <% end %>
       <h3>
-        <%= helpers.link_to_document document %>
+        <span class="d-inline-block mb-2 me-2">
+          <%= helpers.link_to_document document %>
+        </span>
         <%= render CollectionUnitidPillComponent.new(document: document) %>
       </h3>
       <%= render ExtentPillComponent.new(document: document, compact: compact?) %>

--- a/app/components/arclight/online_status_indicator_component.rb
+++ b/app/components/arclight/online_status_indicator_component.rb
@@ -15,7 +15,7 @@ module Arclight
 
     def icon_with_tooltip
       icon = <<~HTML
-        <span class="al-online-content-icon" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Includes digital content">
+        <span class="al-online-content-icon me-2" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Includes digital content">
             #{helpers.blacklight_icon(:online)}
         </span>
       HTML

--- a/app/components/arclight/search_result_title_component.html.erb
+++ b/app/components/arclight/search_result_title_component.html.erb
@@ -2,7 +2,7 @@
     and to add the digital content icon %>
 <header class="documentHeader row" data-document-id="<%= @document.id %>">
   <h3 class="index_title document-title-heading col">
-    <%= helpers.link_to_document @document, counter: @counter %>
+    <span class="d-inline-block me-2 mb-2"><%= helpers.link_to_document @document, counter: @counter %></span>
 
     <%= render Arclight::OnlineStatusIndicatorComponent.new(document: @document) %>
     <%= render CollectionUnitidPillComponent.new(document: @document) %>

--- a/app/components/collection_context_component.html.erb
+++ b/app/components/collection_context_component.html.erb
@@ -3,7 +3,7 @@
     <button type="button" class="btn-close d-lg-none float-end mt-1 me-1" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>
     <h2>Collection</h2>
     <h3>
-      <%= title %>
+      <span class="me-2"><%= title %></span>
       <%= unitid %>
     </h3>
 

--- a/app/components/collection_unitid_pill_component.html.erb
+++ b/app/components/collection_unitid_pill_component.html.erb
@@ -1,3 +1,3 @@
-<div class="ms-0 ms-sm-2 mt-2 mt-sm-0 d-block d-sm-inline-block">
+<div class="d-inline-block mb-2">
   <%= tag.span unitid, class: 'badge rounded-pill collection-info-pill align-middle fs-6' %>
 </div>

--- a/app/components/extent_pill_component.html.erb
+++ b/app/components/extent_pill_component.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex mt-2">
+<div class="d-flex">
   <% extents.each do |extent| %>
     <%= tag.span extent, class: 'badge rounded-pill document-info-pill me-1 fs-6' %>
   <% end %>


### PR DESCRIPTION
Fixes #948 

This is a bit fiddly, but I think it overall looks better at more window widths than the initial implementation.
<img width="989" alt="Screenshot 2025-04-10 at 5 13 55 PM" src="https://github.com/user-attachments/assets/0ea9afed-e4a5-4638-8f8d-3d06d416e4e5" />
<img width="445" alt="Screenshot 2025-04-10 at 5 11 12 PM" src="https://github.com/user-attachments/assets/dcdf7b2e-e6a2-4c14-9782-e4b8ee5eda93" />
<img width="434" alt="Screenshot 2025-04-10 at 5 11 54 PM" src="https://github.com/user-attachments/assets/63b43072-9ee3-4d57-9246-f146f21f0e87" />
