### PR TITLE
Also remove ARK info from components

### DIFF
--- a/lib/traject/sul_component_config.rb
+++ b/lib/traject/sul_component_config.rb
@@ -14,4 +14,7 @@ load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject
 # We want to remove these. This is not an issue with finding aids produced by ArchivesSpace.
 each_record do |_record, context|
   context.output_hash['creator_ssim']&.reject!(&:blank?)
+  # Remove from 'unitid_ssm' -- these ARK-related values live in <unitid> elements in the EAD
+  context.output_hash['unitid_ssm']&.reject! { |v| v == 'Archival Resource Key' }
+  context.output_hash['unitid_ssm']&.reject! { |v| v == 'Previous Archival Resource Key' }
 end

--- a/spec/features/ark_spec.rb
+++ b/spec/features/ark_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe 'ARK indexing and routing' do
     end
   end
 
+  context 'when a component has an ARK' do
+    before { visit 'sc0097_aspace_ref128_jpj' }
+
+    it 'does not index extra ARK fields in the unitid' do
+      expect(page).to have_no_content('Archival Resource Key')
+      expect(page).to have_no_content('Previous Archival Resource Key')
+    end
+  end
+
   context 'when the route requests an ARK with no hyphens' do
     before do
       visit "/findingaid/#{no_hyphen_ark_id}"

--- a/spec/fixtures/ead/uarc/sc0097.xml
+++ b/spec/fixtures/ead/uarc/sc0097.xml
@@ -121,6 +121,9 @@ Stanford University School of Engineering Hero Award, 2011 </p>
           <unittitle>
             <title render="italic">The Art of Computer Programming</title>
           </unittitle>
+          <unitid type="ark">
+            <extref xlink:actuate="onLoad" xlink:href="https://archives.stanford.edu/findingaid/ark:/22236/s1d38f250f-b769-4384-8b95-58191e3a8fca" xlink:show="new">Archival Resource Key</extref>
+          </unitid>
           <unitid>Series 1</unitid>
           <langmaterial><language langcode="eng">English</language>.</langmaterial>
         </did>


### PR DESCRIPTION
We removed this extra info from collections here https://github.com/sul-dlss/stanford-arclight/commit/708be15e48fb02dbe9620622bad84db9960edc6b but we also need to remove it from components.