### PR TITLE
Prevent archival and resource URIs from getting indexed as unitid_ssm

### DIFF
--- a/lib/traject/sul_component_config.rb
+++ b/lib/traject/sul_component_config.rb
@@ -26,6 +26,8 @@ each_record do |_record, context|
   # Remove from 'unitid_ssm' -- these ARK-related values live in <unitid> elements in the EAD
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Archival Resource Key' }
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Previous Archival Resource Key' }
+  # Remove from 'unitid_ssm' -- ASpace archival object URIs
+  context.output_hash['unitid_ssm']&.reject! { |v| v.match?(%r{^/repositories/\d+/archival_objects/\d+$}) }
   # Store a hashed version of the id for blacklight dynamic sitemaps
   context.output_hash['hashed_id_ssi'] = [Digest::MD5.hexdigest(context.output_hash['id'].first)]
 end

--- a/lib/traject/sul_config.rb
+++ b/lib/traject/sul_config.rb
@@ -33,6 +33,8 @@ each_record do |_record, context|
   # Remove from 'unitid_ssm' -- these ARK-related values live in <unitid> elements in the EAD
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Archival Resource Key' }
   context.output_hash['unitid_ssm']&.reject! { |v| v == 'Previous Archival Resource Key' }
+  # Remove from 'unitid_ssm' -- ASpace resource URIs
+  context.output_hash['unitid_ssm']&.reject! { |v| v.match?(%r{^/repositories/\d+/resources/\d+$}) }
   # Remove whitespace before trailing periods but keep the period. Common issue with ASpace-produced EAD.
   context.output_hash['language_ssim']&.map! { |value| value.gsub(/\s+\.\s*$/, '.').strip }
   # Store a hashed version of the id for blacklight dynamic sitemaps

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -97,4 +97,17 @@ RSpec.describe 'Collection Page' do
       end
     end
   end
+
+  describe 'the call number displayed in the summary section' do
+    before do
+      visit solr_document_path('cubb1967')
+    end
+
+    it 'displays the collection-level call number but not the ASpace resource URI' do
+      within('#summary') do
+        expect(page).to have_text('Cubb.1967')
+        expect(page).to have_no_text('/repositories/14/resources/13290')
+      end
+    end
+  end
 end

--- a/spec/features/component_spec.rb
+++ b/spec/features/component_spec.rb
@@ -40,5 +40,14 @@ RSpec.describe 'Component Page' do
         expect(page).to have_link('Ambassador Auditorium Collection, 1974-1995', href: '/catalog/ars0043')
       end
     end
+
+    describe 'the summary section' do
+      it 'displays the component ID but not the ASpace archival object URI' do
+        within('#about-this-level') do
+          expect(page).to have_text('test-unit-id')
+          expect(page).to have_no_text('/repositories/11/archival_objects/867293')
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/ead/ars/ars0043.xml
+++ b/spec/fixtures/ead/ars/ars0043.xml
@@ -122,6 +122,7 @@ In the mid 1990s the Worldwide Church of God, which operated the Ambassador Audi
               <extref xlink:actuate="onLoad" xlink:href="https://archives.stanford.edu/findingaid/ark:/22236/r58e3f24e4-0630-4323-a36c-816b315b6486" xlink:show="new">Archival Resource Key</extref>
             </unitid>
             <unitid type="aspace_uri">/repositories/11/archival_objects/867293</unitid>
+            <unitid>test-unit-id</unitid>
             <unitdate calendar="gregorian" datechar="creation" era="ce" normal="1981/1995" type="inclusive">1981 -- 1995</unitdate>
             <physdesc id="aspace_4d27325812c10f2a245425a6b5defa85" label="Container Summary">77 audio cassettes ; 34 5" open reel tapes ; 5 7" open reel tapes</physdesc>
             <langmaterial>


### PR DESCRIPTION
Fixes #1296 