### PR TITLE
Add the Using this site page

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -5,7 +5,8 @@
 #access-and-use,
 #using-these-materials,
 .online-contents,
-.digital-object-list {
+.digital-object-list,
+#using-this-site .card {
   --bs-card-border-width: 0;
   --bs-card-border-radius: 0;
   background-color: var(--stanford-fog-light);

--- a/app/assets/stylesheets/sulBase.css
+++ b/app/assets/stylesheets/sulBase.css
@@ -108,3 +108,15 @@ label.toggle-bookmark {
   /* Make the top margin equal to the bottom margin */
   margin-top: var(--bs-alert-margin-bottom)
 }
+
+#using-this-site {
+  flex-basis: 100%;
+  padding: .5rem 1rem 1rem 1rem;
+}
+@media (min-width: 992px) {
+  /* same basis as navbar */
+  #using-this-site {
+    padding: 0;
+    flex-basis: 75%;
+  }
+}

--- a/app/controllers/using_this_site_controller.rb
+++ b/app/controllers/using_this_site_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UsingThisSiteController < ApplicationController
+end

--- a/app/views/using_this_site/index.html.erb
+++ b/app/views/using_this_site/index.html.erb
@@ -1,0 +1,67 @@
+<div class="d-flex">
+  <div id="using-this-site">
+    <nav aria-label="breadcrumb" class="w-100 my-4">
+      <ol class="breadcrumb-container list-unstyled d-flex">
+        <li id="breadcrumb-home">
+          <%= link_to 'Home', root_path %>
+        </li>
+        <li class="ms-1 breadcrumb-item active" aria-current="page">Using this site</li>
+      </ol>
+    </nav>
+    <div class="title-container mb-lg-4 mb-1 p-0 border-0">
+      <h1 class="title">Using this site</h1>
+    </div>
+    <div class="mb-4">
+      <h2>About Archival Collections at Stanford</h2>
+      <p>Use this portal to search and explore finding aids, also called collection guides. Search across all finding aids by keyword, subject, title, or browse by containing repositories.</p>
+    </div>
+    <div class="container p-0 m-0 mb-4">
+      <div class="row">
+        <div class="col-12 col-lg-3 align-self-center mb-3 mb-lg-0">
+          <p class="fst-italic">
+            Finding aids describe collections of primary sources and other unique, original, or rare materials held across the special collections repositories at Stanford University Libraries.
+          </p>
+        </div>
+        <!-- Spacer Column -->
+        <div class="col-12 col-lg-1"></div>
+        <div class="col-12 col-lg-8">
+          <div class="card">
+            <div class="card-body p-4">
+              <p class="mb-0">The finding aid provides information about:</p>
+              <ul>
+                <li>The origin of the collection</li>
+                <li>A brief biography or historical sketch of the individual or organization that created the collection</li>
+                <li>A statement of the intellectual and physical organization of the collection</li>
+                <li>A narrative "scope and content note" describing the intellectual content of the collection as a whole and of its major subdivisions</li>
+                <li>A detailed "contents list" providing a hierarchical listing of the collection from the series down to the file, or possibly the item, level</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <h3>How to search <%= render(Blacklight::Icons::SearchComponent.new) %></h3>
+      <p>To begin your search, use the search box on the landing page to enter in a keyword, phrase, individual, or organization to find collection material related to your search term. Click the search tips icon to help craft your query.</p>
+      <p>If you would like to browse all collections, from all repositories, click the "Browse all collections" link beneath the search box on the landing page. If you would like to first see each contributing repository and then their collections, click the "Browse repositories" link beneath the search box.</p>
+      <p>After performing a search, the results will be grouped by collection by default. What displays will be the components of an archival collection with a match to the search term, with the option to view all the matching results within a collection. If you would like to see all results, without the collection grouping, toggle to "all results" at the top of the page. 
+      </p>
+      <p class="mb-0">To further refine search results, use the facets on the right side of the page. </p>
+      <p class="pb-0">To browse a collection, use the Collection contents section on the right side of the page. Click the plus icon to expand the collection's hierarchy, and click on a linked component to see the Contents on the main section of the page. To search within the collection, use the search bar at the top of the page.</p>
+      <p>Digital content is signified by the <%= tag.span blacklight_icon(:online), class: 'al-online-content-icon px-1' %> icon.</p>
+      <p>Some digital objects will display in Archival Collections at Stanford, while others will link out to aggregate digital collections in SearchWorks or other access systems used by Stanford University Libraries. Please use the Feedback button to report access issues with digital collections.
+      </p>
+    </div>
+    <div class="card my-5">
+      <div class="card-body">
+        <h3>
+          <%= image_tag 'rosette.png', height: '42', width: '42', class: 'me-2', role: 'presentation' %>
+          Stanford University Libraries Open Metadata Policy
+        </h3>
+        <p>
+          Stanford University Libraries has an <a href="https://library.stanford.edu/stanford-university-libraries-open-metadata-policy">open metadata policy</a>. All finding aids in Archival Collections at Stanford fall under this policy and are released with a CC0 license. 
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
       about:
         heading: Using this site
         description: Use this portal to search and explore finding aids, also called collection guides. 
-        # button_html: <a href="" class="btn btn-outline-primary">Learn more about using this site</a>
+        button_html: <a href="/using-this-site" class="btn btn-outline-primary">Learn more about using this site</a>
 
 
   feedbacks:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
-
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   mount Blacklight::Engine => '/'
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
 
   get '/search_tips' => 'catalog#search_tips'
 
+  get '/using-this-site' => 'using_this_site#index'
+
   resource :feedback, only: :create
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
@@ -44,3 +46,4 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe 'Home Page' do
     expect(page).to have_css('h3', text: 'Cubberley Education Library')
   end
 
+  it 'links to the Using this site page' do
+    expect(page).to have_link('Learn more about using this site')
+    click_on 'Learn more about using this site'
+    expect(page).to have_current_path('/using-this-site')
+    expect(page).to have_css('h1', text: 'Using this site')
+  end
+
   it 'has the content warning' do
     expect(page).to have_css('.content-warning')
   end


### PR DESCRIPTION
Closes #881

- Since the text on this page is so highly customized, especially the 7 paragraphs in `How to search` I wasn't sure how much of it to put into `en.yml` -- I am happy to move it over if that is preferred.

 
<img width="1100" alt="Screenshot 2025-05-09 at 12 34 41 PM" src="https://github.com/user-attachments/assets/3d9ca36e-763a-4719-876c-dc9ba68d6f04" />
