### PR TITLE
Add bottom border to sidebar scroll section

### DIFF
--- a/app/assets/stylesheets/sulCollection.css
+++ b/app/assets/stylesheets/sulCollection.css
@@ -17,7 +17,15 @@
       #sidebar-scroll-wrapper {
         overflow-y: auto;
         overflow-x: hidden;
-        height: calc(100vh - 180px);
+        height: calc(100vh);
+        background:
+        linear-gradient(rgb(255,255,255) 30%, rgba(255, 255, 255, 0)), 
+        linear-gradient(rgba(255, 255, 255, 0), rgb(255,255,255) 70%) 0 100%,
+        radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)),
+        radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)) 0 100%;
+        background-attachment: local, local, scroll, scroll;
+        background-repeat: no-repeat;
+        background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
       }
     }
   }


### PR DESCRIPTION
This CSS does the shadow style border:
<img width="1213" alt="Screenshot 2025-05-20 at 3 33 08 PM" src="https://github.com/user-attachments/assets/2e3d1eb0-ab28-4c2c-9c8a-a30a90d0b3c7" />


~~ 

I thought the plain line looked pretty good too and matched the rest of the screen. Could change to that if desired.
<img width="1512" alt="Screenshot 2025-05-20 at 3 00 11 PM" src="https://github.com/user-attachments/assets/fce5f15d-b46c-40c8-b21d-63a23ee744d6" />
