### PR TITLE
Update collection digital content banner styles

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -254,14 +254,17 @@ article.document .al-online-content-icon .blacklight-icons svg {
   margin-bottom: 0;
   align-self: center;
   margin-left: 1rem;
+  font-weight: 600;
 }
 
 .online-contents.card {
   border: 0;
   padding: 0;
-  background-color: var(--green-white);
+  background-color: var(--stanford-fog-light);
+  filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
+  drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2));
   .card-body {
-    padding: 0.25rem 0.25rem 0.25rem 1rem;
+    padding: 1rem;
     border-left: 8px solid var(--stanford-palo-alto-dark);
   }
 }


### PR DESCRIPTION
Fixes #906 

Before:
<img width="1086" alt="Screenshot 2025-04-17 at 4 07 35 PM" src="https://github.com/user-attachments/assets/a6f6d2ac-a66b-411d-9928-e8b0b9a709ff" />


After:
<img width="1088" alt="Screenshot 2025-04-17 at 4 01 59 PM" src="https://github.com/user-attachments/assets/85ee0cae-3dc8-4868-a08a-1bc0042df85f" />
