### PR TITLE
Index the ARK shoulder on each collection

### DIFF
--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -38,6 +38,13 @@ to_field 'sul_ark_id_ssi',
   end
 end
 
+to_field 'sul_ark_shoulder_ssi',
+         extract_xpath('/ead/archdesc/did/unitid[@type="ark"]/extref', to_text: false) do |_record, accumulator|
+  accumulator.map! do |node|
+    node.attributes['href']&.text&.match(%r{ark:/\d*/([a-z]*\d).*}) { |m| m[1] }
+  end
+end
+
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb"))
 
 # Some finding aids in OAC have empty elements that are indexed as empty strings in Solr.


### PR DESCRIPTION
I will add a test that will make use of this field in the follow up work to use ARKs for deletes.