### PR TITLE
Turn off "Clear all" and "Back to search" controls on show pages

### DIFF
--- a/app/components/search_context/null_server_applied_params_component.html.erb
+++ b/app/components/search_context/null_server_applied_params_component.html.erb
@@ -1,0 +1,2 @@
+<%# This template is intentionally left blank because we do not %>
+<%# want to render any search controls on show pages %>

--- a/app/components/search_context/null_server_applied_params_component.rb
+++ b/app/components/search_context/null_server_applied_params_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SearchContext
+  class NullServerAppliedParamsComponent < Blacklight::SearchContext::ServerAppliedParamsComponent
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,6 +58,7 @@ class CatalogController < ApplicationController
     config.add_results_document_tool(:online, component: Arclight::OnlineStatusIndicatorComponent)
     config.add_results_document_tool(:arclight_bookmark_control, component: Blacklight::Document::BookmarkComponent)
     config.bookmark_icon_component = Blacklight::Icons::BookmarkIconComponent
+    config.track_search_session.applied_params_component = SearchContext::NullServerAppliedParamsComponent
 
     config.add_results_collection_tool(:group_toggle)
     config.add_results_collection_tool(:sort_widget)


### PR DESCRIPTION
Fixes #1017 