### PR TITLE
Refactor and de-duplicate Bootstrap card styles

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -1,4 +1,50 @@
 /* Shared styles across pages for Bootstrap cards */
+
+/* Digital Content and Access Restriction cards share styles */
+#facet-digital_content,
+.online-contents,
+.digital-object-list {
+  --bs-card-border-width: 0;
+  --bs-card-border-radius: 0;
+  background-color: var(--stanford-fog-light);
+  filter: var(--drop-shadow-filter);
+  .card-body {
+    padding: 1rem;
+    border-left: 8px solid var(--stanford-palo-alto-dark);
+  }
+}
+
+#facet-digital_content {
+  margin-bottom: 1rem;
+  .facet-label,
+  .facet-select {
+    font-weight: bold;
+  }
+  .facet-count {
+    font-weight: normal;
+  }
+  .facet-limit-active {
+    background-color: var(--stanford-10-black);
+  }
+}
+
+.online-contents {
+  padding: 0;
+}
+
+.digital-object-list {
+  .card-body {
+    padding: 0.5rem;
+  }
+  .blacklight-icons-external_link svg {
+    fill: var(--stanford-digital-blue);
+  }
+  ul {
+    margin: 0;
+  }
+}
+
+/* Repository page cards have their own styles */
 .al-repositories .card {
   --bs-card-inner-border-radius: 0;
   --bs-card-border-radius: 0;

--- a/app/assets/stylesheets/groupedResults.css
+++ b/app/assets/stylesheets/groupedResults.css
@@ -1,8 +1,7 @@
 .al-grouped-results {
   .al-grouped-title-bar {
     background-color: var(--stanford-fog-light);
-    filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
-            drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2));
+    filter: var(--drop-shadow-filter);
     border-top: 5px solid var(--stanford-palo-alto-dark);
   }
 

--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -1,6 +1,8 @@
 :root {
   /* arclight override */
-  --al-content-icon-color: var(--stanford-digital-blue)
+  --al-content-icon-color: var(--stanford-digital-blue);
+  --drop-shadow-filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
+                        drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2));
 }
 
 /* make the content area full bleed */

--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -247,57 +247,6 @@ article.document .al-online-content-icon .blacklight-icons svg {
   font-weight: 600;
 }
 
-.online-contents.card {
-  border: 0;
-  padding: 0;
-  background-color: var(--stanford-fog-light);
-  filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
-  drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2));
-  .card-body {
-    padding: 1rem;
-    border-left: 8px solid var(--stanford-palo-alto-dark);
-  }
-}
-
-#facet-digital_content.card {
-  border: 0;
-  margin-bottom: 1rem;
-  background-color: var(--stanford-fog-light);
-  filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
-  drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2)); 
-    .card-body {
-    padding: 1rem;
-    border-left: 8px solid var(--stanford-palo-alto-dark);
-  }
-  .facet-label,
-  .facet-select {
-    font-weight: bold;
-  }
-  .facet-count {
-    font-weight: normal;
-  }
-}
-
-#facet-digital_content.card.facet-limit-active {
-  background-color: var(--stanford-10-black);
-}
-
-.digital-object-list {
-  background-color: var(--stanford-fog-light);
-  filter: drop-shadow(1px 4px 3px rgba(0, 0, 0, 0.25))
-  drop-shadow(-2px 2px 6px rgba(255, 255, 255, 0.2)); 
-  .card-body {
-    padding: 0.5rem;
-    border-left: 8px solid var(--stanford-palo-alto-dark);
-  }
-  .blacklight-icons-external_link svg {
-    fill: var(--stanford-digital-blue);
-  }
-  ul {
-    margin: 0;
-  }
-}
-
 .view-type-group .btn:hover svg {
   fill: var(--stanford-digital-blue);
 }


### PR DESCRIPTION
This moves Bootstrap card styles into `cards.css` and de-duplicates some styles (drop shadow, border, etc.) shared across these cards. No impact to display.

Example card:
<img width="948" alt="Screenshot 2025-04-28 at 3 46 57 PM" src="https://github.com/user-attachments/assets/ddcbd6f8-ed62-4904-976e-5c2121f2018b" />
