### PR TITLE
Index ARKs on components

### DIFF
--- a/lib/traject/sul_component_config.rb
+++ b/lib/traject/sul_component_config.rb
@@ -8,6 +8,13 @@ settings do
   provide 'title_normalizer', 'Sul::NormalizedTitle'
 end
 
+to_field 'sul_ark_id_ssi',
+         extract_xpath('./did/unitid[@type="ark"]/extref', to_text: false) do |_record, accumulator|
+  accumulator.map! do |node|
+    node.attributes['href']&.text&.[](%r{ark:/\S+})
+  end
+end
+
 load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject/ead2_component_config.rb"))
 
 # Some finding aids in OAC have empty elements that are indexed as empty strings in Solr.

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -13,8 +13,7 @@ end
 to_field 'sul_ark_id_ssi',
          extract_xpath('/ead/archdesc/did/unitid[@type="ark"]/extref', to_text: false) do |_record, accumulator|
   accumulator.map! do |node|
-    href = node['href']
-    href[%r{ark:/\S+}] if href
+    node.attributes['href']&.text&.[](%r{ark:/\S+})
   end
 end
 

--- a/spec/features/ark_spec.rb
+++ b/spec/features/ark_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'ARK indexing and routing' do
-  let(:valid_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efc-dc7f-4ca7-bc10-d8456c3451a0" }
+  let(:collection_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efc-dc7f-4ca7-bc10-d8456c3451a0" }
+  let(:component_ark_id) { "ark:/#{Settings.ark_naan}/s1d38f250f-b769-4384-8b95-58191e3a8fca" }
   let(:no_hyphen_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efcdc7f4ca7bc10d8456c3451a0" }
   let(:missing_ark_id) { "ark:/#{Settings.ark_naan}/s19f562efc-dc7f-4ca7-bc10-d8456c3451b3" }
   # This ARK has no shoulder (s1)
@@ -13,7 +14,7 @@ RSpec.describe 'ARK indexing and routing' do
 
   context 'when a valid ARK is found in Solr' do
     before do
-      visit "/findingaid/#{valid_ark_id}"
+      visit "/findingaid/#{collection_ark_id}"
     end
 
     it 'redirects to the catalog page when ARK ID is found' do
@@ -27,7 +28,11 @@ RSpec.describe 'ARK indexing and routing' do
   end
 
   context 'when a component has an ARK' do
-    before { visit 'sc0097_aspace_ref128_jpj' }
+    before { visit "findingaid/#{component_ark_id}" }
+
+    it 'redirects to the catalog page when ARK ID is found' do
+      expect(page).to have_current_path('/catalog/sc0097_aspace_ref128_jpj')
+    end
 
     it 'does not index extra ARK fields in the unitid' do
       expect(page).to have_no_content('Archival Resource Key')


### PR DESCRIPTION
Component level ARKs are included in exported EADs so even though we are not using them for SearchWorks linking, they should be resolvable by `archives.stanford.edu`. All that's needed to make this work is to store each component's ARK.