### PR TITLE
Remove serif fonts from landing page

### DIFF
--- a/app/assets/stylesheets/sulLanding.scss
+++ b/app/assets/stylesheets/sulLanding.scss
@@ -1,9 +1,8 @@
 .blacklight-landing_page {
   #main-container h1,
   h2 {
-    font-size: 2.25rem;
-    font-family: var(--font-family-serif);
-    font-weight: bold;
+    font-size: 1.75rem;
+    font-weight: 600;
   }
 }
 
@@ -11,10 +10,6 @@
 #main-container {
   padding: 0;
   overflow-x: hidden;
-}
-
-.collection-count {
-  font-family: var(--font-family-serif);
 }
 
 $featured-item-height: 22rem;


### PR DESCRIPTION
<img width="687" alt="Screenshot 2025-04-11 at 4 52 25 PM" src="https://github.com/user-attachments/assets/5eb2feb5-7376-4633-952a-ff9947a836d9" />
