### PR TITLE
This gives us a bit more space between the box number and bookmark/digital icon

### DIFF
--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -52,6 +52,10 @@ label.toggle-bookmark {
   color: var(--stanford-digital-blue);
 }
 
+.bookmark-toggle {
+  margin-left: 0.5rem;
+}
+
 .view-type .btn {
   --bs-btn-font-size: 0.875rem;
   --bs-btn-border-radius: var(--bs-border-radius-sm);

--- a/app/components/arclight/search_result_title_component.rb
+++ b/app/components/arclight/search_result_title_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Render a document title for a search result
+  class SearchResultTitleComponent < Blacklight::DocumentTitleComponent
+    def initialize(compact:, **args)
+      @compact = compact
+      super(**args)
+    end
+
+    def compact?
+      @compact
+    end
+
+    # Content for the document actions area
+    def actions # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      return [] unless @actions
+
+      if block_given?
+        @has_actions_slot = true
+        return super
+      end
+
+      (@has_actions_slot && get_slot(:actions)) ||
+        ([@document_component&.actions] if @document_component&.actions.present?) ||
+        [helpers.render_index_doc_actions(presenter.document, wrapping_class:)]
+    end
+
+    def wrapping_class
+      'index-document-functions col-md-3 col-xl-2 mb-4 mb-sm-0'
+    end
+  end
+end


### PR DESCRIPTION
At some widths, before:
<img width="213" alt="Screenshot 2025-04-17 at 3 18 18 PM" src="https://github.com/user-attachments/assets/ec4ddee8-02be-44bc-a2d7-e95b21179841" />

After:
<img width="259" alt="Screenshot 2025-04-17 at 3 16 13 PM" src="https://github.com/user-attachments/assets/20dbd9dd-0733-4968-b3bd-fcb98ed373ce" />
