### PR TITLE
Make Aspace::Repository ark_shoulder aware

### DIFF
--- a/app/models/aspace/repository.rb
+++ b/app/models/aspace/repository.rb
@@ -4,11 +4,12 @@ module Aspace
   # Model for an Aspace repository to manage information
   # needed for downloading and updating a repository's resources
   class Repository
-    attr_reader :uri, :code, :aspace_config_set
+    attr_reader :uri, :code, :ark_shoulder, :aspace_config_set
 
-    def initialize(repo_code:, uri:, aspace_config_set:)
+    def initialize(repo_code:, uri:, aspace_config_set:, ark_shoulder: nil)
       @code = repo_code.downcase
       @uri = uri
+      @ark_shoulder = ark_shoulder
       @aspace_config_set = aspace_config_set
     end
 

--- a/app/services/aspace_repositories.rb
+++ b/app/services/aspace_repositories.rb
@@ -14,7 +14,7 @@ class AspaceRepositories
     Rails.cache.fetch('aspace_repositories', expires_in: 1.hour) do
       Settings.aspace.keys.flat_map do |aspace_config_set|
         client(aspace_config_set).repositories.flat_map do |repo|
-          Aspace::Repository.new(**repo.slice('repo_code', 'uri').symbolize_keys, aspace_config_set:)
+          Aspace::Repository.new(**repo.slice('repo_code', 'uri', 'ark_shoulder').symbolize_keys, aspace_config_set:)
         end
       end
     end

--- a/spec/models/aspace/repository_spec.rb
+++ b/spec/models/aspace/repository_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe Aspace::Repository do
   it { expect(repository.uri).to eq '/repositories/11' }
   it { expect(repository.harvestable?).to be true }
   it { expect(repository.aspace_config_set).to eq 'default' }
+  it { expect(repository.ark_shoulder).to be_nil }
+
+  context 'when an ark_shoulder is provided' do
+    subject(:repository) do
+      described_class.new(repo_code: 'ARS', uri: '/repositories/11', aspace_config_set: 'default', ark_shoulder: 'f4')
+    end
+
+    it { expect(repository.ark_shoulder).to eq 'f4' }
+  end
 
   describe '#each_published_resource' do
     before do

--- a/spec/services/aspace_repositories_spec.rb
+++ b/spec/services/aspace_repositories_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AspaceRepositories do
 
   let(:client) { instance_double(AspaceClient, repositories:) }
   let(:repositories) do
-    [{ 'repo_code' => 'ars', 'uri' => '/repositories/11', 'key' => 'value' },
+    [{ 'repo_code' => 'ars', 'uri' => '/repositories/11', 'key' => 'value', 'ark_shoulder' => 'f4' },
      { 'repo_code' => 'sul', 'uri' => '/repositories/1', 'key' => 'value' }]
   end
 


### PR DESCRIPTION
Part of #1141 

This does not require that ARKs or ARK shoulders exist yet in ASpace, but provides the ability to use them once they do exist.