### PR TITLE
Use Sidekiq in development when environment is set up for it

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,9 @@ Rails.application.configure do
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store
 
+  # Use production-like ActiveJob backend (sidekiq) if Redis is available
+  config.active_job.queue_adapter = :sidekiq if ENV.include? 'SIDEKIQ_REDIS_URL'
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 


### PR DESCRIPTION
This was unintentionally removed during the [Rails 8.1.1 upgrade](https://github.com/sul-dlss/stanford-arclight/commit/ce8afc90140d0a0c0a863faef306ad8050a059e0). Let's restore it so it's easy to use sidekiq in development.