### PR TITLE
repository_uri_ssi should not be removed until we use ARKs for deletes

### DIFF
--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -11,6 +11,10 @@ settings do
   provide 'id_normalizer', 'Sul::NormalizedId'
 end
 
+to_field 'repository_uri_ssi' do |_record, accumulator|
+  accumulator << settings['resource_uri'].to_s[%r{/repositories/\d*}]
+end
+
 to_field 'resource_uri_ssi' do |_record, accumulator|
   accumulator << settings['resource_uri']
 end


### PR DESCRIPTION
Was removed here: https://github.com/sul-dlss/stanford-arclight/commit/e4880e788161355318d66f031647a2bacef12fe2

Still needed until https://github.com/sul-dlss/stanford-arclight/pull/1148 is merged