### PR TITLE
Use ARKs to handle deletes; remove uses of indexed resource URI

### DIFF
--- a/app/jobs/delete_ead_job.rb
+++ b/app/jobs/delete_ead_job.rb
@@ -8,16 +8,18 @@ class DeleteEadJob < ApplicationJob
 
   def self.enqueue_all
     AspaceRepositories.all_harvestable.each do |repository|
-      perform_later(repository_id: repository.id, aspace_config_set: repository.aspace_config_set)
+      perform_later(repository_id: repository.id,
+                    aspace_config_set: repository.aspace_config_set,
+                    ark_shoulder: repository.ark_shoulder)
     end
   end
 
   # @param repository_id [String] the ASpace repository id, such as '11'
   # @param aspace_config_set [String] the ASpace instance configuration set, such as 'default'
   # @param skip_delete_safeguard [Boolean] if true, skips the safeguard that prevents excessive deletes
-  def perform(repository_id:, aspace_config_set:, skip_delete_safeguard: false)
-    indexed_eads = indexed_eads(repository_id:, aspace_config_set:)
-    published_eads = AspaceClient.new(aspace_config_set:).all_published_resource_uris_by(repository_id:)
+  def perform(repository_id:, aspace_config_set:, ark_shoulder:, skip_delete_safeguard: false)
+    indexed_eads = indexed_eads(ark_shoulder:)
+    published_eads = AspaceClient.new(aspace_config_set:).all_published_resource_arks_by(repository_id:)
 
     eads_to_delete = indexed_eads.keys - published_eads
     ids_to_delete = indexed_eads.slice(*eads_to_delete).values
@@ -37,9 +39,8 @@ class DeleteEadJob < ApplicationJob
     Blacklight.default_index.connection.commit
   end
 
-  def indexed_eads(repository_id:, aspace_config_set:)
-    SolrPaginatedQuery.new(filter_queries: { respository_uri_ssi: "/repositories/#{repository_id}",
-                                             aspace_config_set_ssi: aspace_config_set },
-                           fields_to_return: %w[id resource_uri_ssi]).all.to_h
+  def indexed_eads(ark_shoulder:)
+    SolrPaginatedQuery.new(filter_queries: { sul_ark_shoulder_ssi: ark_shoulder },
+                           fields_to_return: %w[sul_ark_id_ssi id]).all.to_h
   end
 end

--- a/app/jobs/download_ead_job.rb
+++ b/app/jobs/download_ead_job.rb
@@ -84,7 +84,7 @@ class DownloadEadJob < ApplicationJob
       f.puts ead.to_xml(indent: 2)
     end
 
-    IndexEadJob.perform_later(file_path:, resource_uri:, aspace_config_set:) if index
+    IndexEadJob.perform_later(file_path:) if index
     GeneratePdfJob.perform_later(file_path:, file_name:, data_dir: file_dir, skip_existing: false) if generate_pdf
   end
 end

--- a/app/jobs/index_ead_job.rb
+++ b/app/jobs/index_ead_job.rb
@@ -10,20 +10,14 @@ class IndexEadJob < ApplicationJob
 
   # @example IndexEadJob.perform_later(file_path: '/data/ars/ars1234.xml')
   # @param file_path [String] the path to the file to be indexed, such as, '/data/ars/ars1234.xml'
-  # @param resource_uri [String] the resource URI for the record in ASpace
-  # @param aspace_config_set [String] the ASpace config set to use for the indexing, such as 'default'
   # @param arclight_repository_code [String] the arclight repository code, such as 'ars'
   # @param solr_url [String] the web address for Solr where the file should be indexed
   # @param app_dir [Pathname] directory where the index command should be executed
-  def perform(file_path:, # rubocop:disable Metrics/ParameterLists
-              resource_uri: nil,
-              aspace_config_set: nil,
+  def perform(file_path:,
               arclight_repository_code: nil,
               solr_url: ENV.fetch('SOLR_URL', Blacklight.default_index.connection.base_uri),
               app_dir: Rails.root)
-    env = { 'REPOSITORY_ID' => arclight_repository_code || arclight_repository_code(file_path),
-            'RESOURCE_URI' => resource_uri,
-            'ASPACE_CONFIG_SET' => aspace_config_set.to_s }
+    env = { 'REPOSITORY_ID' => arclight_repository_code || arclight_repository_code(file_path) }
     cmd = "bundle exec traject -u #{solr_url} -i xml -c ./lib/traject/sul_config.rb #{file_path}"
 
     output, status = Open3.capture2(env, cmd, chdir: app_dir)

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -6,21 +6,8 @@ require_relative 'sul/normalized_id'
 settings do
   provide 'component_traject_config', File.join(__dir__, 'sul_component_config.rb')
   provide 'solr_writer.http_timeout', 1200
-  provide 'resource_uri', ENV.fetch('RESOURCE_URI', nil)
   provide 'aspace_config_set', ENV.fetch('ASPACE_CONFIG_SET', nil)
   provide 'id_normalizer', 'Sul::NormalizedId'
-end
-
-to_field 'repository_uri_ssi' do |_record, accumulator|
-  accumulator << settings['resource_uri'].to_s[%r{/repositories/\d*}]
-end
-
-to_field 'resource_uri_ssi' do |_record, accumulator|
-  accumulator << settings['resource_uri']
-end
-
-to_field 'aspace_config_set_ssi' do |_record, accumulator|
-  accumulator << settings['aspace_config_set']
 end
 
 to_field 'sul_ark_id_ssi',

--- a/spec/jobs/download_ead_job_spec.rb
+++ b/spec/jobs/download_ead_job_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe DownloadEadJob do
       expect do
         described_class.perform_now(resource_uri: '/repositories/1/resources/123', aspace_config_set: 'default',
                                     file_name: 'abc123', file_dir: '/data/archive/', index: true, generate_pdf: false)
-      end.to enqueue_job(IndexEadJob).once.with(file_path: '/data/archive/abc123.xml',
-                                                aspace_config_set: 'default',
-                                                resource_uri: '/repositories/1/resources/123')
+      end.to enqueue_job(IndexEadJob).once.with(file_path: '/data/archive/abc123.xml')
     end
   end
 

--- a/spec/jobs/index_ead_job_spec.rb
+++ b/spec/jobs/index_ead_job_spec.rb
@@ -13,12 +13,10 @@ RSpec.describe IndexEadJob do
   it 'sends a command to index the EAD in Solr with traject' do
     described_class.perform_now(file_path: 'data/sample.xml',
                                 arclight_repository_code: 'ars',
-                                aspace_config_set: 'default',
-                                resource_uri: '/repositories/2/resources/123',
                                 solr_url: 'http://localhost/solr/core',
                                 app_dir: '/some/directory')
     expect(Open3).to have_received(:capture2).with(
-      { 'ASPACE_CONFIG_SET' => 'default', 'REPOSITORY_ID' => 'ars', 'RESOURCE_URI' => '/repositories/2/resources/123' },
+      { 'REPOSITORY_ID' => 'ars' },
       ['bundle',
        'exec',
        'traject',
@@ -36,15 +34,10 @@ RSpec.describe IndexEadJob do
   context 'when the arclight repository code is not provided as an argument' do
     it 'infers the repository code from the file path' do
       described_class.perform_now(file_path: '/data/archive/sample.xml',
-                                  resource_uri: '/repositories/2/resources/123',
-                                  aspace_config_set: 'default',
                                   solr_url: 'http://localhost/solr/core',
                                   app_dir: '/some/directory')
 
-      expect(Open3).to have_received(:capture2).with({ 'ASPACE_CONFIG_SET' => 'default',
-                                                       'REPOSITORY_ID' => 'archive',
-                                                       'RESOURCE_URI' => '/repositories/2/resources/123' },
-                                                     anything, anything)
+      expect(Open3).to have_received(:capture2).with({ 'REPOSITORY_ID' => 'archive' }, anything, anything)
     end
   end
 
@@ -57,7 +50,6 @@ RSpec.describe IndexEadJob do
       expect do
         described_class.perform_now(file_path: 'data/sample.xml',
                                     arclight_repository_code: 'ars',
-                                    resource_uri: '/repositories/2/resources/123',
                                     solr_url: 'http://localhost/solr/core',
                                     app_dir: '/some/directory')
       end.to raise_error(IndexEadJob::IndexEadError)

--- a/spec/services/aspace_client_spec.rb
+++ b/spec/services/aspace_client_spec.rb
@@ -65,21 +65,23 @@ RSpec.describe AspaceClient do
     end
   end
 
-  describe '#all_published_resource_uris_by' do
-    let(:published_resources) do
-      [{ 'ead_id' => 'abc123', 'uri' => '/repositories/3/resources/2' },
-       { 'ead_id' => 'abc456', 'uri' => '/repositories/3/resources/4' }]
+  describe '#all_published_resource_arks_by' do
+    let(:published_resource_arks) do
+      [{ 'ark_name' => ['ark:/22236/c88366e7e5-b138-4d4f-b210-9063f159547c'] },
+       { 'ark_name' => ['ark:/22236/c83390a9ec-7afc-45ef-a2d1-0b065b53591d'] }]
     end
 
     before do
-      allow(AspaceQuery).to receive(:new).with(client:, repository_id: 3, updated_after: nil,
-                                               options: { published: true, suppressed: false })
-                                         .and_return(published_resources)
+      allow(AspaceQuery).to receive(:new).with(client:, repository_id: 3,
+                                               options: { published: true,
+                                                          suppressed: false,
+                                                          select_fields: ['ark_name'] })
+                                         .and_return(published_resource_arks)
     end
 
-    it 'returns an array of published resource uris' do
-      expect(client.all_published_resource_uris_by(repository_id: 3)).to eq(
-        ['/repositories/3/resources/2', '/repositories/3/resources/4']
+    it 'returns an array of published resource ARKs' do
+      expect(client.all_published_resource_arks_by(repository_id: 3)).to eq(
+        ['ark:/22236/c88366e7e5-b138-4d4f-b210-9063f159547c', 'ark:/22236/c83390a9ec-7afc-45ef-a2d1-0b065b53591d']
       )
     end
   end


### PR DESCRIPTION
Fixes #1141 

Hold until we have ARKs generated in ASpace prod. Then we can deploy this to prod and kick off a full reindex.