### PR TITLE
Configure digital icon to appear to document contents list

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -198,10 +198,6 @@ Those borders should look the same but have different types of markup in AL Core
   font-size: 10px;
 }
 
-.al-online-content-icon {
-  align-content: center;
-}
-
 /* arclight overrides */
 article.document .al-online-content-icon .blacklight-icons svg,
 .al-online-content-icon .blacklight-icons svg {

--- a/app/components/arclight/online_status_indicator_component.rb
+++ b/app/components/arclight/online_status_indicator_component.rb
@@ -15,7 +15,7 @@ module Arclight
 
     def icon_with_tooltip
       icon = <<~HTML
-        <span class="al-online-content-icon me-2" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Includes digital content">
+        <span class="al-online-content-icon" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Includes digital content">
             #{helpers.blacklight_icon(:online)}
         </span>
       HTML

--- a/app/components/arclight/search_result_title_component.html.erb
+++ b/app/components/arclight/search_result_title_component.html.erb
@@ -4,7 +4,6 @@
   <h3 class="index_title document-title-heading col">
     <span class="d-inline-block me-2 mb-2"><%= helpers.link_to_document @document, counter: @counter %></span>
 
-    <%= render Arclight::OnlineStatusIndicatorComponent.new(document: @document) %>
     <%= render CollectionUnitidPillComponent.new(document: @document) %>
 
     <%= tag.span class: 'al-document-container text-muted' do %>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -55,6 +55,7 @@ class CatalogController < ApplicationController
     # add_results_document_tool effectively creates an Blacklight action
     # Then actions are interated over in search_results_document_component.html.erb
     # See https://github.com/projectblacklight/blacklight/blob/6c6a72066a6330a815603e839b316958f6321dd7/lib/blacklight/configuration.rb#L560
+    config.add_results_document_tool(:online, component: Arclight::OnlineStatusIndicatorComponent)
     config.add_results_document_tool(:arclight_bookmark_control, component: Blacklight::Document::BookmarkComponent)
     config.bookmark_icon_component = Blacklight::Icons::BookmarkIconComponent
 


### PR DESCRIPTION
Fixes #848 

This brings us inline with the Arclight design and configuration pattern for this component. It differs in location from what is proposed in the issue, but is much more straightforward to implement.

Before:
<img width="1080" alt="Screenshot 2025-04-16 at 8 57 20 AM" src="https://github.com/user-attachments/assets/c71fef53-a1e7-420a-8c60-da95af8325bc" />

After:
<img width="1082" alt="Screenshot 2025-04-16 at 8 57 36 AM" src="https://github.com/user-attachments/assets/4575f624-d002-4e46-bbef-cc4442e03f5b" />
