### PR TITLE
Set lh-base class on grouped title so underlines are not cramped on hover

### DIFF
--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -7,7 +7,7 @@
         </div>
       <% end %>
       <h3>
-        <span class="d-inline-block mb-2 me-2">
+        <span class="d-inline-block mb-2 me-2 lh-base">
           <%= helpers.link_to_document document %>
         </span>
         <%= render CollectionUnitidPillComponent.new(document: document) %>


### PR DESCRIPTION
Before:
<img width="998" alt="Screenshot 2025-05-13 at 2 27 06 PM" src="https://github.com/user-attachments/assets/12641b23-2127-4188-b7f9-d94d2ecfb3b1" />

After:
<img width="1013" alt="Screenshot 2025-05-13 at 2 26 53 PM" src="https://github.com/user-attachments/assets/c9c04bed-d7be-43cc-9bb6-f1c99180b392" />
