### PR TITLE
Fetch speccoll finding aids from ASpace instead of OAC

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,7 @@ aspace:
       - ars
       - cubberley
       - eal
+      - speccoll
   chs:
     user: <%= ENV['ASPACE_CHS_USER'] %>
     password: <%= ENV['ASPACE_CHS_PASSWORD'] %>


### PR DESCRIPTION
For production we will now harvest speccoll collections from ASpace instead of OAC.