### PR TITLE
Add missing alt attribute

### DIFF
--- a/app/components/using_these_materials_component.html.erb
+++ b/app/components/using_these_materials_component.html.erb
@@ -3,7 +3,7 @@
     <div class="card-body">
       <div class="d-flex align-items-center justify-content-between mb-3">
         <h2 class="al-show-sub-heading fs-6 mb-0"><%= t("using_these_materials.heading") %></h2>
-        <%= image_tag 'rosette.png', height: '42', width: '42', class: 'ms-2' %>
+        <%= image_tag 'rosette.png', alt: '', height: '42', width: '42', class: 'ms-2' %>
       </div>
       <ul>
         <li>


### PR DESCRIPTION
This is a decorative logo so adding `alt=''` will address the accessibility issue.