### PR TITLE
Cache repositories response from ASpace for one hour

### DIFF
--- a/app/services/aspace_repositories.rb
+++ b/app/services/aspace_repositories.rb
@@ -11,9 +11,11 @@ class AspaceRepositories
   end
 
   def all
-    Settings.aspace.keys.flat_map do |aspace_config_set|
-      client(aspace_config_set).repositories.flat_map do |repo|
-        Aspace::Repository.new(**repo.slice('repo_code', 'uri').symbolize_keys, aspace_config_set:)
+    Rails.cache.fetch('aspace_repositories', expires_in: 1.hour) do
+      Settings.aspace.keys.flat_map do |aspace_config_set|
+        client(aspace_config_set).repositories.flat_map do |repo|
+          Aspace::Repository.new(**repo.slice('repo_code', 'uri').symbolize_keys, aspace_config_set:)
+        end
       end
     end
   end


### PR DESCRIPTION
This data doesn't change much so we don't need send a request to ASpace every time we need it.