### PR TITLE
Bump boolean clause limit to 900

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,7 @@ hours_api: 'https://library-hours.stanford.edu/'
 
 ark_naan: '22236'
 
-max_aspace_boolean_clauses: 500
+max_aspace_boolean_clauses: 900
 
 # Locations with a 'closed_note' will display the note in lieu of fetching hours from the API.
 hours_locations:


### PR DESCRIPTION
We're hitting the current limit of 500 boolean clauses more often than I expected and I think it's safe to bump this up to 900 to avoid unnecessary re-indexing.