### PR TITLE
Unpin connection_pool gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,5 +121,3 @@ gem 'recaptcha', '~> 5.16'
 gem 'redis', '~> 5.2'
 
 gem 'rack-cors', '~> 2.0'
-
-gem 'connection_pool', '~> 2.5' # pinned until fix for https://github.com/rails/rails/issues/56291 is released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -600,7 +600,6 @@ DEPENDENCIES
   capistrano-rails
   capybara
   config
-  connection_pool (~> 2.5)
   cssbundling-rails (~> 1.1)
   csv (~> 3.3)
   debug


### PR DESCRIPTION
The fix was included in Rails 8.1.2 so we can unpin this now: rails/rails#56292