### PR TITLE
Guard against large numbers of automated deletes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,7 @@ hours_api: 'https://library-hours.stanford.edu/'
 ark_naan: '22236'
 
 max_aspace_boolean_clauses: 500
+max_automated_deletes: 100
 
 # Locations with a 'closed_note' will display the note in lieu of fetching hours from the API.
 hours_locations:


### PR DESCRIPTION
Fixes #1138 

If we get a large number of finding aids to delete it's likely something went wrong so we should raise an error instead. If after investigation the deletes look legitimate the job can be run manually by overriding the safeguard.