### PR TITLE
Consistently handle slashes in ASpace API request paths

### DIFF
--- a/app/services/aspace_client.rb
+++ b/app/services/aspace_client.rb
@@ -20,7 +20,7 @@ class AspaceClient
   # Get a list of repositories
   # See https://archivesspace.github.io/archivesspace/api/#get-a-list-of-repositories
   def repositories
-    response = authenticated_get('repositories')
+    response = authenticated_get('/repositories')
 
     JSON.parse(response)
   end
@@ -228,7 +228,7 @@ class AspaceClient
   def send_request(method, path, body = nil)
     raise ArgumentError, 'Please provide a path for the request' unless path
 
-    uri = URI.parse("#{@base_url}/#{path}")
+    uri = URI.parse(@base_url + path)
     req = case method
           when :get
             Net::HTTP::Get.new(uri)

--- a/app/services/concerns/aspace_paginated_query.rb
+++ b/app/services/concerns/aspace_paginated_query.rb
@@ -31,7 +31,7 @@ module AspacePaginatedQuery
 
   def fetch_page(page_number)
     params = { page: page_number, page_size: PAGE_SIZE }.merge(query_params)
-    response = client.authenticated_post("repositories/#{repository_id}/search", params)
+    response = client.authenticated_post("/repositories/#{repository_id}/search", params)
     JSON.parse(response)
   end
 end

--- a/spec/services/aspace_client_spec.rb
+++ b/spec/services/aspace_client_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AspaceClient do
     it 'sends an authenticated request with correct auth header to the resource_desriptions address' do
       request_url = 'http://example.com:8089/repositories/2/resource_descriptions/10208.xml?include_daos=true&numbered_cs=true'
       stub_request(:get, request_url)
-      client.resource_description('repositories/2/resources/10208')
+      client.resource_description('/repositories/2/resources/10208')
       expect(WebMock).to have_requested(:get, request_url)
         .with(headers: { 'X-ArchivesSpace-Session' => 'token1' }).once
     end
@@ -249,7 +249,7 @@ RSpec.describe AspaceClient do
   describe '#authenticated_get' do
     it 'sends an authenticated request with correct auth header to the specified address' do
       stub_request(:get, 'http://example.com:8089/some_request')
-      client.authenticated_get('some_request')
+      client.authenticated_get('/some_request')
       expect(WebMock).to have_requested(:get,
                                         'http://example.com:8089/some_request')
         .with(headers: { 'X-ArchivesSpace-Session' => 'token1' }).once
@@ -272,7 +272,7 @@ RSpec.describe AspaceClient do
   describe '#authenticated_post' do
     it 'sends an authenticated request with correct auth header to the specified address' do
       stub_request(:post, 'http://example.com:8089/some_request')
-      client.authenticated_post('some_request')
+      client.authenticated_post('/some_request')
       expect(WebMock).to have_requested(:post,
                                         'http://example.com:8089/some_request')
         .with(headers: { 'X-ArchivesSpace-Session' => 'token1' }).once


### PR DESCRIPTION
Part of #1286 

ArchivesSpace 4 is pickier about API requests and revealed a path/slash handling bug in our client code where we were sometimes generating requests with double `//`. The ASpace API returns paths with `/` prefixed so this standardizes to assume the path is prefixed with a slash.

Fixes:
```
AspaceClient.new.resource_description("/repositories/15/resource_descriptions/14662")
app/services/aspace_client.rb:247:in 'AspaceClient#send_request': Unexpected response code 400: <h1>Bad Message 400</h1><pre>reason: Ambiguous URI empty segment</pre> (StandardError)
	from app/services/aspace_client.rb:133:in 'AspaceClient#authenticated_get'
	from app/services/aspace_client.rb:40:in 'AspaceClient#resource_description'
	from (stanford-arclight):1:in '<main>'
```