### PR TITLE
Add download bookmarks to CSV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,8 @@ gem 'blacklight_range_limit', '~> 9'
 
 gem 'config'
 
+gem 'csv', '~> 3.3'
+
 gem 'faraday', '~> 2' # for library hours
 gem 'faraday-retry'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -577,6 +577,7 @@ DEPENDENCIES
   capybara
   config
   cssbundling-rails (~> 1.1)
+  csv (~> 3.3)
   debug
   devise
   devise-guests (~> 0.8)

--- a/app/components/blacklight/icons/export_component.rb
+++ b/app/components/blacklight/icons/export_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # Cloud export/download icon
+    class ExportComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cloud-arrow-down-fill" viewBox="0 0 16 16">
+          <path d="M8 2a5.53 5.53 0 0 0-3.594 1.342c-.766.66-1.321 1.52-1.464 2.383C1.266 6.095 0 7.555 0 9.318 0 11.366 1.708 13 3.781 13h8.906C14.502 13 16 11.57 16 9.773c0-1.636-1.242-2.969-2.834-3.194C12.923 3.999 10.69 2 8 2m2.354 6.854-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 9.293V5.5a.5.5 0 0 1 1 0v3.793l1.146-1.147a.5.5 0 0 1 .708.708"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/bookmark_tools_component.html.erb
+++ b/app/components/bookmark_tools_component.html.erb
@@ -1,0 +1,6 @@
+<%= disclaimer_alert %>
+<%= export_info_alert %>
+
+<div class='d-flex justify-content-end pe-1'>
+  <%= export_link %>
+</div>

--- a/app/components/bookmark_tools_component.rb
+++ b/app/components/bookmark_tools_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Component for rendering bookmark tools and related alerts.
+class BookmarkToolsComponent < ViewComponent::Base
+  def initialize(response:, params:)
+    @params = Blacklight::Parameters.sanitize(params.to_unsafe_h)
+    @response = response
+    super
+  end
+
+  def disclaimer_alert
+    return unless current_page == 1
+
+    render AlertComponent.new(message: t('bookmarks.disclaimer_html'), type: :info)
+  end
+
+  def export_info_alert
+    return unless bookmarks_total_count > bookmarks_shown_count
+
+    render AlertComponent.new(message: t('bookmarks.export_info_html',
+                                         bookmarks_total_count: number_with_delimiter(bookmarks_total_count),
+                                         bookmarks_shown_count: bookmarks_shown_count),
+                              type: :info)
+  end
+
+  def export_link
+    link_to url_for(params:, format: 'csv'), download: csv_download do
+      helpers.blacklight_icon('export') + t('bookmarks.export_csv')
+    end
+  end
+
+  def render?
+    bookmarks_total_count.positive?
+  end
+
+  private
+
+  attr_reader :params, :response
+
+  delegate :current_page, to: :response
+
+  def bookmarks_shown_count
+    response.documents.count
+  end
+
+  def bookmarks_total_count
+    response.total
+  end
+
+  def csv_download
+    CsvService.filename(prefix: 'bookmarks')
+  end
+end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -5,6 +5,8 @@ class BookmarksController < CatalogController
   include Blacklight::Bookmarks
 
   configure_blacklight do |config|
+    config.index.respond_to.csv = true
     config.view_config(:index).collection_actions.delete(:group_toggle)
+    config.default_per_page = 50
   end
 end

--- a/app/services/csv_service.rb
+++ b/app/services/csv_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Service to generate a CSV from documents in a Solr response
+class CsvService
+  COLUMN_HEADERS = %w[id
+                      collection_id
+                      ead_id
+                      level
+                      title
+                      date
+                      containers
+                      description
+                      extent].freeze
+
+  def self.response_to_csv(response:)
+    new(response: response).generate_csv
+  end
+
+  def self.filename(prefix: 'response')
+    [prefix, '-', DateTime.now.strftime('%Y%m%d'), '.csv'].join
+  end
+
+  def initialize(response:)
+    @response = response
+  end
+
+  def generate_csv # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    CSV.generate do |csv|
+      csv << COLUMN_HEADERS
+      @response.documents.each do |doc|
+        csv << [
+          doc.id,
+          doc.collection_unitid,
+          doc.eadid,
+          doc.level,
+          ActionController::Base.helpers.strip_tags(doc.normalized_title),
+          doc.normalized_date,
+          doc.containers&.join('|'),
+          ActionController::Base.helpers.strip_tags(doc.abstract_or_scope),
+          doc.extent&.join('|')
+        ]
+      end
+    end
+  end
+end

--- a/app/views/bookmarks/index.csv.erb
+++ b/app/views/bookmarks/index.csv.erb
@@ -1,0 +1,1 @@
+<%= CsvService.response_to_csv(response: @response).html_safe %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,19 @@
+<% @page_title = t('blacklight.bookmarks.page_title', application_name: application_name) %>
+
+<div id="content" class="col-md-12">
+  <h1 class='page-heading pt-4'><%= t('blacklight.bookmarks.title') %></h1>
+
+  <%= render BookmarkToolsComponent.new(response: @response, params:)%>
+
+  <% if current_or_guest_user.blank? %>
+    <h2 class='section-heading'><%= t('blacklight.bookmarks.need_login') %></h2>
+  <% elsif @response.documents.blank? %>
+    <h2 class='section-heading'><%= t('blacklight.bookmarks.no_bookmarks') %></h2>
+  <% else %>
+    <%= render 'sort_and_per_page' %>
+    <%= render partial: 'tools', locals: { document_list: @response.documents } %>
+    <h2 class='section-heading visually-hidden'><%= t('blacklight.bookmarks.list_title') %></h2>
+    <%= render_document_index @response.documents %>
+    <%= render 'results_pagination' %>
+  <% end %>
+</div>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Add new mime types for use in respond_to blocks:
+Mime::Type.register 'text/csv', :csv

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,14 @@ en:
   blacklight:
     search:
       start_over: 'Clear all'
+  bookmarks:
+    export_csv: 'Export to CSV'
+    disclaimer_html: '<strong>Saved bookmarks are not permanent.</strong> They are stored in your browser and will be lost if you clear your session.'
+    export_info_html: |
+        <strong>You have %{bookmarks_total_count} items bookmarked, but only %{bookmarks_shown_count} appear on this
+        page</strong>. Exporting them will only include the current page of
+        bookmarks. You can export each page separately or increase the number shown per
+        page (up to 100).
   shared:
     beta_banner:
       beta_message_html: Please note this is a public beta version of this application. Visit the <a href="https://oac.cdlib.org/">Online Archive of California</a> for the most up to date information and to make a request.

--- a/spec/components/bookmark_tools_component_spec.rb
+++ b/spec/components/bookmark_tools_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BookmarkToolsComponent, type: :component do
+  subject(:component) { described_class.new(response:, params:) }
+
+  let(:response) do
+    instance_double(
+      Blacklight::Solr::Response,
+      documents: %w[document1 document2 document3],
+      total: 10,
+      current_page: 1
+    )
+  end
+
+  let(:params) { ActionController::Parameters.new({}) }
+
+  before do
+    with_request_url '/bookmarks.csv' do
+      render_inline(component)
+    end
+  end
+
+  it 'renders the bookmark tools' do
+    expect(page).to have_link(text: 'Export to CSV', href: '/bookmarks.csv')
+    expect(page).to have_text('Saved bookmarks are not permanent.')
+    expect(page).to have_text('Exporting them will only include the current page')
+  end
+
+  context 'when all the bookmarks are shown' do
+    let(:response) do
+      instance_double(
+        Blacklight::Solr::Response,
+        documents: %w[document1 document2 document3],
+        total: 3,
+        current_page: 1
+      )
+    end
+
+    it 'does not show the export info alert' do
+      expect(page).to have_no_text('Exporting them will only include the current page')
+    end
+  end
+end

--- a/spec/services/csv_service_spec.rb
+++ b/spec/services/csv_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CsvService do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '.response_to_csv' do
+    let(:response) do
+      instance_double(
+        Blacklight::Solr::Response,
+        documents: [
+          instance_double(
+            SolrDocument,
+            id: '1',
+            collection_unitid: 'collection_1',
+            eadid: 'ead_1',
+            level: 'level_1',
+            normalized_title: 'Title 1',
+            normalized_date: 'Date 1',
+            containers: ['Container 1', 'Container 2'],
+            abstract_or_scope: 'Description 1',
+            extent: ['Extent 1']
+          )
+        ]
+      )
+    end
+
+    it 'generates a CSV string from the response' do
+      expect(described_class.response_to_csv(response: response)).to eq(
+        "id,collection_id,ead_id,level,title,date,containers,description,extent\n" \
+        "1,collection_1,ead_1,level_1,Title 1,Date 1,Container 1|Container 2,Description 1,Extent 1\n"
+      )
+    end
+  end
+
+  describe '.filename' do
+    before do
+      travel_to Time.zone.parse('2024-04-12T10:00:00.000+00:00')
+    end
+
+    it 'returns a filename with the current date' do
+      expect(described_class.filename).to eq('response-20240412.csv')
+    end
+
+    it 'returns a filename with a custom prefix' do
+      expect(described_class.filename(prefix: 'custom')).to eq('custom-20240412.csv')
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/sul-dlss/stanford-arclight/issues/882
Fixes #885 

Adds export to CSV link with messaging about how bookmarks are saved/stored:
<img width="1021" alt="Screenshot 2025-05-01 at 8 31 21 AM" src="https://github.com/user-attachments/assets/8cad4e88-3ca6-4b5d-86c9-49ce1ff1216b" />

Export works by exporting a full page of bookmarks, so an alert shows if there are multiple pages of bookmarks. I've bumped the default per page setting to 50 so this should be avoided in most cases.
<img width="983" alt="Screenshot 2025-05-01 at 8 31 52 AM" src="https://github.com/user-attachments/assets/c37a78a0-a309-4150-83fd-5cbc490fbb21" />

This only addresses the CSV export. I thought it made sense to address the send to email feature as separate work.