### PR TITLE
Adjust collection context box to match designs

### DIFF
--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -71,6 +71,10 @@ label.toggle-bookmark {
   fill: var(--stanford-digital-blue);
 }
 
+.btn-outline-secondary:hover svg {
+  fill: var(--stanford-digital-blue);
+}
+
 .btn-outline-secondary.remove svg {
   fill: var(--stanford-70-black);
 }

--- a/app/components/arclight/sidebar_component.html.erb
+++ b/app/components/arclight/sidebar_component.html.erb
@@ -1,5 +1,5 @@
 <div class="offcanvas-lg offcanvas-start sticky-lg-top" tabindex="-1" id="sidebar">
-  <%= render CollectionContextComponent.new(presenter: document_presenter(document), download_component: Arclight::DocumentDownloadComponent) %>
+  <%= render CollectionContextComponent.new(presenter: document_presenter(document), download_component: DocumentDownloadComponent) %>
   <div id="sidebar-scroll-wrapper">
     <%= render 'show_tools', document: document %>
     <%= render CollectionOverviewComponent.new(document: document,

--- a/app/components/collection_context_component.html.erb
+++ b/app/components/collection_context_component.html.erb
@@ -1,16 +1,26 @@
 <div class='al-show-actions-box mb-3'>
   <div class="al-actions-box-container">
     <button type="button" class="btn-close d-lg-none float-end mt-1 me-1" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>
-    <h2>Collection</h2>
-    <h3>
-      <span class="me-2 mb-2 d-inline-block"><%= title %></span>
-      <%= unitid %>
-    </h3>
+    <div class="container">
+      <div class="row gx-0">
+        <div class="col-xl-1 pt-1 visually-hidden-xl">
+          <%= helpers.blacklight_icon(:collection) %>
+        </div>
+        <div class="col-12 col-xl-11">
+          <h2 class="visually-hidden">Collection</h2>
 
-    <div class="al-collection-context-actions d-flex flex-wrap gap-1">
-      <%= render 'arclight/requests', document: collection %>
-      <%= document_download %>
-      <%= collection_info %>
+          <h3 class="h2 ps-2 mb-4">
+            <span class="me-2"><%= title %></span>
+            <%= unitid %>
+          </h3>
+
+          <div class="al-collection-context-actions d-flex flex-wrap gap-1 ps-2">
+            <%= render 'arclight/requests', document: collection %>
+            <%= document_download %>
+            <%= collection_info %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/components/document_download_component.html.erb
+++ b/app/components/document_download_component.html.erb
@@ -1,0 +1,25 @@
+<%# Overriden from ArcLight core to modify Bootstrap classes on buttons and links %>
+<div class="al-show-actions-box-downloads-container">
+  <% case files.size %>
+  <% when 2 %>
+    <div class="dropdown">
+      <button class="btn btn-outline-secondary btn-sm dropdown-toggle me-1" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <%= t("arclight.views.show.download.default") %>
+      </button>
+      <ul class="dropdown-menu">
+        <% files.each do |file| %>
+          <li><%= link_to(file.href, class: "dropdown-item", **@link_options) do %>
+            <%= icon_for(file.type) %> <%= dropdown_label(file) %>
+          <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% when 1 %>
+    <% files.each do |file| %>
+      <%= link_to(file.href, class: "btn btn-outline-secondary btn-sm me-1", **@link_options) do %>
+        <%= download_icon %> <%= label(file) %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/document_download_component.rb
+++ b/app/components/document_download_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# ViewComponent for rendering a document download link
+class DocumentDownloadComponent < Arclight::DocumentDownloadComponent
+end


### PR DESCRIPTION
Fixes #1000 

Before:
<img width="572" alt="Screenshot 2025-04-22 at 9 31 44 AM" src="https://github.com/user-attachments/assets/ce44b55c-9c96-4027-bdf6-76a4cc63da5a" />

After:
<img width="569" alt="Screenshot 2025-04-22 at 9 29 12 AM" src="https://github.com/user-attachments/assets/8bba8fe2-945b-483f-9637-3da0cc7e6931" />
