### PR TITLE
Use btn-outline-secondary for clear bookmarks and search history buttons

### DIFF
--- a/app/views/bookmarks/_clear_bookmarks_widget.html.erb
+++ b/app/views/bookmarks/_clear_bookmarks_widget.html.erb
@@ -1,0 +1,7 @@
+<%# Override from Blacklight to set button classes %>
+<%= link_to t('blacklight.bookmarks.clear.action_title'), clear_bookmarks_path,
+    data: {
+      turbo_method: :delete,
+      turbo_confirm: t('blacklight.bookmarks.clear.action_confirm')
+    },
+    class: 'clear-bookmarks btn btn-outline-secondary' %>

--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -1,0 +1,25 @@
+<%# Override from Blacklight to set button classes %>
+<% @page_title = t('blacklight.search_history.page_title', :application_name => application_name) %>
+
+<div id="content" class="col-md-12">
+  <h1 class='page-heading pt-4'><%= t('blacklight.search_history.title') %></h1>
+  <% if @searches.blank? %>
+    <h2 class='section-heading'><%= t('blacklight.search_history.no_history') %></h2>
+  <% else %>
+    <%= link_to t('blacklight.search_history.clear.action_title'),
+                blacklight.clear_search_history_path,
+                data: {
+                  turbo_confirm: t('blacklight.search_history.clear.action_confirm'),
+                  turbo_method: :delete
+                },
+                class: 'btn btn-outline-secondary float-md-right float-md-end' %>
+    <h2 class='section-heading'><%= t('blacklight.search_history.recent') %></h2>
+    <table class="table table-striped search-history">
+      <% @searches.each_with_index do |search,index| %>
+      <tr id="document_<%= index + 1 %>">
+        <td class="query"><%= link_to_previous_search(search_state.reset(search.query_params).to_hash) %></td>
+      </tr>
+    <% end %>
+    </table>
+  <% end %>
+</div>


### PR DESCRIPTION
Fixes #1064 
<img width="1018" alt="Screenshot 2025-05-07 at 1 51 00 PM" src="https://github.com/user-attachments/assets/178e8c8d-786a-4ccb-893f-7c3df84d177e" />
<img width="540" alt="Screenshot 2025-05-07 at 1 51 08 PM" src="https://github.com/user-attachments/assets/2dbcce3a-c56b-42d6-aba9-11a5ffba0e74" />
