### PR TITLE
Link to library hours from LibraryHoursComponent

### DIFF
--- a/app/components/landing_page/library_hours_component.rb
+++ b/app/components/landing_page/library_hours_component.rb
@@ -15,13 +15,9 @@ module LandingPage
     end
 
     def formatted_hours
-      return hours.closed_note if hours.closed_note
+      return link_to(hours_text, hours_link) if hours_link
 
-      return "Open until #{format_time(hours.hours_today.closes_at_time)}" if hours.open_now?
-
-      return "Closed until #{format_time(hours.next_open_hours.opens_at_time)}" if hours.next_open_hours
-
-      'Closed'
+      hours_text
     end
 
     delegate :seconds_until_next_half_hour, to: :TimeService
@@ -31,6 +27,20 @@ module LandingPage
     end
 
     private
+
+    def hours_text
+      return hours.closed_note if hours.closed_note
+
+      return "Open until #{format_time(hours.hours_today.closes_at_time)}" if hours.open_now?
+
+      return "Closed until #{format_time(hours.next_open_hours.opens_at_time)}" if hours.next_open_hours
+
+      'Closed'
+    end
+
+    def hours_link
+      hours_location_config&.url
+    end
 
     def hours
       @hours ||= LibraryHours.from_config(hours_location_config)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,20 +12,19 @@ hours_locations:
   - label: 'Green Library, 2nd Floor'
     library: 'spc'
     location: 'field-reading-room'
-    url: 'https://library.stanford.edu/libraries/special-collections'
+    url: 'https://library-hours.stanford.edu/'
   - label: 'Archive of Recorded Sound'
     library: 'ars'
     location: 'archive-recorded-sound'
-    url: 'https://library.stanford.edu/libraries/archive-recorded-sound'
+    url: 'https://library-hours.stanford.edu/'
   - label: 'Cubberley Education Library'
     library: 'cubberley'
     location: 'library-circulation'
-    url: 'https://library.stanford.edu/libraries/cubberley-education-library'
     closed_note: 'Closed for construction until 2025'
   - label: 'East Asia Library'
     library: 'eal'
     location: 'library-circulation'
-    url: 'https://library.stanford.edu/libraries/east-asia-library'
+    url: 'https://library-hours.stanford.edu/'
 
 aspace:
   url: <%= ENV['ASPACE_URL'] || 'http://archivesspace-stage.stanford.edu:8081' %>

--- a/spec/components/landing_page/library_hours_component_spec.rb
+++ b/spec/components/landing_page/library_hours_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe LandingPage::LibraryHoursComponent, type: :component do
 
     it 'renders the closed icon and message' do
       expect(page).to have_css('.library-closed')
-      expect(page).to have_text('Closed until 12pm')
+      expect(page).to have_link('Closed until 12pm', href: 'https://library-hours.stanford.edu/')
     end
 
     context 'when the library has a custom closed message' do


### PR DESCRIPTION
Fixes #952 

Adds configured link to the hours info:
<img width="664" alt="Screenshot 2025-04-24 at 1 29 48 PM" src="https://github.com/user-attachments/assets/fa5d52de-4a93-4905-8a78-4e9b7a9a52c3" />
