### PR TITLE
Reformat stray periods from ArchivesSpace EAD <langmaterial>

### DIFF
--- a/app/jobs/delete_ead_job.rb
+++ b/app/jobs/delete_ead_job.rb
@@ -6,6 +6,9 @@
 class DeleteEadJob < ApplicationJob
   class DeleteEadJobError < StandardError; end
 
+  # Since we run this job every 6 hours there isn't much benefit to retrying more than once.
+  sidekiq_options retry: 1
+
   def self.enqueue_all
     AspaceRepositories.all_harvestable.each do |repository|
       perform_later(repository_id: repository.id,

--- a/lib/traject/sul_component_config.rb
+++ b/lib/traject/sul_component_config.rb
@@ -21,6 +21,8 @@ load_config_file(File.expand_path("#{Arclight::Engine.root}/lib/arclight/traject
 # We want to remove these. This is not an issue with finding aids produced by ArchivesSpace.
 each_record do |_record, context|
   context.output_hash['creator_ssim']&.reject!(&:blank?)
+  # Remove whitespace before trailing periods but keep the period. Common issue with ASpace-produced EAD.
+  context.output_hash['language_ssim']&.map! { |value| value.gsub(/\s+\.\s*$/, '.').strip }
   # Remove from 'unitid_ssm' -- these ARK-related values live in <unitid> elements in the EAD
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Archival Resource Key' }
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Previous Archival Resource Key' }

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -33,6 +33,8 @@ each_record do |_record, context|
   # Remove from 'unitid_ssm' -- these ARK-related values live in <unitid> elements in the EAD
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Archival Resource Key' }
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Previous Archival Resource Key' }
+  # Remove whitespace before trailing periods but keep the period. Common issue with ASpace-produced EAD.
+  context.output_hash['language_ssim']&.map! { |value| value.gsub(/\s+\.\s*$/, '.').strip }
   # Store a hashed version of the id for blacklight dynamic sitemaps
   context.output_hash['hashed_id_ssi'] = [Digest::MD5.hexdigest(context.output_hash['id'].first)]
 end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -82,4 +82,18 @@ RSpec.describe 'Collection Page' do
       expect(page).to have_no_css('#collection-context')
     end
   end
+
+  context 'when visiting a collection with language values' do
+    before do
+      visit solr_document_path('universite-de-toulouse')
+    end
+
+    it 'displays the language values without newlines or spaces before periods' do
+      # Checks that our indexing correctly formats stray periods in <langmaterial> coming from ArchivesSpace EAD
+      # See universite-de-toulouse.xml fixture
+      within('#summary') do
+        expect(page).to have_text('English.')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This stray period is in every ArchivesSpace EAD with a language in `<langmaterial>`:

```xml
    <langmaterial>
      <language langcode="eng">English</language>
.    </langmaterial>
```

It was being indexed resulting in:
```json
 {
      "id":"cubb00078_aspace_ref2_gxs",
      "language_ssim":["English ."]
    },{
      "id":"cubb00078_aspace_ref4_gmp",
      "language_ssim":["English ."]
    },{
      "id":"cubb00078_aspace_ref5_871",
      "language_ssim":["English ."]
    },{
      "id":"cubb00078_aspace_ref8_58t",
      "language_ssim":["English ."]
  ```
(note space before period)
<img width="668" height="310" alt="Screenshot 2026-03-20 at 3 33 27 PM" src="https://github.com/user-attachments/assets/c3f7c8a6-7c77-4069-a482-4ea191257dd5" />

The odd space was reported by users and @dinahhandel. Reindexing with this change will fix the issue.

I debated putting this into Arclight Core. This issue can be seen in Arclight at other institutions, as ArchivesSpace is so commonly used to generate EAD. I figured that would take discussion and a release, so I put the fix here for now, but happy to move it if desired.

Note,`<langmaterial>` can be used in other ways than what's shown above (sole `<language>` child).
There can be text surrounding `<language>`
```xml
<langmaterial>Correspondence in <language>French, </language>
                <language>German, </language>and <language>English.</language>
</langmaterial>
```
