### PR TITLE
Add our own animated loading message for content lists

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -14,3 +14,4 @@
 @import "sulFacets";
 @import "sulBreadcrumbs";
 @import "cards";
+@import "loadingPlaceholder";

--- a/app/assets/stylesheets/loadingPlaceholder.css
+++ b/app/assets/stylesheets/loadingPlaceholder.css
@@ -1,0 +1,28 @@
+/* Remove Arclight's default loading animation */
+.al-sidebar-navigation-context,
+#collection-context {
+  turbo-frame[busy] {
+    &::before {
+      content: '';
+    }
+  }
+}
+
+turbo-frame[busy] + .loading-placeholder {
+  display: flex;
+}
+
+.loading-placeholder {
+  display: none;
+  background: linear-gradient(to right, var(--stanford-fog-light) 40%, #fff 50%, var(--stanford-fog-light) 60%);
+  animation: shimmer 1s infinite linear;
+  background-size: 300%;
+  background-position-x: 100%;
+  border-radius: 0.25rem;
+}
+
+@keyframes shimmer {
+  to {
+     background-position-x: 0%
+  }
+}

--- a/app/components/arclight/document_component.html.erb
+++ b/app/components/arclight/document_component.html.erb
@@ -37,6 +37,7 @@
 <div id="contents">
   <h2 class="al-show-sub-heading"><%= t 'arclight.views.show.contents' %></h2>
   <%= helpers.turbo_frame_tag "al-hierarchy-#{document.id}-document", loading: 'lazy', src: helpers.hierarchy_solr_document_path(id: document.id, paginate: true, key: '-document', per_page: 50) %>
+  <%= render LoadingPlaceholderComponent.new %>
 </div>
 <% end %>
 

--- a/app/components/arclight/document_components_hierarchy_component.html.erb
+++ b/app/components/arclight/document_components_hierarchy_component.html.erb
@@ -1,0 +1,39 @@
+<% if paginate? && @target_index >= 0 && @target_index >= @maximum_left_gap %>
+  <%# render the hierarchy as: outer (left) window ... window ... because our current document hierarchy is so far down the list it'd be buried %>
+  <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-left", loading: 'lazy', src: hierarchy_path(limit: @left_outer_window, key: '-left') %>
+  <%= render LoadingPlaceholderComponent.new %>
+  <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-gap" do %>
+    <ul>
+      <li>
+        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @left_outer_window, limit: @target_index - @left_outer_window - (@window / 2), key: '-gap'), class: 'btn btn-secondary btn-sm' %>
+      </li>
+    </ul>
+  <% end %>
+  <%= render LoadingPlaceholderComponent.new %>
+  <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-window", src: hierarchy_path(offset: @target_index - (@window / 2), limit: @window, key: '-window') %>
+  <%= render LoadingPlaceholderComponent.new %>
+  <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-right" do %>
+    <ul>
+      <li>
+        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @target_index + (@window / 2), key: '-right'), class: 'btn btn-secondary btn-sm' %>
+      </li>
+    </ul>
+  <% end %>
+  <%= render LoadingPlaceholderComponent.new %>
+<% elsif paginate? %>
+  <%# render the first N documents, and let the user expand the remaining if desired %>
+  <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-sidebar", loading: ('lazy' unless @target_index >= 0), src: hierarchy_path(limit: @maximum_left_gap, key: '-sidebar') %>
+  <%= render LoadingPlaceholderComponent.new %>
+  <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-right" do %>
+    <ul>
+      <li>
+        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @maximum_left_gap, key: '-right'), class: 'btn btn-secondary btn-sm' %>
+      </li>
+    </ul>
+  <% end %>
+  <%= render LoadingPlaceholderComponent.new %>
+<% else %>
+  <%# there aren't enough to bother paginating, so load them all at once %>
+  <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-sidebar", loading: ('lazy' unless @target_index >= 0), src: hierarchy_path(key: '-sidebar') %>
+  <%= render LoadingPlaceholderComponent.new %>
+<% end %>

--- a/app/components/arclight/document_components_hierarchy_component.rb
+++ b/app/components/arclight/document_components_hierarchy_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Display a document's constituent components with appropriate lazy-loading
+  # to keep the page load time reasonable.
+  class DocumentComponentsHierarchyComponent < ViewComponent::Base
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(document: nil, target_index: -1, minimum_pagination_size: 20, left_outer_window: 3, maximum_left_gap: 10, window: 10)
+      super
+
+      @document = document
+      @target_index = target_index&.to_i || -1
+      @minimum_pagination_size = minimum_pagination_size
+      @left_outer_window = left_outer_window
+      @maximum_left_gap = maximum_left_gap
+      @window = window
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    def paginate?
+      @document.number_of_children > @minimum_pagination_size
+    end
+
+    def hierarchy_path(**kwargs)
+      helpers.hierarchy_solr_document_path(id: @document.id, hierarchy: true, nest_path: params[:nest_path], **kwargs)
+    end
+  end
+end

--- a/app/components/arclight/sidebar_component.html.erb
+++ b/app/components/arclight/sidebar_component.html.erb
@@ -10,6 +10,7 @@
     <div id="collection-context" class="sidebar-section">
       <h2><%= t('arclight.views.show.has_content') %></h2>
       <%= turbo_frame_tag "al-hierarchy-#{document.root}", loading: 'lazy', src: hierarchy_solr_document_path(id: document.root, nest_path: @document.nest_path, hierarchy: true) %>
+      <%= render LoadingPlaceholderComponent.new %>
     </div>
     <% end %>
   </div>

--- a/app/components/loading_placeholder_component.html.erb
+++ b/app/components/loading_placeholder_component.html.erb
@@ -1,0 +1,4 @@
+<div class="loading-placeholder p-2 justify-content-center">
+  <%= image_tag 'rosette.png', height: '42', width: '42', class: 'p-0 m-0' %>
+  <p class="d-inline align-middle ms-3 m-0 p-0 pt-1 pe-4 fs-5"><%= t('loading_placeholder')%></p>
+</div>

--- a/app/components/loading_placeholder_component.rb
+++ b/app/components/loading_placeholder_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Component for rendering a placeholder when loading content asynchronously
+class LoadingPlaceholderComponent < ViewComponent::Base
+end

--- a/app/views/catalog/hierarchy.html.erb
+++ b/app/views/catalog/hierarchy.html.erb
@@ -19,3 +19,4 @@
 
   <%= render 'results_pagination' if params[:paginate] %>
 <% end %>
+<%= render LoadingPlaceholderComponent.new %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,3 +147,4 @@ en:
   search:
     constraints_title: 'Your selections: '
     search_bar_button: 'Search'
+  loading_placeholder: 'Loading contents...'


### PR DESCRIPTION
Fixes #902 

Leaving this as a draft until I update Arclight to make overrides needed here easier.

<img width="1709" alt="Screenshot 2025-05-06 at 4 30 20 PM" src="https://github.com/user-attachments/assets/70e5aaf8-060b-4351-85c2-06bf23d5bbd9" />
