### PR TITLE
Adjust margin and display of collection title

### DIFF
--- a/app/components/collection_context_component.html.erb
+++ b/app/components/collection_context_component.html.erb
@@ -3,7 +3,7 @@
     <button type="button" class="btn-close d-lg-none float-end mt-1 me-1" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>
     <h2>Collection</h2>
     <h3>
-      <span class="me-2"><%= title %></span>
+      <span class="me-2 mb-2 d-inline-block"><%= title %></span>
       <%= unitid %>
     </h3>
 


### PR DESCRIPTION
Fixes #967 

Before:
<img width="418" alt="Screenshot 2025-04-11 at 2 52 13 PM" src="https://github.com/user-attachments/assets/b6720324-5bf6-47d2-b06d-bf65efe65831" />

After:
<img width="420" alt="Screenshot 2025-04-11 at 2 51 51 PM" src="https://github.com/user-attachments/assets/3a9a7acb-aac5-4b68-8c15-26bb894ac1c0" />
