### PR TITLE
Turn off turbo prefetch

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,6 +1,7 @@
 <%# This file copies the equivalent file in Blacklight and adds Google Analytics in :head %>
 <% content_for(:head) do %>
   <%= render 'shared/analytics' %>
+  <meta name="turbo-prefetch" content="false">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-01-10/styles/sul.css" />
   <%= stylesheet_link_tag 'componentLibraryOverrides' %>
 <% end %>


### PR DESCRIPTION
We've done this elsewhere: https://github.com/sul-dlss/SearchWorks/pull/4322

Turning this off will reduce requests and may help prevent real users from encountering rack-attack throttling.