### PR TITLE
Watch for an embed success and remove the displayed link

### DIFF
--- a/app/components/embed_component.html.erb
+++ b/app/components/embed_component.html.erb
@@ -3,12 +3,12 @@
   <h2 class="al-show-sub-heading"><%= t('arclight.views.show.embedded_content') %></h2>
   <%= render OembedViewerComponent.with_collection(embeddable_resources, document: @document) %>
 
-  <% if linked_resources.any? %>
-    <div class="card digital-object-list mt-3">
+  <% if resources.any? %>
+    <%= tag.div(class: 'card digital-object-list mt-3', data: { controller: 'online-content' }) do %>
       <div class="card-body d-flex align-items-center">
         <ul>
-          <% linked_resources.each do |resource| %>
-            <li class="al-digital-object">
+          <% resources.each do |resource| %>
+            <li class="al-digital-object" data-online-content-target="link" data-href-value="<%= resource.href %>">
               <%= link_to(resource.label, resource.href) %>
               <span class="ps-1"><%= render Arclight::OnlineStatusIndicatorComponent.new(document: @document)  %></span>
               <span class="ps-1"><%= helpers.blacklight_icon('external_link') %></span>
@@ -16,6 +16,6 @@
           <% end %>
           </ul>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/components/oembed_viewer_component.html.erb
+++ b/app/components/oembed_viewer_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.div(class: 'al-oembed-viewer', data: viewer_attrs) do %>
-  <div class="al-digital-object">
+  <div class="al-digital-object d-none">
     <%= link_to(@resource.label, @resource.href) %>
   </div>
 <% end %>

--- a/app/javascript/controllers/online_content_controller.js
+++ b/app/javascript/controllers/online_content_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ 'link' ]
+
+  connect() {
+    // If the oembed-loaded event fires we know the oembed endpoint is valid
+    // so we can hide the fallback purl link
+    window.addEventListener('oembed-loaded', (event) => {
+      this.removeEmbededLink(event)
+    }, { once: true })
+  }
+
+  // Either hide the whole container if the fallback link is the only one in the list
+  // or remove the link from the list, leaving the container visible with the other links
+  removeEmbededLink(event) {
+    const embedUrl = event.detail.embedUrl
+    if (this.isOnlyOnlineContentLink(embedUrl)) {
+      this.element.classList.add('d-none')
+    } else {
+      this.removeEmbeddedLinkFromList(embedUrl)
+    }
+  }
+
+  // Checks whether the fallback link is the only one in the list
+  isOnlyOnlineContentLink(embedUrl) {
+    return this.onlineContentLinks().length === 1 &&
+      this.onlineContentLinks().includes(embedUrl)
+  }
+
+  // Returns an array of the online content link href values
+  onlineContentLinks() {
+    return this.linkTargets.map(function(link) {
+      return link.dataset.hrefValue
+    })
+  }
+
+  // Hides the fallback link leaving the other links visible
+  removeEmbeddedLinkFromList(embedUrl) {
+    this.linkTargets.forEach((link) => {
+      if (link.dataset.hrefValue === embedUrl) {
+        link.classList.add('d-none')
+      }
+    })
+  }
+}

--- a/app/javascript/controllers/sul_embed_controller.js
+++ b/app/javascript/controllers/sul_embed_controller.js
@@ -19,4 +19,16 @@ export default class SulEmbedController extends OembedController {
       ...(this.hideTitleValue && { hide_title: this.hideTitleValue })
     };
   }
+
+  // This gets called once we know the oembed endpoint is valid so
+  // we disptach an event to let us know we can remove the fallback purl link
+  loadEndPoint(oEmbedEndPoint) {
+    this.sendOembedLoadedEvent(this.data.get('urlValue'))
+    super.loadEndPoint(oEmbedEndPoint)
+  }
+
+  sendOembedLoadedEvent(embedUrl) {
+    const event = new CustomEvent('oembed-loaded', { detail: { embedUrl: embedUrl } })
+    window.dispatchEvent(event)
+  }
 }

--- a/spec/features/online_content_links_spec.rb
+++ b/spec/features/online_content_links_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OnlineContentLinks', :js do
+  before do
+    visit '/catalog/sc0097_aspace_ref33_thm'
+  end
+
+  it 'has a link to the non-embedded online content' do
+    expect(page).to have_link('A non-embedded online content link', href: 'https://purl.stanford.edu/zc892pd6364')
+  end
+
+  it 'removes the link to the non-embedded online content' do
+    expect(page).to have_css(".al-oembed-viewer[loaded='loaded']")
+    expect(page).to have_no_link('Comments on student answers (2)', href: 'https://purl.stanford.edu/vz772ry6707')
+  end
+end

--- a/spec/fixtures/ead/uarc/sc0097.xml
+++ b/spec/fixtures/ead/uarc/sc0097.xml
@@ -4416,6 +4416,11 @@ Stanford University School of Engineering Hero Award, 2011 </p>
                 <p>Comments on student answers (2): 10/19/1987</p>
               </daodesc>
             </dao>
+            <dao xlink:actuate="onRequest" xlink:href="zc892pd6364" xlink:show="new" xlink:title="A non-embedded online content link" xlink:type="simple">
+              <daodesc>
+                <p>A non-embedded online content link</p>
+              </daodesc>
+            </dao>
           </did>
         </c>
         <c id="aspace_ref35_hw3" level="file">


### PR DESCRIPTION
Fixes #1087 

This adds the possibly embed-able link to the list of displayed list of online content links, dispatches an event once we're sure the embed is really an embed, and removes the link if that event fires. This way if the purl isn't an embed the link it appears styled and within the same list as any other links if they exist.

Before:
<img width="1080" alt="Screenshot 2025-05-15 at 10 26 45 AM" src="https://github.com/user-attachments/assets/796b4212-9da9-4cad-a1e7-6f9b38e2d63f" />

After:
<img width="1065" alt="Screenshot 2025-05-15 at 10 28 24 AM" src="https://github.com/user-attachments/assets/3876ca9e-2aa2-42d3-abe1-2da7ce005301" />
