### PR TITLE
Display digital content icon in grouped results headers

### DIFF
--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -11,6 +11,7 @@
           <%= helpers.link_to_document document %>
         </span>
         <%= render CollectionUnitidPillComponent.new(document: document) %>
+        <%= render Arclight::OnlineStatusIndicatorComponent.new(document: document)  %>  
       </h3>
       <div class="d-flex">
         <%= render ExtentPillComponent.new(document: document, compact: compact?) %>


### PR DESCRIPTION
Fixes #955 
<img width="1035" alt="Screenshot 2025-05-13 at 12 55 46 PM" src="https://github.com/user-attachments/assets/309c7580-a7b3-4473-9f96-1a0d8e81bb6b" />
