### PR TITLE
Restyle grouped by collection results

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -6,6 +6,7 @@
 @import "arclight/app/assets/stylesheets/arclight/application";
 @import "sulBase";
 @import "featuredItemTeasers";
+@import "groupedResults";
 @import "sulHeader";
 @import "sulLanding";
 @import "sulCollection";

--- a/app/assets/stylesheets/groupedResults.css
+++ b/app/assets/stylesheets/groupedResults.css
@@ -1,0 +1,25 @@
+.al-grouped-results {
+  .al-grouped-title-bar {
+    background-color: var(--stanford-fog-light);
+    filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
+            drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2));
+    border-top: 5px solid var(--stanford-palo-alto-dark);
+  }
+
+  .grouped-documents {
+    margin-top: 2rem;
+
+    .documents-list {
+      margin-bottom: 0;
+    }
+
+    .grouped-results-count {
+      text-transform: uppercase;
+      font-weight: 600;
+    }
+
+    .al-grouped-more {
+      border: none;
+    }
+  }
+}

--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -1,4 +1,4 @@
-<div class='al-grouped-title-bar'>
+<div class='al-grouped-title-bar me-2'>
   <div class='row'>
     <div class='col-md-12'>
       <% if document.repository_config.present? %>
@@ -20,18 +20,23 @@
   </div>
 </div>
 
-<div class="grouped-documents">
-  <div class="al-grouped-more">
+<div class="grouped-documents ms-3">
+  <div class="grouped-results-count mb-3">
     <% if @group.total > 3 %>
-      <%= t('arclight.views.index.top_group_results', count: 3) %>
-      <%= link_to(
-        t('arclight.views.index.all_group_results', count: @group.total),
-        search_within_collection_url)
-      %>
+      <%= t('arclight.views.index.group_results_count_more') %>
     <% else %>
       <%= t('arclight.views.index.group_results_count', count: @group.total) %>
     <% end %>
   </div>
-
-  <%= helpers.render_document_index @group.docs %>
+  <div class="ms-0 ms-sm-4">
+    <%= helpers.render_document_index @group.docs %>
+  </div>
+  <div class="al-grouped-more mb-4">
+    <% if @group.total > 3 %>
+      <%= link_to(
+        t('arclight.views.index.all_group_results', count: helpers.number_with_delimiter(@group.total)),
+        search_within_collection_url, class: 'btn btn-secondary')
+      %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,12 @@ en:
         sections:
           contact_field: "Repository contact information"
           in_person_field: "In person information"
+      index:
+        all_group_results: View all %{count} results in this collection
+        group_results_count:
+          one: One result in this collection
+          other: "%{count} results in this collection"
+        group_results_count_more: Top 3 results in this collection
     within_collection_dropdown:
       all_collections: All collections
       this_collection: This collection


### PR DESCRIPTION
Before:
<img width="1044" alt="Screenshot 2025-04-14 at 2 37 49 PM" src="https://github.com/user-attachments/assets/cfd009b6-cf97-4c05-9c47-c85819a4f28e" />

After:
<img width="1037" alt="Screenshot 2025-04-14 at 2 37 27 PM" src="https://github.com/user-attachments/assets/53964258-aaae-49c4-a394-84588dd027a6" />
