### PR TITLE
Apply correct pill style to content list

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -161,8 +161,10 @@ Those borders should look the same but have different types of markup in AL Core
   }
 }
 
-/* These are the badges in the heirarchy that show the number of items */
-.documentHeader .bg-secondary {
+/* These are the badges in the heirarchy and content list
+that show the number of items */
+.documentHeader .bg-secondary,
+.al-collection-context .bg-secondary {
   --bs-secondary-rgb: var(--stanford-70-black-rgb);
   --bs-badge-font-weight: 400;
   --bs-border-radius: 0.625rem;


### PR DESCRIPTION
Fixes #985 

Before:
<img width="907" alt="Screenshot 2025-04-16 at 9 28 19 AM" src="https://github.com/user-attachments/assets/120d4868-bb21-4779-9078-7cf35ab89ed6" />

After:
<img width="916" alt="Screenshot 2025-04-16 at 9 28 04 AM" src="https://github.com/user-attachments/assets/ca8744ea-4b38-42c6-88cb-eb191d287f8e" />
