### PR TITLE
Convert digital content tooltip to a popover

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -15,3 +15,4 @@
 @import "sulBreadcrumbs";
 @import "cards";
 @import "loadingPlaceholder";
+@import "popovers";

--- a/app/assets/stylesheets/popovers.css
+++ b/app/assets/stylesheets/popovers.css
@@ -1,0 +1,30 @@
+article.document .al-online-content-icon .blacklight-icons svg,
+.al-online-content-icon .blacklight-icons svg {
+  fill: var(--stanford-digital-blue);
+  height: 24px;
+  width: 24px;
+}
+
+button.al-online-content-icon {
+  height: 23px;
+  width: 32px;
+  padding: 0;
+  border: none;
+}
+
+article.document .al-online-content-icon .blacklight-icons svg {
+  margin-left: 0.5rem;
+}
+
+.popover {
+  --bs-popover-bg: var(--stanford-black);
+  --bs-popover-border-radius: 0.25rem;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.5));
+  font-weight: 600;
+}
+
+.popover-body {
+  --bs-popover-body-color: white;
+  --bs-popover-body-padding-y: 0.25rem;
+  --bs-popover-body-padding-x: 0.5rem;
+}

--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -223,28 +223,6 @@ that show the number of items */
   font-size: 10px;
 }
 
-/* arclight overrides */
-article.document .al-online-content-icon .blacklight-icons svg,
-.al-online-content-icon .blacklight-icons svg {
-  fill: var(--stanford-digital-blue);
-  height: 24px;
-  width: 24px;
-}
-
-article.document .al-online-content-icon .blacklight-icons svg {
-  margin-left: 0.5rem;
-}
-
-.tooltip-inner {
-  background-color: var(--stanford-digital-blue);
-  filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.5));
-  color: white;
-}
-
-.tooltip.bs-tooltip-top .tooltip-arrow::before {
-  border-top-color: var(--stanford-digital-blue);
-}
-
 .title-container .online-contents h2 {
   text-transform: none;
   margin-bottom: 0;

--- a/app/components/arclight/online_content_filter_component.html.erb
+++ b/app/components/arclight/online_content_filter_component.html.erb
@@ -1,4 +1,4 @@
-<%# Overrides AL Core to use custom icon/tooltip and layout %>
+<%# Overrides AL Core to use custom icon/popover and layout %>
 <div class="card online-contents">
   <div class="card-body d-flex align-items-center">
     <div class="d-flex">

--- a/app/components/arclight/online_status_indicator_component.html.erb
+++ b/app/components/arclight/online_status_indicator_component.html.erb
@@ -1,1 +1,1 @@
-<%=  icon_with_tooltip %>
+<%=  icon_with_popover %>

--- a/app/components/arclight/online_status_indicator_component.rb
+++ b/app/components/arclight/online_status_indicator_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Overrides Arclight's OnlineStatusIndicatorComponent to replace with a custom template that includes our tooltip
+# Overrides Arclight's OnlineStatusIndicatorComponent to replace with a custom template that includes our popover
 module Arclight
   # Render an online status indicator for a document
   class OnlineStatusIndicatorComponent < Blacklight::Component
@@ -13,13 +13,8 @@ module Arclight
       @document.online_content?
     end
 
-    def icon_with_tooltip
-      icon = <<~HTML
-        <span class="al-online-content-icon" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Includes digital content">
-            #{helpers.blacklight_icon(:online)}
-        </span>
-      HTML
-      icon.html_safe # rubocop:disable Rails/OutputSafety
+    def icon_with_popover
+      render OnlineContentPopoverComponent.new
     end
   end
 end

--- a/app/components/digital_content_facet_component.html.erb
+++ b/app/components/digital_content_facet_component.html.erb
@@ -1,8 +1,6 @@
 <div id="facet-digital_content" class="card <%='facet-limit-active' if @facet_field.active? %>">
     <div class="card-body d-flex align-items-center justify-content-between">
-        <span class="al-online-content-icon" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="Includes digital content">
-            <%= helpers.blacklight_icon(:online) %>
-        </span>
+        <%= icon_with_popover %>
         <ul class="facet-values list-unstyled d-inline ms-2 mb-0 flex-grow-1">
             <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
         </ul>

--- a/app/components/digital_content_facet_component.rb
+++ b/app/components/digital_content_facet_component.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
+# component for rendering a digital content facet
 class DigitalContentFacetComponent < Blacklight::FacetFieldListComponent
+  def icon_with_popover
+    render OnlineContentPopoverComponent.new
+  end
 end

--- a/app/components/online_content_popover_component.html.erb
+++ b/app/components/online_content_popover_component.html.erb
@@ -1,0 +1,1 @@
+<%= icon_with_popover %>

--- a/app/components/online_content_popover_component.rb
+++ b/app/components/online_content_popover_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Component for rendering an online content popover
+class OnlineContentPopoverComponent < ViewComponent::Base
+  def icon_with_popover
+    tag.button(class: 'al-online-content-icon btn',
+               data: { 'bs-toggle': 'popover',
+                       'bs-placement': 'top',
+                       'bs-content': 'Includes digital content' },
+               aria: { label: 'al-online-content-icon' }) do
+      helpers.blacklight_icon(:online).to_s
+    end
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,9 +8,9 @@ import Blacklight from "blacklight"
 import "arclight"
 
 Blacklight.onLoad(() => {
-    // Initialize Bootstrap tooltips
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+    // Initialize Bootstrap popovers
+    const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
+    const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
 })
 import BlacklightRangeLimit from "blacklight-range-limit";
 BlacklightRangeLimit.init({onLoadHandler: Blacklight.onLoad });

--- a/spec/components/online_content_popover_component_spec.rb
+++ b/spec/components/online_content_popover_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OnlineContentPopoverComponent, type: :component do
+  subject(:component) { described_class.new }
+
+  before do
+    render_inline(component)
+  end
+
+  it 'renders the button for the popover' do
+    expect(page).to have_css '.al-online-content-icon'
+    expect(page).to have_css 'button[data-bs-toggle="popover"]'
+    expect(page).to have_css 'button[data-bs-content="Includes digital content"]'
+  end
+end


### PR DESCRIPTION
Fixes #1058 
<img width="271" alt="Screenshot 2025-05-07 at 10 18 52 AM" src="https://github.com/user-attachments/assets/2bb05056-423f-46bb-88b2-392897730d3d" />
