### PR TITLE
Do not group results when the results are limited to collections

### DIFF
--- a/app/javascript/controllers/search_form_controller.js
+++ b/app/javascript/controllers/search_form_controller.js
@@ -9,12 +9,14 @@ export default class extends Controller {
     event.preventDefault();
 
     const selectElement = this.element.querySelector('[id^="within_collection"]');
+    const levelFacet = this.element.querySelector('input[name="f[level][]"]');
     const groupByCollection = this.element.querySelector('input[name="group"]');
 
     // See https://github.com/sul-dlss/stanford-arclight/issues/544
     // We default to grouping results by collection, but if the user
-    // is searching within a collection then default to all results.
-    if (selectElement.value) {
+    // is searching within a collection or limits their results to
+    // collections only then default to all results.
+    if (selectElement.value || levelFacet?.value == 'Collection') {
       groupByCollection?.remove();
     }
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe 'Searching', :js do
     end
   end
 
+  context 'when the level facet is limited to collections' do
+    it 'does not group by collection' do
+      visit arclight_engine.collections_path
+      fill_in 'q', with: 'knuth'
+      within '.search-btn-wrapper' do
+        click_on 'Search'
+      end
+
+      expect(page).to have_content(/You searched for:\s*Keyword knuth/)
+      expect(page.current_url).not_to include('group=true')
+    end
+  end
+
   context 'when within a collection and user selects group by all collections' do
     it 'groups by collection' do
       visit solr_document_path(id: 'ars-0043')


### PR DESCRIPTION
It doesn't make sense to group results by collection when the results are limited only to collections.