### PR TITLE
Make the Access and Use section collapsible

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -30,10 +30,6 @@
 }
 
 #access-and-use {
-  .card-body {
-    border-left: none;
-    border-top: 8px solid var(--stanford-palo-alto-dark);
-  }
   address, dl, p {
     margin-bottom: 0;
   }

--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -52,34 +52,6 @@
     padding-bottom: 0;
   }
 
-  #collection-nav {
-    /* h2 size and weight */
-    --bs-btn-font-size: 1.6rem;
-    font-weight: 500;
-    padding: 0;
-  }
-  
-  #collection-nav:hover {
-    text-decoration: underline;
-  }
-
-  /* Remove Bootstrap's focus ring from the button */
-  #collection-nav:focus,
-  #collection-nav:focus-visible,
-  #collection-nav:active {
-    outline: none;
-    box-shadow: none;
-  }
-
-  #collection-nav .bi-chevron-down {
-    margin-left: 0.75rem;
-    color: var(--stanford-digital-blue)
-  }
-
-  #collection-nav[aria-expanded="true"] .bi-chevron-down {
-    transform: rotate(180deg);
-  }
-
   .al-show-actions-box-info .btn-secondary,
   .al-collection-context-collapsible .btn-secondary {
     /* rather than overriding the entire components inherited from AL Core to change the .btn-secondary class to the more appropriate .btn-outline-secondary, just change the colors in these cases */
@@ -96,6 +68,44 @@
     margin: 0.5rem 0.5rem 1rem 0.5rem;
     padding: 0.5rem 1rem;
   }
+}
+
+/* 
+  ** expand/collapse h2 buttons with shared styles ** 
+*/
+#collection-nav,
+#access-use {
+  /* h2 size and weight */
+  --bs-btn-font-size: 1.6rem;
+  font-weight: 500;
+  padding: 0;
+}
+
+#collection-nav:hover, 
+#access-use:hover {
+  text-decoration: underline;
+}
+
+/* Remove Bootstrap's focus ring from the button */
+#collection-nav:focus,
+#collection-nav:focus-visible,
+#collection-nav:active 
+#access-use:focus,
+#access-use:focus-visible,
+#access-use:active {
+  outline: none;
+  box-shadow: none;
+}
+
+#collection-nav .bi-chevron-down,
+#access-use .bi-chevron-down {
+  margin-left: 0.75rem;
+  color: var(--stanford-digital-blue)
+}
+
+#collection-nav[aria-expanded="true"] .bi-chevron-down,
+#access-use[aria-expanded="true"] .bi-chevron-down {
+  transform: rotate(180deg);
 }
 
 /* match padding in document area for even space across page top */

--- a/app/components/access_component.html.erb
+++ b/app/components/access_component.html.erb
@@ -3,11 +3,25 @@
               metadata_attr: { layout: AccessMetadataLayoutComponent },
               presenter: presenter) %>
 <% end %>
-<% if access_content.present? %>
-  <div id="<%= t('arclight.views.show.sections.access_field').parameterize %>" class="card">
-    <div class="card-body">
-      <h2 class="al-show-sub-heading"><%= t 'arclight.views.show.sections.access_field' %></h2>
-      <%= access_content%>
+  
+  <% if access_content.present? %>
+    <div id="<%= t('arclight.views.show.sections.access_field').parameterize %>" class="card">
+      <div class="card-body">  
+        <h2 class="al-show-sub-heading mb-0">
+          <button class="btn btn-link d-flex align-items-center w-100"
+              id="access-use"
+              data-bs-toggle="collapse"
+              data-bs-target="#access-use-content"
+              aria-expanded="<%= collection? %>"
+              aria-controls="access-use">
+              <span><%= t 'arclight.views.show.sections.access_field' %></span>
+              <%= helpers.blacklight_icon('chevron_down') %>
+          </button>
+        </h2>
+    
+        <div class="nav collapse mt-2 <%= 'show' if collection? %>" id="access-use-content" aria-labelledby="access-use">
+          <%= access_content %>
+        </div>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe 'Collection Page' do
     it 'displays the normalized collection id in the URL' do
       expect(page.current_url).to eq('http://www.example.com/catalog/ars-0043_ambassador-auditorium-collection')
     end
+
+    it 'displays the Access and Use collapsible section in an expanded state' do
+      expect(page).to have_css('div#access-use-content.show')
+    end
   end
 
   context 'when visiting a collection page with an id derived from its title' do


### PR DESCRIPTION
Closes #865

 (underline on hover)
<img width="889" alt="Screenshot 2025-04-30 at 1 55 07 PM" src="https://github.com/user-attachments/assets/9dd2ccea-68f1-4286-be87-068f90588e03" />


<img width="1028" alt="Screenshot 2025-04-30 at 1 55 15 PM" src="https://github.com/user-attachments/assets/31fb9876-ee6e-4fed-b918-3fd0ffa164df" />
