### PR TITLE
Guard against queries that are too large for ASpace/Solr

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,8 @@ hours_api: 'https://library-hours.stanford.edu/'
 
 ark_naan: '22236'
 
+max_aspace_boolean_clauses: 500
+
 # Locations with a 'closed_note' will display the note in lieu of fetching hours from the API.
 hours_locations:
   - label: 'Green Library, 2nd Floor'

--- a/spec/services/aspace_client_spec.rb
+++ b/spec/services/aspace_client_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe AspaceClient do
         end.to raise_error(ArgumentError)
       end
     end
+
+    context 'with too many exclude uris' do
+      it 'raises an error' do
+        expect do
+          client.published_resource_with_updated_component_uris(repository_id: 11, uris_to_exclude: (0..500).to_a)
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when too many resources have updated components' do
+      before do
+        allow(aspace_query).to receive(:each).and_return((0..500).to_a.map { |v| { resource: v } })
+      end
+
+      it 'raises an error' do
+        expect do
+          client.published_resource_with_updated_component_uris(repository_id: 11)
+        end.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#published_resource_with_linked_agent_uris' do
@@ -202,6 +222,20 @@ RSpec.describe AspaceClient do
     end
 
     context 'without an agent_uris argument' do
+      it 'raises an error' do
+        expect do
+          client.resources_with_linked_agents(repository_id:)
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when too many resources have updated agents' do
+      before do
+        allow(client).to receive(:record_uris_from_linked_agent_uris)
+          .with(repository_id:, agent_uris:)
+          .and_return((0..500).to_a)
+      end
+
       it 'raises an error' do
         expect do
           client.resources_with_linked_agents(repository_id:)


### PR DESCRIPTION
Partially addresses #1129 

There will be some follow-on work to catch this error when enqueuing jobs and reverting the a full re-index, since it's likely that many/most objects have been updated if we reach this limit.