### PR TITLE
Wrap non-embeddable digital resources in a bootstrap card

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -292,6 +292,22 @@ article.document .al-online-content-icon .blacklight-icons svg {
   background-color: var(--stanford-10-black);
 }
 
+.digital-object-list {
+  background-color: var(--stanford-fog-light);
+  filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
+  drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2)); 
+  .card-body {
+    padding: 0.5rem;
+    border-left: 8px solid var(--stanford-palo-alto-dark);
+  }
+  .blacklight-icons-external_link svg {
+    fill: var(--stanford-digital-blue);
+  }
+  ul {
+    margin: 0;
+  }
+}
+
 .view-type-group .btn:hover svg {
   fill: var(--stanford-digital-blue);
 }

--- a/app/components/blacklight/icons/external_link_component.rb
+++ b/app/components/blacklight/icons/external_link_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # Box arrow up-right icon to display with external links
+    class ExternalLinkComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16">
+          <path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5"/>
+          <path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/embed_component.html.erb
+++ b/app/components/embed_component.html.erb
@@ -3,9 +3,19 @@
   <h2 class="al-show-sub-heading"><%= t('arclight.views.show.embedded_content') %></h2>
   <%= render OembedViewerComponent.with_collection(embeddable_resources, document: @document) %>
 
-  <% linked_resources.each do |resource| %>
-    <div class="al-digital-object">
-      <%= link_to(resource.label, resource.href) %>
+  <% if linked_resources.any? %>
+    <div class="card digital-object-list mt-3">
+      <div class="card-body d-flex align-items-center">
+        <ul>
+          <% linked_resources.each do |resource| %>
+            <li class="al-digital-object">
+              <%= link_to(resource.label, resource.href) %>
+              <span class="ps-1"><%= render Arclight::OnlineStatusIndicatorComponent.new(document: @document)  %></span>
+              <span class="ps-1"><%= helpers.blacklight_icon('external_link') %></span>
+            </li>
+          <% end %>
+          </ul>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/components/embed_component.rb
+++ b/app/components/embed_component.rb
@@ -2,4 +2,13 @@
 
 # Render digital object links for a document
 class EmbedComponent < Arclight::EmbedComponent
+  EMBEDDABLE_RESOURCE_PATTERN = %r{https://purl.stanford.edu/([a-z]{2})(\d{3})([a-z]{2})(\d{4})}
+
+  def embeddable_resources
+    resources.select { |object| embeddable?(object) }.first(1)
+  end
+
+  def embeddable?(object)
+    object.href.match?(EMBEDDABLE_RESOURCE_PATTERN)
+  end
 end

--- a/spec/components/embed_component_spec.rb
+++ b/spec/components/embed_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmbedComponent, type: :component do
+  subject(:component) { described_class.new(document:, presenter: nil) }
+
+  let(:document) do
+    SolrDocument.new(id: 'abc123',
+                     digital_objects_ssm: ['{"label":"Preparing books for publication (3)","href":"jp131ht4213"}'])
+  end
+
+  before do
+    render_inline(component)
+  end
+
+  it 'renders the embeddable resource' do
+    expect(page).to have_text('Preparing books for publication (3)')
+  end
+
+  describe '#embeddable_resources' do
+    it 'selects the first embeddable resource' do
+      expect(component.embeddable_resources.first.href).to eq('https://purl.stanford.edu/jp131ht4213')
+    end
+  end
+end


### PR DESCRIPTION
We might want to consolidate some of these digital card styles, but I'll do that as a separate PR after this is merged.

Only links:
<img width="1016" alt="Screenshot 2025-04-18 at 8 50 42 AM" src="https://github.com/user-attachments/assets/01f9b201-a106-4f5e-a0f6-d12328074e16" />

Embed and links:
<img width="1031" alt="Screenshot 2025-04-18 at 8 04 50 AM" src="https://github.com/user-attachments/assets/de848ac0-ae18-4066-ba5f-4d0754bd7500" />
