### PR TITLE
Move online content below first metadata section for collections

### DIFF
--- a/app/components/document_body_collection_component.html.erb
+++ b/app/components/document_body_collection_component.html.erb
@@ -1,4 +1,3 @@
-<%= embed_html %>
 <%# Extract the first item %>
 <% first_partial, *rest_partials = metadata_partials %>
 <div id="summary-container" class="metadata row">
@@ -12,6 +11,7 @@
     <%= render UsingTheseMaterialsComponent.new(document:) %>
   </div>
 </div>
+<%= embed_html %>
 <% rest_partials.each do |partial| %>
   <div class="metadata">
     <%= render Arclight::MetadataSectionComponent.with_collection([partial],

--- a/app/components/embed_component.html.erb
+++ b/app/components/embed_component.html.erb
@@ -4,7 +4,7 @@
   <%= render OembedViewerComponent.with_collection(embeddable_resources, document: @document) %>
 
   <% if resources.any? %>
-    <%= tag.div(class: 'card digital-object-list mt-3', data: { controller: 'online-content' }) do %>
+    <%= tag.div(class: 'card digital-object-list mt-3 mb-2', data: { controller: 'online-content' }) do %>
       <div class="card-body d-flex align-items-center">
         <ul>
           <% resources.each do |resource| %>


### PR DESCRIPTION
Fixes #1124 

Possibly controversial...

We seem to have more collections with online content at the collection level and the current display doesn't look great. This moves the online content below the first metadata section.

Before:
<img width="1114" alt="Screenshot 2025-05-19 at 8 43 37 AM" src="https://github.com/user-attachments/assets/f457f5a4-47f5-4302-a244-e9ce82477897" />

After:
<img width="1141" alt="Screenshot 2025-05-19 at 9 07 41 AM" src="https://github.com/user-attachments/assets/153bb425-b558-4d18-bd02-8dc00591bcad" />
<img width="1140" alt="Screenshot 2025-05-19 at 9 06 29 AM" src="https://github.com/user-attachments/assets/a67377ea-ec6b-419d-a4de-d94017fac70d" />
