### PR TITLE
Increase padding above collection source component

### DIFF
--- a/app/components/collection_source_component.html.erb
+++ b/app/components/collection_source_component.html.erb
@@ -1,4 +1,4 @@
-<div id="collection-source" class='pt-3'>
+<div id="collection-source" class='pt-4'>
   <span class="me-2" aria-hidden="true">
     <%= helpers.blacklight_icon(:collection_source, classes: 'collection-source-icon') %>
   </span>


### PR DESCRIPTION
Current -- looks a bit crowded:
<img width="1265" alt="Screenshot 2025-05-06 at 9 16 52 AM" src="https://github.com/user-attachments/assets/d6c9bf12-a5de-4052-ad09-ca19f6777877" />

This change:
<img width="1077" alt="Screenshot 2025-05-06 at 9 18 20 AM" src="https://github.com/user-attachments/assets/025a01f3-eb5f-4cb1-9111-2084e12a8479" />
