### PR TITLE
Make the collection sidebar overview section collapsible

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -47,9 +47,36 @@
     margin-left: 0;
   }
 
-  /* this targets each button within the .al-collection-context-actions */
-  .al-collection-context-actions > * {
-    margin-right: 0.5rem;
+  .collection-info-section {
+    padding-bottom: 0;
+  }
+
+  #collection-nav {
+    /* h2 size and weight */
+    --bs-btn-font-size: 1.6rem;
+    font-weight: 500;
+    padding: 0;
+  }
+  
+  #collection-nav:hover {
+    text-decoration: underline;
+  }
+
+  /* Remove Bootstrap's focus ring from the button */
+  #collection-nav:focus,
+  #collection-nav:focus-visible,
+  #collection-nav:active {
+    outline: none;
+    box-shadow: none;
+  }
+
+  #collection-nav .bi-chevron-down {
+    margin-left: 0.75rem;
+    color: var(--stanford-digital-blue)
+  }
+
+  #collection-nav[aria-expanded="true"] .bi-chevron-down {
+    transform: rotate(180deg);
   }
 
   .al-show-actions-box-info .btn-secondary,

--- a/app/components/arclight/sidebar_component.html.erb
+++ b/app/components/arclight/sidebar_component.html.erb
@@ -2,7 +2,10 @@
   <%= render CollectionContextComponent.new(presenter: document_presenter(document), download_component: Arclight::DocumentDownloadComponent) %>
   <div id="sidebar-scroll-wrapper">
     <%= render 'show_tools', document: document %>
-    <%= collection_sidebar %>
+    <%= render CollectionOverviewComponent.new(document: document,
+                                              collection_presenter: document_presenter(document.collection),
+                                              partials: blacklight_config.show.metadata_partials)
+    %>
     <% if document.collection_components? %>
     <div id="collection-context" class="sidebar-section">
       <h2><%= t('arclight.views.show.has_content') %></h2>

--- a/app/components/blacklight/icons/chevron_down_component.rb
+++ b/app/components/blacklight/icons/chevron_down_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # Icon used in collection sidebar info section for expand/collapse
+    # Rotated 180 degrees via CSS transform
+    class ChevronDownComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+            fill="currentColor"
+            class="bi bi-chevron-down transition"
+            viewBox="0 0 16 16">
+            <path fill-rule="evenodd"
+                d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1#{' '}
+                .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708" />
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/collection_overview_component.html.erb
+++ b/app/components/collection_overview_component.html.erb
@@ -1,0 +1,28 @@
+<nav class="al-sidebar-navigation-context sidebar-section collection-info-section" aria-labelledby="collection-nav">
+  <div class="d-flex justify-content-between align-items-center mb-2">
+  <h2 class="mb-0 w-100 d-flex justify-content-between align-items-center">
+    <button class="btn btn-link d-flex align-items-center w-100"
+            id="collection-nav"
+            data-bs-toggle="collapse"
+            data-bs-target="#collection-info"
+            aria-expanded="false"
+            aria-controls="collection-info">
+      <span><%= t('arclight.views.show.context_nav.title') %></span>
+      <%= helpers.blacklight_icon('chevron_down') %>
+      </button>
+    </h2>
+  </div>
+
+  <ul class="nav collapse" id="collection-info" aria-labelledby="collection-nav">
+    <% partials.each do |section| %>
+      <% next unless has_section?(section) %>
+      <li class="nav-item w-100">
+        <%= link_to section_label(section),
+          document_section_path(section),
+          class: 'nav-link pl-0 ps-0 py-1',
+          data: { turbolinks: 'false' }
+        %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/components/collection_overview_component.rb
+++ b/app/components/collection_overview_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class CollectionOverviewComponent < Arclight::CollectionSidebarComponent
+end

--- a/spec/features/collection_overview_spec.rb
+++ b/spec/features/collection_overview_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Collection sidebar' do
+  before do
+    visit search_catalog_path
+    within('#facet-level') do
+      click_on('Collection')
+    end
+    within('#facet-repository') do
+      click_on('Archive of Recorded Sound')
+    end
+    find('#documents .document-title-heading a', text: 'Ambassador Auditorium Collection, 1974-1995').click
+  end
+
+  let(:expand_button) { find_by_id('collection-nav') }
+
+  it 'displays the expand button and collapsed section' do
+    expect(page).to have_css('#collection-info.collapse:not(.show)')
+    expect(expand_button['aria-expanded']).to eq('false')
+  end
+end


### PR DESCRIPTION
Closes https://github.com/sul-dlss/stanford-arclight/issues/907

<img width="502" alt="Screenshot 2025-04-15 at 4 26 26 PM" src="https://github.com/user-attachments/assets/a4bab7e9-4c5a-4273-8fca-58978d899654" />
<img width="482" alt="Screenshot 2025-04-15 at 4 34 18 PM" src="https://github.com/user-attachments/assets/46be4b6d-9384-4ef3-8fd2-e1ecd86df34c" />
