### PR TITLE
Make searchbar design responsive

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,6 +9,7 @@
 @import "groupedResults";
 @import "sulHeader";
 @import "sulLanding";
+@import "sulSearchbar";
 @import "sulCollection";
 @import "sulFacets";
 @import "cards";

--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -3,6 +3,12 @@
   --al-content-icon-color: var(--stanford-digital-blue)
 }
 
+/* make the content area full bleed */
+#main-container {
+  padding: 0;
+  overflow-x: hidden;
+}
+
 .navbar {
   --bs-navbar-nav-link-padding-y: 1rem;
   --bs-navbar-nav-link-padding-x: 1rem;  
@@ -56,12 +62,6 @@ label.toggle-bookmark {
   --bs-btn-font-size: 0.875rem;
   --bs-btn-border-radius: var(--bs-border-radius-sm);
   padding: 0.25rem;
-}
-
-/* TODO: may be able to remove this after */
-/* https://github.com/sul-dlss/stanford-arclight/issues/913 */
-.search-btn .blacklight-icons svg {
-  fill: var(--stanford-digital-blue);
 }
 
 /* NOTE: Component library is competing with some styles from Arclight. */

--- a/app/assets/stylesheets/sulHeader.css
+++ b/app/assets/stylesheets/sulHeader.css
@@ -1,141 +1,73 @@
+/* Search bar in header -- interior pages */
 .navbar-search {
-  .search-query-form {
-    gap: 0;
-    .input-group {
-      height: 2.75rem;
-    }
-  }
-}
-
-.blacklight-icons-search {
-  background-color: var(--bs-body-bg); 
-  align-self: center;
-  svg {
-    margin: 0 0 0 0.5rem;
-    fill: var(--stanford-80-black);
-  }
-}
-
-.input-group {
-  .search-autocomplete-wrapper {
-    border: none;
-  }
-
-  > .search-autocomplete-wrapper ul li:active {
-    color: var(--stanford-black);
-    background-color: var(--grey-lighter);
-  }
-}
-
-/* Make border 80% height to match designs */
-.input-group .search-autocomplete-wrapper::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  height: 80%;
-  width: 1px;
-  background-color: var(--stanford-40-black);
-
-}
-
-.search-btn-wrapper {
-  background-color: var(--bs-body-bg);
-  border: none;
-  height: 100%;
-  .search-btn {
-    border-radius: var(--bs-btn-border-radius);
-    margin: 0.5rem;
-    padding: 0.15rem var(--bs-btn-padding-x);
-  }
-}
-
-/* Arclight override */
-.input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) { 
-  border-top-right-radius: var(--bs-border-radius);
-  border-bottom-right-radius: var(--bs-border-radius);
-}
-
-.al-masthead ~ .navbar-search {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   background-color: var(--stanford-black);
   border-top: none;
   margin-bottom: 0;
-
-  .input-group-text {
-    background-color: var(--stanford-black);
-    border: none;
-    color: white;
-    font-weight: 700;
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
-  }
-
-  .within-collection-dropdown {
-    background-color: var(--bs-body-bg);
-    border-top-left-radius: var(--bs-border-radius);
-    border-bottom-left-radius: var(--bs-border-radius);
-
-    select {
-      border: none;
-    }
-
-    .input-group-text {
-      padding-left: 0;
-      padding-right: 1.25rem;
-    }
-  }
-
-  /* Make border about 80% height to match designs */
-  .within-collection-dropdown::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    right: 0;
-    transform: translateY(-50%);
-    height: 80%;
-    width: 1px;
-    background-color: var(--stanford-40-black);
-    pointer-events: none;
-
-  }
-
-  .custom-select.form-select {
-    width: auto;
-    flex: 0 0 auto;
-    border: none;
-    border-right: var(--stanford-black) 1px solid;
-  }
-
+   
   .form-select {
     background-size: 1.125rem 1.125rem;
     padding-top: 0;
     padding-bottom: 0;
-    border-radius: 0;
   }
 
-  .searchtips-link a {
-    color: white;
+  /* fill entire width on small screens, 75% when larger */
+  .search-query-form {
+    gap: 0;
+    flex: 0 0 100%;
+    max-width: 100%;
   }
 
-  .blacklight-icons-outline_info svg {
-    fill: white;  
+  .searchtips-links {
+    flex: 0 0 auto;
+    white-space: nowrap;
   }
 }
 
 @media (min-width: 992px) {
-  .al-masthead ~ .navbar-search .input-group:nth-of-type(2) {
-    min-width: 90%;
+  .navbar-search .search-query-form {
+    flex: 0 0 75%;
+    max-width: 75%;
   }
+}
+
+/* custom-select aka the fielded search (keyword, place, etc.) styles 
+   display only on larger screens
+*/
+.custom-select {
+  border-radius: 0;
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .custom-select {
+    display: block;
+  }
+}
+
+.al-masthead ~ .navbar-search .custom-select.form-select {
+  width: auto;
+  flex: 0 0 auto;
+  border: none;
+  border-right: var(--stanford-black) 1px solid;
+}
+
+/* Misc other styles */
+.searchtips-link a {
+  color: white;
+}
+
+.blacklight-icons-outline_info svg {
+  fill: white;
 }
 
 .beta-banner {
   background-color: var(--stanford-illuminating);
-  /* These aren't official stanford colors
-  but no combination of official interactive colors
-  meet accessibility contrast requirements on this background. */
   color: #000;
-  a {
-    color: #0065ad;
-  }
+}
+
+.beta-banner a {
+  color: #0065ad;
 }

--- a/app/assets/stylesheets/sulLanding.css
+++ b/app/assets/stylesheets/sulLanding.css
@@ -7,12 +7,9 @@
     font-size: 1.75rem;
     font-weight: 600;
   }
-}
-
-/* make the content area full bleed */
-#main-container {
-  padding: 0;
-  overflow-x: hidden;
+  .search-btn {
+    align-items: center;
+  }
 }
 
 #featured-item-wrapper {
@@ -45,21 +42,25 @@
     box-shadow: 0 0 0 0.25rem rgba(var(--stanford-digital-blue-rgb), 0.25);
   }
 
-  .input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) { 
-    border-top-left-radius: var(--bs-border-radius);
-    border-bottom-left-radius: var(--bs-border-radius);
-  }
-
   /* Remove left border from the search input on the landing page */
   .input-group .search-autocomplete-wrapper::before {
     width: 0px;
   }
-  
+
   .input-group input {
-    background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path fill="%23585754" d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>');
+    background-image: none;
     background-repeat: no-repeat;
     background-position: 0.5rem center;
-    padding-left: 2.75rem;
+    padding-left: 0.75rem;
+  }
+    
+  @media (min-width: 768px) {
+    .input-group input {
+      background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path fill="%23585754" d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>');
+      background-repeat: no-repeat;
+      background-position: 0.5rem center;
+      padding-left: 2.75rem;
+    }
   }
 
   li a {
@@ -105,11 +106,6 @@
   /* 30px matches height of stanford top white brand bar */
   padding-top: 30px;
   padding-bottom: 30px;
-}
-
-.search-query-form > .input-group {
-  padding: 0;
-  height: 3rem;
 }
 
 #autocomplete-popup {

--- a/app/assets/stylesheets/sulSearchbar.css
+++ b/app/assets/stylesheets/sulSearchbar.css
@@ -1,0 +1,120 @@
+/* Input group styles -- make sure to only impact input-groups within .navbar-search */
+.search-query-form {
+    .input-group {
+        height: 2.75rem;
+        border-radius: var(--bs-border-radius);
+    }
+
+    .input-group .search-autocomplete-wrapper {
+        border: none;
+    }
+
+    .input-group .search-autocomplete-wrapper ul li:active {
+        color: var(--stanford-black);
+        background-color: var(--grey-lighter);
+    }
+
+    /* make dividers 80% of height to match designs */
+    .input-group .search-autocomplete-wrapper::before {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 0;
+        transform: translateY(-50%);
+        height: 80%;
+        width: 1px;
+        background-color: var(--stanford-40-black);
+    }
+
+    .input-group.within-collection-dropdown {
+        background-color: var(--bs-body-bg);
+        border-radius: var(--bs-border-radius);
+        position: relative;
+    }
+
+    .input-group.within-collection-dropdown select {
+        border: none;
+    }
+
+    .input-group.within-collection-dropdown .input-group-text {
+        padding-left: 0;
+        padding-right: 1.25rem;
+        background-color: var(--stanford-black);
+        border: none;
+        color: white;
+        font-weight: 700;
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+    }
+
+    /* make dividers 80% of height to match designs */
+    .input-group.within-collection-dropdown::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        right: 0;
+        transform: translateY(-50%);
+        height: 80%;
+        width: 1px;
+        background-color: var(--stanford-40-black);
+        pointer-events: none;
+    }
+
+    /* Bootstrap overrides -- needs to be this specific in order to work */
+    .input-group.within-collection-dropdown> :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
+        border-top-left-radius: var(--bs-border-radius);
+        border-bottom-left-radius: var(--bs-border-radius);
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    /* Search button -- says "Search" or displays magnifying glass icon depending on size
+      See SearchButtonComponent
+    */
+    .search-btn-wrapper {
+        background-color: var(--bs-body-bg);
+        border: none;
+        height: 100%;
+        border-top-right-radius: var(--bs-border-radius);
+        border-bottom-right-radius: var(--bs-border-radius);
+        align-items: center;
+        align-self: center;
+    }
+
+    .search-btn-wrapper .search-btn {
+        border-radius: var(--bs-btn-border-radius);
+        margin: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        max-height: 2.25rem;
+        align-items: center;
+    }
+}
+
+@media (min-width: 768px) {
+    .search-btn-wrapper .search-btn {
+        padding: var(--bs-btn-padding-y) var(--bs-btn-padding-x);
+    }
+}
+
+/* Search icon -- the magnifying glass on left side of bar */
+.blacklight-icons-search {
+    background-color: transparent;
+}
+
+.blacklight-icons-search svg {
+    margin: 0;
+    fill: var(--grey-lighter);
+    width: 1.5rem;
+}
+
+@media (min-width: 786px) {
+    .blacklight-icons-search {
+        align-self: center;
+        background-color: var(--bs-body-bg);
+    }
+    
+    .blacklight-icons-search svg {
+        margin: 0 0 0 0.5rem;
+        fill: var(--stanford-80-black);
+    }
+}

--- a/app/components/arclight/search_bar_component.html.erb
+++ b/app/components/arclight/search_bar_component.html.erb
@@ -7,8 +7,10 @@
 
   <% c.with_before_input_group do %>
     <div class="input-group within-collection-dropdown">
-      <%= render(Blacklight::Icons::SearchComponent.new) %>
-
+      <%# don't show magnifying glass icon if screen smaller than md breakpoint %>
+      <span class="d-none d-md-flex">
+        <%= render(Blacklight::Icons::SearchComponent.new) %>
+      </span>
       <%= select_tag ('f[collection][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field' %>
     </div>
   <% end %>
@@ -23,6 +25,5 @@
 
   <% c.with_search_button do %>
     <%= render SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit')) %>
-    <%= render SearchTipsLinkComponent.new %>
   <% end %>
 <% end %>

--- a/app/components/blacklight/search_navbar_component.html.erb
+++ b/app/components/blacklight/search_navbar_component.html.erb
@@ -1,5 +1,6 @@
 <%= tag.div class: 'navbar-search navbar py-3', role: 'navigation', aria: { label: t('blacklight.search.header') } do %>
   <div class="container d-flex flex-wrap justify-content-start">
     <%= search_bar %>
+    <%= render SearchTipsLinkComponent.new %>
   </div>
 <% end %>

--- a/app/components/landing_page_search_bar_component.html.erb
+++ b/app/components/landing_page_search_bar_component.html.erb
@@ -13,7 +13,7 @@
       <%= f.search_field @query_param, value: @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control me-xl-3", autofocus: @autofocus, aria: { label: scoped_t('search.label') }  %>
     <% end %>
     <%= append %>
-    <%= search_button || render(Blacklight::SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))) %>
+    <%= with_search_button %>
   </div>
   <div class="search-links col-12">
     <ul class="ps-md-0 pt-3">

--- a/app/components/landing_page_search_bar_component.rb
+++ b/app/components/landing_page_search_bar_component.rb
@@ -9,7 +9,7 @@ class LandingPageSearchBarComponent < Arclight::SearchBarComponent
     @params = @params.merge(@params, group: true)
   end
 
-  def search_button
+  def with_search_button
     render SearchButtonComponent.new(id: "#{@prefix}search", text: scoped_t('submit'))
   end
 end

--- a/app/components/search_button_component.rb
+++ b/app/components/search_button_component.rb
@@ -4,10 +4,12 @@
 # button text to visually-hidden at all screen sizes
 class SearchButtonComponent < Blacklight::SearchButtonComponent
   def call
-    tag.div(class: 'search-btn-wrapper d-flex align-items-center') do
+    tag.div(class: 'search-btn-wrapper d-flex') do
       tag.button(class: 'btn btn-primary search-btn', type: 'submit', id: @id) do
-        tag.span(@text, class: 'visually-hidden submit-search-text') +
-          t('search.search_bar_button')
+        # Text visible only on md and larger screens
+        tag.span(t('search.search_bar_button'), class: 'd-none d-md-flex') +
+          # Icon visible only on smaller screens
+          tag.span(render(Blacklight::Icons::SearchComponent.new), class: 'd-md-none')
       end
     end
   end

--- a/app/components/search_tips_link_component.html.erb
+++ b/app/components/search_tips_link_component.html.erb
@@ -1,4 +1,4 @@
-<div class="align-self-center searchtips-link ms-2">
+<div class="align-self-center searchtips-link ms-lg-2 mt-2 mt-lg-0">
   <a class="" data-blacklight-modal="trigger" href="/search_tips">
   <%= helpers.blacklight_icon('outline_info', classes: 'me-1 pt-0 d-inline-block') %><%= t('search_tips.title') %></a>
 </div>


### PR DESCRIPTION
Closes #980

I had to reorganize the `sulHeader.css` file in order to really understand what was going on. It may look like a ton of changes but most of it is just reorganization -- hopefully not confusing.

Here are all the iterations:

<img width="1511" alt="Screenshot 2025-04-16 at 2 53 47 PM" src="https://github.com/user-attachments/assets/eafe8a89-0578-472a-a347-bc607c004977" />



<img width="973" alt="Screenshot 2025-04-16 at 2 53 56 PM" src="https://github.com/user-attachments/assets/da4dbc4c-7280-4dde-82d4-79b185c4b322" />



<img width="746" alt="Screenshot 2025-04-16 at 2 54 06 PM" src="https://github.com/user-attachments/assets/7057b00c-3e03-4e26-9fc4-1629d3807631" />



<img width="496" alt="Screenshot 2025-04-16 at 2 54 15 PM" src="https://github.com/user-attachments/assets/e02d9a14-d7c8-4fe6-b12d-efecb99956d9" />
