### PR TITLE
Set border radius for repository cards

### DIFF
--- a/app/assets/stylesheets/cards.scss
+++ b/app/assets/stylesheets/cards.scss
@@ -1,5 +1,7 @@
 /* Shared styles across pages for Bootstrap cards */
 .al-repositories .card {
+  --bs-card-inner-border-radius: 0;
+  --bs-card-border-radius: 0;
   margin-top: 2rem;
   margin-bottom: -1.5rem;
   background-color: var(--grey-lighter);


### PR DESCRIPTION
Fixes #961 

Before:
<img width="460" alt="Screenshot 2025-04-14 at 11 11 43 AM" src="https://github.com/user-attachments/assets/f1c1403a-20cc-4374-ba5f-0352fadb3db8" />

After:
<img width="455" alt="Screenshot 2025-04-14 at 11 11 31 AM" src="https://github.com/user-attachments/assets/bf997697-f952-4c9a-914a-3f07e03a8f27" />
