### PR TITLE
Use the predicate method to check format in bot challenge config

### DIFF
--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -30,7 +30,7 @@ Rails.application.config.to_prepare do
   # Also exempt any IPs contained in the CIDR blocks in Settings.turnstile.safelist.
   BotChallengePage::BotChallengePageController.bot_challenge_config.allow_exempt = lambda do |controller, _config|
     (controller.is_a?(CatalogController) && controller.params[:action].in?(%w[facet index]) &&
-      controller.params[:format] == 'json' && controller.request.headers['sec-fetch-dest'] == 'empty') ||
+      controller.request.format.json? && controller.request.headers['sec-fetch-dest'] == 'empty') ||
       SAFELIST.map { |cidr| IPAddr.new(cidr) }.any? { |range| controller.request.remote_ip.in?(range) }
   end
 


### PR DESCRIPTION
SearchWorks mini-bento uses `headers: { 'accept': 'application/json' }` which does not appear to put the json in the params