### PR TITLE
Add vertical line between info cards on landing page

### DIFF
--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -163,3 +163,21 @@ $featured-teaser-overhang: 1rem;
     fill: var(--stanford-black);
   }
 }
+
+.landing-page-info {
+  // Add vertical line between cards when side by side
+  .info-card:nth-child(even) {
+    .card:before  {
+      @include media-breakpoint-up(lg) {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: -1.438rem;
+        transform: translateY(-50%);
+        height: 80%;
+        width: 1px;
+        background-color: var(--stanford-70-black);
+      }
+    }
+  }
+}

--- a/app/components/landing_page/info_card_component.html.erb
+++ b/app/components/landing_page/info_card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-12 col-lg-6">
+<div class="info-card col-md-12 col-lg-6">
   <div class="card h-100">
     <div class="card-body">
       <div class="row">


### PR DESCRIPTION
Fixes #953 
<img width="1187" alt="Screenshot 2025-04-11 at 4 18 03 PM" src="https://github.com/user-attachments/assets/f331ed84-f678-4175-adef-4cb493348a2b" />
<img width="741" alt="Screenshot 2025-04-11 at 4 18 18 PM" src="https://github.com/user-attachments/assets/08050bb4-98f4-4f00-b3cb-710828c7ac82" />
