### PR TITLE
Configure capistrano to manage sidekiq on background vms

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -56,12 +56,6 @@ namespace :deploy do
       end
     end
   end
-
-  after :restart, :restart_sidekiq do
-    on roles(:background) do
-      sudo :systemctl, 'restart', 'sidekiq-*', raise_on_non_zero_exit: false
-    end
-  end
 end
 
 # update shared_configs before restarting app

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -8,3 +8,4 @@ server 'sul-arclight-worker-prod-b.stanford.edu', user: 'arclight', roles: %w[ba
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 set :sidekiq_roles, :background
+set :sidekiq_systemd_role, :background


### PR DESCRIPTION
Based on https://github.com/sul-dlss/dlss-capistrano/blob/cd4766654f600888ecb32bc3f18ff3735de9555e/lib/dlss/capistrano/tasks/sidekiq_systemd.rake#L4 I think this is what's needed to let capistrano manage sidekiq on the background/worker vms in prod