### PR TITLE
Configure Rack Attack and use Redis as the cache store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,8 @@ gem 'sidekiq', '~> 7.0'
 
 gem 'whenever', require: false
 
+gem 'rack-attack'
+
 gem 'recaptcha', '~> 5.16'
 
 gem 'redis', '~> 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.13)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-session (2.1.0)
@@ -595,6 +597,7 @@ DEPENDENCIES
   pg (~> 1.5)
   propshaft
   puma (~> 6.0)
+  rack-attack
   rack-cors (~> 2.0)
   rails (~> 7.2.2)
   recaptcha (~> 5.16)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+##
+# See https://github.com/kickstarter/rack-attack/blob/master/docs/example_configuration.md
+# for more configuration options
+
+# If RACK_ATTACK_REDIS_URL is set in the environment, turn on throttling and use Redis as the cache store
+if ENV['RACK_ATTACK_REDIS_URL']
+  Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(url: ENV['RACK_ATTACK_REDIS_URL'])
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  Rack::Attack.throttle('req/ip', limit: 300, period: 5.minutes, &:ip)
+
+  # Throttle search requests by IP (15rpm)
+  Rack::Attack.throttle('req/search/ip', limit: 15, period: 1.minute) do |req|
+    route = begin
+      Rails.application.routes.recognize_path(req.path) || {}
+    rescue StandardError
+      {}
+    end
+
+    req.ip if route[:controller] == 'catalog' && %w[index facet].include?(route[:action])
+  end
+
+  # Throttle document actions requests by IP (15rpm)
+  Rack::Attack.throttle('req/actions/ip', limit: 15, period: 1.minute) do |req|
+    route = begin
+      Rails.application.routes.recognize_path(req.path) || {}
+    rescue StandardError
+      {}
+    end
+
+    req.ip if route[:action].in? %w[email sms]
+  end
+
+  # Inform throttled clients about limits and when they will get out of jail
+  Rack::Attack.throttled_response_retry_after_header = true
+  Rack::Attack.throttled_responder = lambda do |request|
+    match_data = request.env['rack.attack.match_data']
+    now = match_data[:epoch_time]
+
+    headers = {
+      'RateLimit-Limit' => match_data[:limit].to_s,
+      'RateLimit-Remaining' => '0',
+      'RateLimit-Reset' => (now + (match_data[:period] - (now % match_data[:period]))).to_s
+    }
+
+    [429, headers, ["Throttled\n"]]
+  end
+
+  # Safelist the following IP ranges:
+  Rack::Attack.safelist_ip('171.64.0.0/14')
+  Rack::Attack.safelist_ip('10.0.0.0/8')
+  Rack::Attack.safelist_ip('172.16.0.0/12')
+end


### PR DESCRIPTION
Fixes #911 

Related puppet PR to set the RACK_ATTACK_REDIS_URL environment variable in prod https://github.com/sul-dlss/puppet/pull/12338