### PR TITLE
Redesign using these materials box

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -3,6 +3,7 @@
 /* Digital Content and Access Restriction cards share styles */
 #facet-digital_content,
 #access-and-use,
+#using-these-materials,
 .online-contents,
 .digital-object-list {
   --bs-card-border-width: 0;
@@ -32,6 +33,24 @@
 #access-and-use {
   address, dl, p {
     margin-bottom: 0;
+  }
+}
+
+#using-these-materials {
+  margin-top: -2rem;
+  margin-bottom: 2rem;
+  width: 100%;
+  @media (min-width: 576px) {
+    width: 35%;
+  }
+  @media (min-width: 992px) {
+    width: 40%;
+  }
+  @media (min-width: 1200px) {
+    width: 35%;
+  }
+  @media(min-width: 1400px) {
+    width: 28%;
   }
 }
 

--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -129,9 +129,13 @@
   color: black;
 }
 
+#contents {
+  border-top: none;
+}
+
 /* AL Core overrides for metadata sections and the top title areas
 Those borders should look the same but have different types of markup in AL Core */
-#using-these-materials,
+#summary .dl-invert,
 #metadata .dl-invert,
 .title-container,
 #about-this-level {
@@ -144,11 +148,7 @@ Those borders should look the same but have different types of markup in AL Core
   border-top: 1px solid #d1d1d1;
 }
 
-#using-these-materials {
-  ul {
-    color: var(--stanford-digital-blue);
-  }
-}
+
 
 .al-sidebar-navigation-context {
   ul {

--- a/app/components/using_these_materials_component.html.erb
+++ b/app/components/using_these_materials_component.html.erb
@@ -1,6 +1,9 @@
-<div id="using-these-materials">
-  <h2 class="al-show-sub-heading"><%= t("using_these_materials.heading") %></h2>
-  <div class="pt-2">
+<div id="using-these-materials" class="card float-end clearfix ms-0 ms-xl-4">
+  <div class="card-body">
+    <div class="d-flex align-items-center justify-content-between mb-3">
+      <h2 class="al-show-sub-heading fs-6 mb-0"><%= t("using_these_materials.heading") %></h2>
+      <%= image_tag 'rosette.png', height: '42', width: '42', class: 'ms-2' %>
+    </div>
     <ul>
       <li>
         <%= link_to t("using_these_materials.info_for_visitors"), repository_url, target: "_blank" %>
@@ -13,5 +16,9 @@
         <%= link_to t("using_these_materials.access_and_use"), "#access-and-use" %>
       </li>
     </ul>
+    <% if restrictions.present? %>
+      <h3 class="fs-6">Restrictions</h3>
+      <p><%= restrictions %></p>
+    <% end %>
   </div>
 </div>

--- a/app/components/using_these_materials_component.rb
+++ b/app/components/using_these_materials_component.rb
@@ -12,4 +12,12 @@ class UsingTheseMaterialsComponent < ViewComponent::Base
   def repository_url
     document.repository_config.url
   end
+
+  def restrictions
+    document.collection.fetch('accessrestrict_html_tesm', ['']).first.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def render?
+    document.collection?
+  end
 end

--- a/spec/components/using_these_materials_component_spec.rb
+++ b/spec/components/using_these_materials_component_spec.rb
@@ -5,7 +5,13 @@ require 'rails_helper'
 RSpec.describe UsingTheseMaterialsComponent, type: :component do
   subject(:component) { described_class.new(document:) }
 
-  let(:document) { SolrDocument.new(id: 'abc123', repository_ssm: ['Archive of Recorded Sound']) }
+  let(:document) do
+    SolrDocument.new(id: 'abc123',
+                     repository_ssm: ['Archive of Recorded Sound'],
+                     accessrestrict_html_tesm: ['Collection is open for research.'],
+                     level_ssm: ['collection'],
+                     component_level_isim: [0])
+  end
 
   before do
     render_inline(component)
@@ -16,5 +22,35 @@ RSpec.describe UsingTheseMaterialsComponent, type: :component do
     expect(page).to have_link 'Info for visitors', href: 'https://library.stanford.edu/libraries/archive-recorded-sound'
     expect(page).to have_link 'How to request', href: 'https://library.stanford.edu/access-rare-and-distinctive-materials'
     expect(page).to have_link 'Access and use', href: '#access-and-use'
+    expect(page).to have_text 'Restrictions'
+    expect(page).to have_text 'Collection is open for research.'
+  end
+
+  context 'when the document has no restrictions' do
+    let(:document) do
+      SolrDocument.new(id: 'abc123',
+                       repository_ssm: ['Archive of Recorded Sound'],
+                       accessrestrict_html_tesm: [''],
+                       level_ssm: ['collection'],
+                       component_level_isim: [0])
+    end
+
+    it 'does not render the restrictions' do
+      expect(page).to have_no_text 'Restrictions'
+    end
+  end
+
+  context 'when the document is not a collection' do
+    let(:document) do
+      SolrDocument.new(id: 'abc123',
+                       repository_ssm: ['Archive of Recorded Sound'],
+                       accessrestrict_html_tesm: ['Collection is open for research.'],
+                       level_ssm: ['item'],
+                       component_level_isim: [1])
+    end
+
+    it 'does not render the component' do
+      expect(page).to have_no_text 'Using these materials'
+    end
   end
 end


### PR DESCRIPTION
Part of #845 

I will add styles to the Access and Use section in a separate PR

This PR adds the "Using these materials" card.

<img width="1011" alt="Screenshot 2025-04-29 at 1 56 58 PM" src="https://github.com/user-attachments/assets/04a8375a-6914-41bc-b45e-692cb96d7bd6" />

