### PR TITLE
Disable active_storage variant_processor

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,10 @@ module StanfordArclight
     config.time_zone = 'Pacific Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
 
+    # Disable Active Storage variants (image processing) to avoid installing
+    # image_processing gem where not needed.
+    config.active_storage.variant_processor = :disabled
+
     Recaptcha.configure do |config|
       config.site_key = ENV.fetch('RECAPTCHA_SITE_KEY', '6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy')
       config.secret_key = ENV.fetch('RECAPTCHA_SECRET_KEY', '6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx')


### PR DESCRIPTION
Should stop cron warning:

```
Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
```