### PR TITLE
Set background of collection info box to fog-light

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -32,6 +32,7 @@
 
   .al-show-actions-box {
     border: 0;
+    background-color: var(--stanford-fog-light);
   }
 
   /* and add padding within .collection-sidebar */


### PR DESCRIPTION
Noticed this while doing other work that the background color was not right.

Before:
<img width="596" alt="Screenshot 2025-04-24 at 4 49 08 PM" src="https://github.com/user-attachments/assets/6c98999b-d7d3-44e5-9364-9bd09f9f3dd6" />

After
<img width="596" alt="Screenshot 2025-04-24 at 4 48 43 PM" src="https://github.com/user-attachments/assets/9f15af1a-37e5-41fb-9883-85d0f53d2f74" />
