### PR TITLE
Keep call number pill and online content icon together

### DIFF
--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -10,8 +10,10 @@
         <span class="d-inline-block mb-2 me-2 lh-base">
           <%= helpers.link_to_document document %>
         </span>
-        <%= render CollectionUnitidPillComponent.new(document: document) %>
-        <%= render Arclight::OnlineStatusIndicatorComponent.new(document: document)  %>  
+        <span class="d-inline-block">
+          <%= render CollectionUnitidPillComponent.new(document: document) %>
+          <%= render Arclight::OnlineStatusIndicatorComponent.new(document: document)  %>
+        </span>
       </h3>
       <div class="d-flex">
         <%= render ExtentPillComponent.new(document: document, compact: compact?) %>


### PR DESCRIPTION
Fixes #1115 

Before:
<img width="730" alt="Screenshot 2025-05-15 at 2 15 49 PM" src="https://github.com/user-attachments/assets/54b31604-2852-409c-b8b9-3e72cb506585" />

After:
<img width="1040" alt="Screenshot 2025-05-15 at 6 00 27 PM" src="https://github.com/user-attachments/assets/ef444a3a-0639-4c21-81c4-fa5b1fb9f94b" />
