### PR TITLE
Add new mobile styles for collection contents panel

### DIFF
--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -16,6 +16,7 @@ body {
   padding: 0;
   overflow-x: hidden;
   flex: 1;
+  z-index: 5;
 }
 
 .navbar {

--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -35,13 +35,6 @@
     background-color: var(--stanford-fog-light);
   }
 
-  /* and add padding within .collection-sidebar */
-  .al-show-actions-box,
-  #sidebar-scroll-wrapper {
-    /* padding around the light-green section */
-    padding: 2rem 2rem 2rem 3rem;
-  }
-
   .al-sidebar-navigation-context,
   #collection-context {
     /* overriding this from AL Core allows it to hit the edge of #sidebar-scroll-wrapper above */
@@ -69,6 +62,22 @@
     padding: 0.5rem 1rem;
   }
 }
+
+
+/* mobile padding */
+.collection-sidebar .al-show-actions-box,
+.collection-sidebar #sidebar-scroll-wrapper {
+  padding: 1rem;
+}
+
+/* lg padding */
+@media screen and (min-width: 992px) {
+  .collection-sidebar .al-show-actions-box,
+  .collection-sidebar #sidebar-scroll-wrapper {
+      padding: 2rem 2rem 2rem 3rem;
+    }
+}
+
 
 /* 
   ** expand/collapse h2 buttons with shared styles ** 

--- a/app/assets/stylesheets/sulHeader.css
+++ b/app/assets/stylesheets/sulHeader.css
@@ -1,3 +1,27 @@
+header {
+  position: sticky;
+  top: 0;
+  z-index: 500; /* brute force, but doesn't work otherwise */
+  background-color: white;
+}
+
+/* reset for the sticky header on lg screens */
+@media screen and (min-width: 992px) {
+  header {
+    position: relative;
+  } 
+}
+
+.sidebar-toggle {
+  margin-left: -1.5rem;
+  margin-bottom: 1rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  font-weight: 500;
+  font-size: 1rem;
+  background-color: var(--stanford-palo-alto-dark);
+}
+
 /* Search bar in header -- interior pages */
 .navbar-search {
   display: flex;

--- a/app/components/arclight/header_component.html.erb
+++ b/app/components/arclight/header_component.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header data-controller="offcanvas" data-offcanvas-target="header">
   <%= render 'shared/stanford_stripe' %>
   <%= top_bar %>
   <%= masthead %>

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -3,7 +3,7 @@
     <div class="row align-items-center">
       <div class="col-md-8 d-flex justify-content-center justify-content-md-start">
       <span class="align-self-center"><%= image_tag 'rosette.png', height: '42', width: '42' %></span>
-      <span class="h1"><%= heading %></span>
+      <span class="h1 text-start"><%= heading %></span>
       </div>
       <div class="col-md-4 d-none d-md-block">
         <nav class="navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">

--- a/app/components/arclight/sidebar_component.html.erb
+++ b/app/components/arclight/sidebar_component.html.erb
@@ -1,4 +1,4 @@
-<div class="offcanvas-lg offcanvas-start sticky-lg-top" tabindex="-1" id="sidebar">
+<div class="offcanvas-lg offcanvas-start sticky-lg-top" data-controller-"offcanvas" data-offcanvas-target="panel" tabindex="-1" id="sidebar">
   <%= render CollectionContextComponent.new(presenter: document_presenter(document), download_component: DocumentDownloadComponent) %>
   <div id="sidebar-scroll-wrapper">
     <%= render 'show_tools', document: document %>

--- a/app/components/collection_context_component.html.erb
+++ b/app/components/collection_context_component.html.erb
@@ -1,7 +1,7 @@
-<div class='al-show-actions-box mb-3'>
+<div class='al-show-actions-box mt-0'>
   <div class="al-actions-box-container">
     <button type="button" class="btn-close d-lg-none float-end mt-1 me-1" data-bs-dismiss="offcanvas" data-bs-target="#sidebar" aria-label="Close"></button>
-    <div class="container">
+    <div class="container ps-0">
       <div class="row gx-0">
         <div class="col-xl-1 pt-1 visually-hidden-xl">
           <%= helpers.blacklight_icon(:collection) %>
@@ -9,12 +9,12 @@
         <div class="col-12 col-xl-11">
           <h2 class="visually-hidden">Collection</h2>
 
-          <h3 class="h2 ps-2 mb-4">
+          <h3 class="h2 mb-4">
             <span class="me-2"><%= title %></span>
             <%= unitid %>
           </h3>
 
-          <div class="al-collection-context-actions d-flex flex-wrap gap-1 ps-2">
+          <div class="al-collection-context-actions d-flex flex-wrap gap-1">
             <%= render 'arclight/requests', document: collection %>
             <%= document_download %>
             <%= collection_info %>

--- a/app/components/landing_page/masthead_component.html.erb
+++ b/app/components/landing_page/masthead_component.html.erb
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-8 d-flex justify-content-center justify-content-md-start">
         <span class="align-self-center"><%= image_tag 'rosette.png', height: '42', width: '42' %></span>
-        <span class="h1"><%= heading %></span>
+        <span class="h1 text-start"><%= heading %></span>
       </div>
     </div>
   </div>

--- a/app/javascript/controllers/offcanvas_controller.js
+++ b/app/javascript/controllers/offcanvas_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["header"]
+
+  connect() {
+    this.panel = document.querySelector('.collection-sidebar #sidebar')
+    if (!this.panel) {
+      console.warn("Offcanvas panel not found in DOM")
+      return
+    }
+
+    this.handleResize = this.updatePanelPosition.bind(this)
+    window.addEventListener('resize', this.handleResize)
+
+    this.updatePanelPosition()
+  }
+
+  disconnect() {
+    window.removeEventListener('resize', this.handleResize)
+  }
+
+  updatePanelPosition() {
+    // Only run this behavior on small screens
+    if (window.innerWidth < 992) {
+      this.positionPanelBelowHeader()
+    } else {
+      this.resetPanelStyles()
+    }
+  }
+
+  positionPanelBelowHeader() {
+    const headerBottom = this.headerTarget.getBoundingClientRect().bottom
+    this.panel.style.top = `${headerBottom}px`
+    this.panel.style.position = 'fixed'
+    this.panel.style.height = `calc(100vh - ${headerBottom}px)`
+  }
+
+  resetPanelStyles() {
+    this.panel.style.top = ''
+    this.panel.style.position = ''
+    this.panel.style.height = ''
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         sections:
           contact_field: "Repository contact information"
           in_person_field: "In person information"
+        toggle_sidebar: Collection contents
         download:
           default: Finding aid / EAD
           multiple:

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Searching', :js do
     end
 
     it 'creates Clear all link with the group=true parameter' do
-      click_on('Clear all')
+      find('a.catalog_startOverLink').click.call(x: 1, y: 1)
 
       expect(page).to have_current_path(search_catalog_path(group: true))
     end


### PR DESCRIPTION
Closes #863

Notes:

- the `z-index` work is a bit wonky but didn't work otherwise
- the stimulus controller is a mix of stimulus targets and DOM queries, but I left a comment explaining
- the overall approach of calculating the mobile sidebar position in JS is needed due to the new sticky header and use of Bootstrap's `offcanvas` feature.

Question:
- I would like to confirm that this feature should be in effect at 992px (bs lg breakpoint) and below.


Definitely take this for a spin! I am open to a different approach.

closed, with new button 
<img width="879" alt="Screenshot 2025-05-02 at 4 26 14 PM" src="https://github.com/user-attachments/assets/394f672c-2fa6-4ff1-afdd-e939a221fbea" />


open
<img width="942" alt="Screenshot 2025-05-02 at 4 27 06 PM" src="https://github.com/user-attachments/assets/725b0038-c195-4883-a0ca-4ea48f7f2665" />
