### PR TITLE
Use sort_isi as the fallback when there is no relevancy score

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -257,7 +257,7 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, title_sort asc', label: 'relevance'
+    config.add_sort_field 'relevance', sort: 'score desc, sort_isi asc, title_sort asc', label: 'relevance'
     config.add_sort_field 'date_sort asc', label: 'date (ascending)'
     config.add_sort_field 'date_sort desc', label: 'date (descending)'
     config.add_sort_field 'creator_sort asc', label: 'creator (A-Z)'

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,11 +5,18 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
   include Arclight::SearchBehavior
 
-  ##
-  # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+  self.default_processor_chain += [:apply_group_sort_parameter]
+
+  # If no query is supplied when results are grouped and sorted by relevance,
+  # we adjust the sort order so that each group is sorted in component order
+  # with collections last.
+  def apply_group_sort_parameter(solr_parameters)
+    return unless blacklight_params[:group] == 'true' && blacklight_params[:q].blank? &&
+                  (blacklight_params[:sort] == 'relevance' || blacklight_params[:sort].blank?)
+
+    # sort_isi contains the component order starting with the collection at 0. To put
+    # the collection last but leave the remaining components in order we divide 1 by
+    # sort_isi values other than 0 and change the sort to DESC.
+    solr_parameters['group.sort'] = 'if(eq(sort_isi,0),0,div(1,field(sort_isi))) desc'
+  end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SearchBuilder do
+  subject(:search_builder) { described_class.new scope }
+
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:scope) { instance_double ApplicationController, blacklight_config:, action_name: nil }
+
+  describe '#apply_group_sort_parameter' do
+    subject(:solr_parameters) do
+      search_builder.with(query).processed_parameters
+    end
+
+    context 'when the results are grouped' do
+      context 'when there is no query and results are sorted by relevance' do
+        let(:query) { { q: '', group: 'true', sort: 'relevance' } }
+
+        it 'sets the group.sort solr parameter' do
+          expect(solr_parameters['group.sort']).to eq('if(eq(sort_isi,0),0,div(1,field(sort_isi))) desc')
+        end
+      end
+
+      context 'when there is no query and sort is not set (and defaults to relevance)' do
+        let(:query) { { q: '', group: 'true' } }
+
+        it 'sets the group.sort solr parameter' do
+          expect(solr_parameters['group.sort']).to eq('if(eq(sort_isi,0),0,div(1,field(sort_isi))) desc')
+        end
+      end
+
+      context 'when there is a query' do
+        let(:query) { { q: 'a query', group: 'true' } }
+
+        it 'does not set the group.sort solr parameter' do
+          expect(solr_parameters['group.sort']).to be_nil
+        end
+      end
+    end
+
+    context 'when results are not grouped' do
+      let(:query) { { q: '', sort: 'relevance' } }
+
+      it 'does not set the group.sort solr parameter' do
+        expect(solr_parameters['group.sort']).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1034

This only impacts the sort order when relevance is selected (or no sort order is selected -- defaulting to relevance).

When results are grouped and there is no query supplied: each of the groups will sort by collection title and the components within each group will sort in component order with the collection last.

When results are NOT grouped and there is no query supplied: the results will be sorted in component order starting with the collection (so all collections will be listed in title order first):

