### PR TITLE
Move containers info to document-info-pill

### DIFF
--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -12,7 +12,9 @@
         </span>
         <%= render CollectionUnitidPillComponent.new(document: document) %>
       </h3>
-      <%= render ExtentPillComponent.new(document: document, compact: compact?) %>
+      <div class="d-flex">
+        <%= render ExtentPillComponent.new(document: document, compact: compact?) %>
+      </div>
       <dl>
         <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
       </dl>

--- a/app/components/arclight/search_result_title_component.html.erb
+++ b/app/components/arclight/search_result_title_component.html.erb
@@ -5,12 +5,11 @@
     <span class="d-inline-block me-2 mb-2"><%= helpers.link_to_document @document, counter: @counter %></span>
 
     <%= render CollectionUnitidPillComponent.new(document: @document) %>
-
-    <%= tag.span class: 'al-document-container text-muted' do %>
-      <%= @document.containers.join(', ') %>
-    <% end if @document.containers.present? %>
-
-    <%= render ExtentPillComponent.new(document: @document, compact: compact?) %>
+    
+    <span class="d-flex">
+      <%= render ContainersPillComponent.new(document: @document, compact: compact?) %>
+      <%= render ExtentPillComponent.new(document: @document, compact: compact?) %>
+    </span>
   </h3>
 
   <%# these are set in the catalog_controller by add_results_document_tool %>

--- a/app/components/collection_unitid_pill_component.html.erb
+++ b/app/components/collection_unitid_pill_component.html.erb
@@ -1,3 +1,3 @@
-<div class="d-inline-block mb-2">
+<span class="d-inline-block mb-2">
   <%= tag.span unitid, class: 'badge rounded-pill collection-info-pill align-middle fs-6' %>
-</div>
+</span>

--- a/app/components/containers_pill_component.html.erb
+++ b/app/components/containers_pill_component.html.erb
@@ -1,0 +1,3 @@
+<%= tag.span class: 'badge rounded-pill document-info-pill me-1 fs-6' do %>
+  <%= containers %>
+<% end %>

--- a/app/components/containers_pill_component.rb
+++ b/app/components/containers_pill_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Component for rendering the container information
+class ContainersPillComponent < ViewComponent::Base
+  def initialize(document:, compact: false)
+    @document = document
+    @compact = compact
+    super
+  end
+
+  def containers
+    @document.containers.join(', ')
+  end
+
+  def render?
+    @document.containers.any? && !@compact
+  end
+end

--- a/app/components/extent_pill_component.html.erb
+++ b/app/components/extent_pill_component.html.erb
@@ -1,6 +1,5 @@
-<div class="d-flex">
-  <% extents.each do |extent| %>
-    <%= tag.span extent, class: 'badge rounded-pill document-info-pill me-1 fs-6' %>
-  <% end %>
-</div>
+<% extents.each do |extent| %>
+  <%= tag.span extent, class: 'badge rounded-pill document-info-pill me-1 fs-6' %>
+<% end %>
+
 

--- a/spec/components/containers_pill_component_spec.rb
+++ b/spec/components/containers_pill_component_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContainersPillComponent, type: :component do
+  subject(:component) { described_class.new(document:, compact:) }
+
+  let(:document) do
+    SolrDocument.new(id: 'abc123',
+                     containers_ssim: ['Box 3'])
+  end
+  let(:compact) { false }
+
+  before do
+    render_inline(component)
+  end
+
+  it 'renders the extents' do
+    expect(page).to have_text 'Box 3'
+  end
+
+  context 'when compact is true' do
+    let(:compact) { true }
+
+    it 'does not render the extents' do
+      expect(page).to have_no_text 'Box 3'
+    end
+  end
+end


### PR DESCRIPTION
Before:
<img width="967" alt="Screenshot 2025-04-18 at 5 11 47 PM" src="https://github.com/user-attachments/assets/6c6e0088-4d9b-454f-9a9d-a6ca0f202d0f" />


After:
<img width="988" alt="Screenshot 2025-04-18 at 5 11 22 PM" src="https://github.com/user-attachments/assets/5875ee06-42ab-47dc-b8cf-e95b489c1f30" />
