### PR TITLE
Align alerts and flash messages with component library

### DIFF
--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -101,3 +101,8 @@ label.toggle-bookmark {
   --bs-bg-opacity: 1;
   margin-left: 0.25rem;
 }
+
+#main-flashes .alert {
+  /* Make the top margin equal to the bottom margin */
+  margin-top: var(--bs-alert-margin-bottom)
+}

--- a/app/components/alert_component.html.erb
+++ b/app/components/alert_component.html.erb
@@ -1,0 +1,7 @@
+<div class="alert <%= @classes %> alert-dismissible shadow-sm d-flex align-items-center">
+    <%= render(icon.new) %>
+    <div class="text-body ps-2">
+        <div><%= message %></div>
+    </div>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Component used to comply with SUL component-library Alert styles
+class AlertComponent < Blacklight::System::FlashMessageComponent
+  attr_reader :message, :type
+
+  def initialize(message:, type:)
+    super
+    @message = message
+    @type = type
+  end
+
+  def icon
+    # Fallback is BootstrapInfoCircleFillComponent
+    {
+      'info' => Blacklight::Icons::BootstrapInfoCircleFillComponent,
+      'alert' => Blacklight::Icons::BootstrapInfoCircleFillComponent,
+      'notice' => Blacklight::Icons::BootstrapInfoCircleFillComponent,
+      'warning' => Blacklight::Icons::BootstrapExclamationTriangleFillComponent,
+      'danger' => Blacklight::Icons::BootstrapExclamationTriangleFillComponent,
+      'success' => Blacklight::Icons::BootstrapCheckCircleFillComponent,
+      'note' => Blacklight::Icons::BootstrapExclamationCircleFillComponent
+    }.fetch(type.to_s, Blacklight::Icons::BootstrapInfoCircleFillComponent)
+  end
+end

--- a/app/components/blacklight/icons/bootstrap_check_circle_fill_component.rb
+++ b/app/components/blacklight/icons/bootstrap_check_circle_fill_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # source: https://icons.getbootstrap.com/icons/check-circle-fill/
+    class BootstrapCheckCircleFillComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle-fill" viewBox="0 0 16 16">
+          <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/blacklight/icons/bootstrap_exclamation_circle_fill_component.rb
+++ b/app/components/blacklight/icons/bootstrap_exclamation_circle_fill_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # source: https://icons.getbootstrap.com/icons/exclamation-circle-fill/
+    class BootstrapExclamationCircleFillComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-circle-fill" viewBox="0 0 16 16">
+          <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M8 4a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4m.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/blacklight/icons/bootstrap_exclamation_triangle_fill_component.rb
+++ b/app/components/blacklight/icons/bootstrap_exclamation_triangle_fill_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # source: https://icons.getbootstrap.com/icons/exclamation-triangle-fill/
+    class BootstrapExclamationTriangleFillComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 16 16">
+          <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/blacklight/icons/bootstrap_info_circle_fill_component.rb
+++ b/app/components/blacklight/icons/bootstrap_info_circle_fill_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module Icons
+    # source: https://icons.getbootstrap.com/icons/info-circle-fill/
+    class BootstrapInfoCircleFillComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle-fill" viewBox="0 0 16 16">
+          <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2"/>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -16,8 +16,11 @@
     <div class="row justify-content-center">
       <%= form_with url: feedback_path, method: :post, class: 'col-md-8', html: { name: 'feedback_form' } do |f| %>
         <%= f.hidden_field :reporting_from, value: request.original_url %>
-        <div class="alert alert-info" role="alert">
-          <%= t('feedbacks.reporting_from', url: request.original_url) %>
+        <div role="alert" class="alert alert-info d-flex shadow-sm align-items-center">
+          <%= render(Blacklight::Icons::BootstrapInfoCircleFillComponent.new) %>
+          <div class="ps-2 text-body">
+            <div><%= t('feedbacks.reporting_from', url: request.original_url) %></div>
+          </div>
         </div>
         <div class="mb-3 row">
           <%= f.label :message, class: "col-md-3 col-form-label" %>

--- a/app/views/shared/_flash_msg.html.erb
+++ b/app/views/shared/_flash_msg.html.erb
@@ -1,6 +1,6 @@
 <%= render 'global_alerts/alerts' if Settings.global_alert %>
 <div class="flash_messages">
   <% [:success, :notice, :error, :alert].each do |type| %>
-    <%= render(Blacklight::System::FlashMessageComponent.with_collection(Array.wrap(flash[type]), type: type)) if flash[type] %>
+     <%= render(AlertComponent.with_collection(Array.wrap(flash[type]), type: type)) if flash[type] %>
   <% end %>
 </div>


### PR DESCRIPTION
Closes #534

I believe only `info` icon/alert styles are used in this app.

But, in case the Blacklight system flash generates any type other than `info`, it is good have the entire set of options available. 

<img width="1148" alt="Screenshot 2025-04-29 at 3 25 45 PM" src="https://github.com/user-attachments/assets/2389da6a-0ba8-4f77-a7eb-705f2eda59c4" />
<img width="1370" alt="Screenshot 2025-04-29 at 3 27 59 PM" src="https://github.com/user-attachments/assets/095c4449-964e-4130-8898-ad9c738c544e" />

