### PR TITLE
Resolve ARKs to catalog entry

### DIFF
--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This controller handles the resolution of ARK IDs to finding aids in the solr index
+class FindingAidsController < ApplicationController
+  def resolve
+    ark_id = params[:ark_id]
+    response = search_solr(ark_id)
+
+    unless response['response']['numFound'].positive?
+      raise ActiveRecord::RecordNotFound, "Finding aid not found for ARK ID: #{ark_id}"
+    end
+
+    solr_id = response['response']['docs'][0]['id']
+    redirect_to solr_document_path(solr_id)
+  end
+
+  private
+
+  delegate :repository, to: :blacklight_config
+
+  def search_solr(ark_id)
+    ark = ArkNormalizer.normalize(ark_id)
+    repository.search(
+      rows: 1,
+      fl: 'id',
+      fq: %(sul_ark_id_ssi:"#{ark}"),
+      q: '*:*',
+      sort: 'id ASC',
+      facet: false
+    )
+  end
+
+  def blacklight_config
+    @blacklight_config ||= CatalogController.blacklight_config.configure
+  end
+end

--- a/app/services/ark_normalizer.rb
+++ b/app/services/ark_normalizer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This class normalizes ARK IDs to the format needed to match with ARKs in Solr
+class ArkNormalizer
+  NAAN = Settings.ark_naan
+
+  # Adds hyphens to the UUID if missing, preserving the shoulder
+  # rubocop:disable Metrics/MethodLength
+  def self.normalize(ark)
+    match = ark.match(%r{\Aark:/#{NAAN}/([a-z]\d)([0-9a-f]{32})\z}io)
+    return ark unless match
+
+    shoulder = match[1]
+    uuid = match[2]
+
+    hyphenated_uuid = [
+      uuid[0, 8],
+      uuid[8, 4],
+      uuid[12, 4],
+      uuid[16, 4],
+      uuid[20, 12]
+    ].join('-')
+
+    "ark:/#{NAAN}/#{shoulder}#{hyphenated_uuid}"
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
+
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
@@ -38,6 +39,17 @@ Rails.application.routes.draw do
   get '/search_tips' => 'catalog#search_tips'
 
   get '/using-this-site' => 'using_this_site#index'
+
+  # Match ARKs that contain:
+  # - a respistory shoulder (one letter followed by one digit)
+  # - a UUID (with or without hyphens)
+  # In the ARK spec, strings that differ only by hyphens are considered identical
+  # rubocop :disable Layout/LineLength
+  get '/findingaid/*ark_id', to: 'finding_aids#resolve', as: :findingaid,
+                             constraints: lambda { |req|
+                               req.params[:ark_id] =~ %r{\Aark:/#{Settings.ark_naan}/[a-z]\d(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\z}i
+                             }
+  # rubocop :enable Layout/LineLength
 
   resource :feedback, only: :create
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,8 @@ global_alert: <%= ENV['GLOBAL_ALERT'] || false %>
 
 hours_api: 'https://library-hours.stanford.edu/'
 
+ark_naan: '22236'
+
 # Locations with a 'closed_note' will display the note in lieu of fetching hours from the API.
 hours_locations:
   - label: 'Green Library, 2nd Floor'

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -27,6 +27,21 @@ to_field 'aspace_config_set_ssi' do |_record, accumulator|
   accumulator << settings['aspace_config_set']
 end
 
+to_field 'sul_ark_link_ssi',
+         extract_xpath('/ead/archdesc/did/unitid[@type="ark"]/extref', to_text: false) do |_record, accumulator|
+  accumulator.map! do |node|
+    node['href'] if node
+  end
+end
+
+to_field 'sul_ark_id_ssi',
+         extract_xpath('/ead/archdesc/did/unitid[@type="ark"]/extref', to_text: false) do |_record, accumulator|
+  accumulator.map! do |node|
+    href = node['href']
+    href[%r{ark:/\S+}] if href
+  end
+end
+
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb"))
 
 # Some finding aids in OAC have empty elements that are indexed as empty strings in Solr.

--- a/spec/features/ark_routing_spec.rb
+++ b/spec/features/ark_routing_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ARK indexing and routing' do
+  let(:valid_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efc-dc7f-4ca7-bc10-d8456c3451a0" }
+  let(:no_hyphen_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efcdc7f4ca7bc10d8456c3451a0" }
+  let(:missing_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efc-dc7f-4ca7-bc10-d8456c3451b3" }
+  # This ARK has no shoulder (s1)
+  let(:invalid_ark_id) do
+    "ark:/#{Settings.ark_naan}/9f562efc-dc7f-4ca7-bc10-d8372c3451a0"
+  end
+
+  context 'when a valid ARK is found in Solr' do
+    before do
+      visit "/findingaid/#{valid_ark_id}"
+    end
+
+    it 'redirects to the catalog page when ARK ID is found' do
+      expect(page).to have_current_path('/catalog/sc0097')
+    end
+  end
+
+  context 'when the route requests an ARK with no hyphens' do
+    before do
+      visit "/findingaid/#{no_hyphen_ark_id}"
+    end
+
+    it 'redirects to the catalog page when ARK ID is found' do
+      expect(page).to have_current_path('/catalog/sc0097')
+    end
+  end
+
+  context 'when a valid ARK has no match in Solr' do
+    before do
+      visit "/findingaid/#{missing_ark_id}"
+    end
+
+    it 'shows not found message' do
+      expect(page).to have_content('Finding aid not found')
+      expect(page.status_code).to eq(404)
+    end
+  end
+
+  context 'with an invalid ARK' do
+    before do
+      visit "/findingaid/#{invalid_ark_id}"
+    end
+
+    it 'shows not found message' do
+      expect(page.status_code).to eq(404)
+    end
+  end
+end

--- a/spec/fixtures/ead/uarc/sc0097.xml
+++ b/spec/fixtures/ead/uarc/sc0097.xml
@@ -41,6 +41,12 @@
       </repository>
       <unittitle>Donald E. Knuth papers</unittitle>
       <unitid>SC0097</unitid>
+      <unitid type="ark">
+        <extref xlink:actuate="onLoad" xlink:href="https://archives.stanford.edu/ark:/22236/s19f562efc-dc7f-4ca7-bc10-d8456c3451a0" xlink:show="new">Archival Resource Key</extref>
+      </unitid>
+      <unitid type="ark-superseded">
+        <extref xlink:actuate="onLoad" xlink:href="https://oac.cdlib.org/findaid/ark:/13030/testark/" xlink:show="new">Previous Archival Resource Key</extref>
+      </unitid>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">39.75 Linear Feet</extent>
       </physdesc>


### PR DESCRIPTION
Closes #896
I believe this closes #895 as well (we decided not to index `ark-superceded` ) 
