### PR TITLE
Render utility links (bookmarks, history) on landing page

### DIFF
--- a/app/components/landing_page/user_util_links_component.html.erb
+++ b/app/components/landing_page/user_util_links_component.html.erb
@@ -1,3 +1,5 @@
 <ul class="navbar-nav">
+  <li class="nav-item"><%= render 'blacklight/nav/bookmark' %></li>
+  <li class="nav-item"><%= render 'blacklight/nav/search_history' %></li>
   <li class="nav-item"><a href="#feedback" class="nav-link" data-bs-toggle="collapse">Feedback</a></li>
 </ul>

--- a/spec/features/navbar_spec.rb
+++ b/spec/features/navbar_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe 'Navbar' do
     end
 
     it "does not render 'Bookmark' and 'Search History' navigation items" do
-      expect(page).to have_css('.navbar-nav .nav-item', count: 1)
-      expect(page).to have_no_css('.navbar-nav .nav-item', text: 'Bookmarks')
-      expect(page).to have_no_css('.navbar-nav .nav-item', text: 'History')
+      expect(page).to have_css('.navbar-nav .nav-item', count: 3)
+      expect(page).to have_css('.navbar-nav .nav-item', text: 'Bookmarks')
+      expect(page).to have_css('.navbar-nav .nav-item', text: 'History')
     end
 
     it "always renders the 'Feedback' navigation item" do


### PR DESCRIPTION
<img width="344" alt="Screenshot 2025-04-22 at 2 28 48 PM" src="https://github.com/user-attachments/assets/df9e3f3f-cea6-4390-a878-18f431a156ab" />
