### PR TITLE
Adjust landing page search/image area layout

### DIFF
--- a/app/assets/stylesheets/sulLanding.css
+++ b/app/assets/stylesheets/sulLanding.css
@@ -1,5 +1,5 @@
 .blacklight-landing_page {
-  --featured-item-height: 22rem;
+  --featured-item-height: 18.75rem;
   --featured-teaser-overhang: 1rem;
 
   #main-container h1,

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -1,7 +1,7 @@
 <div id="landing-page-search" class="pb-3">
   <div class="container mx-auto">
     <div class="row">
-      <div class="col-sm-12 col-xxl-6 col-xl-7 col-lg-8 lg-pt-5 pe-5">
+      <div class="col-sm-12 col-xxl-6 col-xl-7 col-lg-8 pt-lg-5 pe-lg-5">
         <div class="d-flex">
           <h1 class="pe-3 mb-0"><%= t '.title' %></h1>
         </div>
@@ -16,7 +16,7 @@
             autocomplete_path: suggest_index_catalog_path)) %>
         </div>
       </div>
-      <div class="col-sm-12 col-xxl-6 col-xl-5 col-lg-4 featured-teasers">
+      <div class="col-sm-12 col-xxl-6 col-xl-5 col-lg-4 featured-teasers ps-4">
         <%= render 'landing_page/featured_item_teasers' %>
       </div>
     </div>


### PR DESCRIPTION
Fixes #975 

Before
<img width="1349" alt="Screenshot 2025-04-22 at 3 58 10 PM" src="https://github.com/user-attachments/assets/ce55ba43-3b32-4259-9c83-320868d0c040" />

After
<img width="1356" alt="Screenshot 2025-04-22 at 3 58 01 PM" src="https://github.com/user-attachments/assets/a6d904d2-e54a-427f-a1f7-d90b76c8c2d9" />
